### PR TITLE
[0.x] Add Fixers for Laravel specific PHPDocs

### DIFF
--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -2,6 +2,9 @@
 
 namespace App\Factories;
 
+use App\Fixers\LaravelPhpdocAlignmentFixer;
+use App\Fixers\LaravelPhpdocOrderFixer;
+use App\Fixers\LaravelPhpdocSeparationFixer;
 use App\Repositories\ConfigurationJsonRepository;
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
@@ -59,6 +62,11 @@ class ConfigurationFactory
             ->setFinder($finder)
             ->setRules(array_merge($rules, $localConfiguration->rules()))
             ->setRiskyAllowed(true)
-            ->setUsingCache(true);
+            ->setUsingCache(true)
+            ->registerCustomFixers([
+                new LaravelPhpdocOrderFixer,
+                new LaravelPhpdocSeparationFixer,
+                new LaravelPhpdocAlignmentFixer,
+            ]);
     }
 }

--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -64,9 +64,9 @@ class ConfigurationFactory
             ->setRiskyAllowed(true)
             ->setUsingCache(true)
             ->registerCustomFixers([
-                new LaravelPhpdocOrderFixer,
-                new LaravelPhpdocSeparationFixer,
-                new LaravelPhpdocAlignmentFixer,
+                new LaravelPhpdocOrderFixer(),
+                new LaravelPhpdocSeparationFixer(),
+                new LaravelPhpdocAlignmentFixer(),
             ]);
     }
 }

--- a/app/Fixers/LaravelPhpdocAlignmentFixer.php
+++ b/app/Fixers/LaravelPhpdocAlignmentFixer.php
@@ -33,7 +33,7 @@ class LaravelPhpdocAlignmentFixer implements FixerInterface
      * need a fixing, but when this method returns false then the Tokens collection
      * need no fixing for sure.
      *
-     * @param  \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @param  \PhpCsFixer\Tokenizer\Tokens  $tokens
      * @return bool
      */
     public function isCandidate(Tokens $tokens): bool
@@ -57,8 +57,8 @@ class LaravelPhpdocAlignmentFixer implements FixerInterface
     /**
      * Fixes a file.
      *
-     * @param  \SplFileInfo $file
-     * @param  \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @param  \SplFileInfo  $file
+     * @param  \PhpCsFixer\Tokenizer\Tokens  $tokens
      * @return void
      */
     public function fix(SplFileInfo $file, Tokens $tokens): void

--- a/app/Fixers/LaravelPhpdocAlignmentFixer.php
+++ b/app/Fixers/LaravelPhpdocAlignmentFixer.php
@@ -14,15 +14,40 @@ use SplFileInfo;
 class LaravelPhpdocAlignmentFixer implements FixerInterface
 {
     /**
-     * {@inheritdoc}
+     * Returns the name of the fixer.
+     * The name must match the pattern /^[A-Z][a-zA-Z0-9]*\/[a-z][a-z0-9_]*$/
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Laravel/laravel_phpdoc_alignment';
+    }
+
+    /**
+     * Check if the fixer is a candidate for given Tokens collection.
+     *
+     * Fixer is a candidate when the collection contains tokens that may be fixed
+     * during fixer work. This could be considered as some kind of bloom filter.
+     * When this method returns true then to the Tokens collection may or may not
+     * need a fixing, but when this method returns false then the Tokens collection
+     * need no fixing for sure.
+     *
+     * @param  \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @return bool
      */
     public function isCandidate(Tokens $tokens): bool
     {
         return $tokens->isAnyTokenKindsFound([\T_DOC_COMMENT]);
     }
 
+
     /**
-     * {@inheritdoc}
+     * Check if fixer is risky or not.
+     *
+     * Risky fixer could change code behavior!
+     *
+     * @return bool
      */
     public function isRisky(): bool
     {
@@ -30,7 +55,11 @@ class LaravelPhpdocAlignmentFixer implements FixerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Fixes a file.
+     *
+     * @param  \SplFileInfo $file
+     * @param  \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @return void
      */
     public function fix(SplFileInfo $file, Tokens $tokens): void
     {
@@ -56,7 +85,9 @@ class LaravelPhpdocAlignmentFixer implements FixerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the definition of the fixer.
+     *
+     * @return \PhpCsFixer\FixerDefinition\FixerDefinitionInterface
      */
     public function getDefinition(): FixerDefinitionInterface
     {
@@ -73,15 +104,11 @@ function a($foo, $bar) {}
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getName(): string
-    {
-        return 'LaravelCodeStyle/laravel_phpdoc_alignment';
-    }
-
-    /**
-     * {@inheritdoc}
+     * Returns the priority of the fixer.
+     *
+     * The default priority is 0 and higher priorities are executed first.
+     *
+     * @return int
      */
     public function getPriority(): int
     {
@@ -89,7 +116,9 @@ function a($foo, $bar) {}
     }
 
     /**
-     * {@inheritdoc}
+     * Returns true if the file is supported by this fixer.
+     *
+     * @return bool
      */
     public function supports(SplFileInfo $file): bool
     {

--- a/app/Fixers/LaravelPhpdocAlignmentFixer.php
+++ b/app/Fixers/LaravelPhpdocAlignmentFixer.php
@@ -11,7 +11,7 @@ use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 
-final class LaravelPhpdocAlignmentFixer implements FixerInterface
+class LaravelPhpdocAlignmentFixer implements FixerInterface
 {
     /**
      * {@inheritdoc}

--- a/app/Fixers/LaravelPhpdocAlignmentFixer.php
+++ b/app/Fixers/LaravelPhpdocAlignmentFixer.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Fixers;
+
+use PhpCsFixer\DocBlock\TypeExpression;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+final class LaravelPhpdocAlignmentFixer implements FixerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound([\T_DOC_COMMENT]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        for ($index = $tokens->count() - 1; $index > 0; $index--) {
+            if (! $tokens[$index]->isGivenKind([\T_DOC_COMMENT])) {
+                continue;
+            }
+
+            $newContent = preg_replace_callback(
+                '/(?P<tag>@param)\s+(?P<hint>(?:'.TypeExpression::REGEX_TYPES.')?)\s+(?P<var>(?:&|\.{3})?\$\S+)/ux',
+                function ($matches) {
+                    return $matches['tag'].'  '.$matches['hint'].'  '.$matches['var'];
+                },
+                $tokens[$index]->getContent()
+            );
+
+            if ($newContent === $tokens[$index]->getContent()) {
+                continue;
+            }
+
+            $tokens[$index] = new Token([\T_DOC_COMMENT, $newContent]);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition('After @param must be two spaces and after the Type Definition must also be two spaces.', [
+            new CodeSample('<?php
+/**
+ * @param string $foo
+ * @param  string  $bar
+ * @return string
+ */
+function a($foo, $bar) {}
+'),
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'LaravelCodeStyle/laravel_phpdoc_alignment';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return -42;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(SplFileInfo $file): bool
+    {
+        return true;
+    }
+}

--- a/app/Fixers/LaravelPhpdocAlignmentFixer.php
+++ b/app/Fixers/LaravelPhpdocAlignmentFixer.php
@@ -41,7 +41,6 @@ class LaravelPhpdocAlignmentFixer implements FixerInterface
         return $tokens->isAnyTokenKindsFound([\T_DOC_COMMENT]);
     }
 
-
     /**
      * Check if fixer is risky or not.
      *

--- a/app/Fixers/LaravelPhpdocOrderFixer.php
+++ b/app/Fixers/LaravelPhpdocOrderFixer.php
@@ -32,7 +32,7 @@ class LaravelPhpdocOrderFixer extends AbstractFixer
      * need a fixing, but when this method returns false then the Tokens collection
      * need no fixing for sure.
      *
-     * @param  \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @param  \PhpCsFixer\Tokenizer\Tokens  $tokens
      * @return bool
      */
     public function isCandidate(Tokens $tokens): bool
@@ -86,6 +86,8 @@ class LaravelPhpdocOrderFixer extends AbstractFixer
      * - PhpdocScalarFixer
      * - PhpdocToCommentFixer
      * - PhpdocTypesFixer.
+     *
+     * @return int
      */
     public function getPriority(): int
     {
@@ -95,8 +97,8 @@ class LaravelPhpdocOrderFixer extends AbstractFixer
     /**
      * Fixes a file.
      *
-     * @param  \SplFileInfo $file
-     * @param  \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @param  \SplFileInfo  $file
+     * @param  \PhpCsFixer\Tokenizer\Tokens  $tokens
      * @return void
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
@@ -120,7 +122,7 @@ class LaravelPhpdocOrderFixer extends AbstractFixer
     /**
      * Move all `param` annotations to be before `throws` and `return` annotations.
      *
-     * @param  string $content
+     * @param  string  $content
      * @return string
      */
     private function moveParamAnnotations($content)
@@ -159,7 +161,7 @@ class LaravelPhpdocOrderFixer extends AbstractFixer
     /**
      * Move all `return` annotations to be after `param` and `throws` annotations.
      *
-     * @param  string $content
+     * @param  string  $content
      * @return string
      */
     private function moveThrowsAnnotations($content)

--- a/app/Fixers/LaravelPhpdocOrderFixer.php
+++ b/app/Fixers/LaravelPhpdocOrderFixer.php
@@ -13,15 +13,27 @@ use PhpCsFixer\Tokenizer\Tokens;
 class LaravelPhpdocOrderFixer extends AbstractFixer
 {
     /**
-     * {@inheritdoc}
+     * Returns the name of the fixer.
+     * The name must match the pattern /^[A-Z][a-zA-Z0-9]*\/[a-z][a-z0-9_]*$/
+     *
+     * @return string
      */
     public function getName(): string
     {
-        return 'LaravelCodeStyle/laravel_phpdoc_order';
+        return 'Laravel/laravel_phpdoc_order';
     }
 
     /**
-     * {@inheritdoc}
+     * Check if the fixer is a candidate for given Tokens collection.
+     *
+     * Fixer is a candidate when the collection contains tokens that may be fixed
+     * during fixer work. This could be considered as some kind of bloom filter.
+     * When this method returns true then to the Tokens collection may or may not
+     * need a fixing, but when this method returns false then the Tokens collection
+     * need no fixing for sure.
+     *
+     * @param  \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @return bool
      */
     public function isCandidate(Tokens $tokens): bool
     {
@@ -29,7 +41,9 @@ class LaravelPhpdocOrderFixer extends AbstractFixer
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the definition of the fixer.
+     *
+     * @return \PhpCsFixer\FixerDefinition\FixerDefinitionInterface
      */
     public function getDefinition(): FixerDefinitionInterface
     {
@@ -54,10 +68,24 @@ class LaravelPhpdocOrderFixer extends AbstractFixer
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the priority of the fixer.
      *
-     * Must run before PhpdocAlignFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocIndentFixer, PhpdocNoEmptyReturnFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * The default priority is 0 and higher priorities are executed first.
+     *
+     * Must run before
+     * - PhpdocAlignFixer
+     * - PhpdocSeparationFixer
+     * - PhpdocTrimFixer.
+     *
+     * Must run after
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - PhpdocAddMissingParamAnnotationFixer
+     * - PhpdocIndentFixer
+     * - PhpdocNoEmptyReturnFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer.
      */
     public function getPriority(): int
     {
@@ -65,7 +93,11 @@ class LaravelPhpdocOrderFixer extends AbstractFixer
     }
 
     /**
-     * {@inheritdoc}
+     * Fixes a file.
+     *
+     * @param  \SplFileInfo $file
+     * @param  \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @return void
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
@@ -86,9 +118,12 @@ class LaravelPhpdocOrderFixer extends AbstractFixer
     }
 
     /**
-     * Move all param annotations in before throws and return annotations.
+     * Move all `param` annotations to be before `throws` and `return` annotations.
+     *
+     * @param  string $content
+     * @return string
      */
-    private function moveParamAnnotations(string $content): string
+    private function moveParamAnnotations($content)
     {
         $doc = new DocBlock($content);
         $params = $doc->getAnnotationsOfType('param');
@@ -122,9 +157,12 @@ class LaravelPhpdocOrderFixer extends AbstractFixer
     }
 
     /**
-     * Move all return annotations after param and throws annotations.
+     * Move all `return` annotations to be after `param` and `throws` annotations.
+     *
+     * @param  string $content
+     * @return string
      */
-    private function moveThrowsAnnotations(string $content): string
+    private function moveThrowsAnnotations($content)
     {
         $doc = new DocBlock($content);
         $throws = $doc->getAnnotationsOfType('throws');

--- a/app/Fixers/LaravelPhpdocOrderFixer.php
+++ b/app/Fixers/LaravelPhpdocOrderFixer.php
@@ -10,7 +10,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
-final class LaravelPhpdocOrderFixer extends AbstractFixer
+class LaravelPhpdocOrderFixer extends AbstractFixer
 {
     /**
      * {@inheritdoc}

--- a/app/Fixers/LaravelPhpdocOrderFixer.php
+++ b/app/Fixers/LaravelPhpdocOrderFixer.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Fixers;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class LaravelPhpdocOrderFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'LaravelCodeStyle/laravel_phpdoc_order';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Annotations in PHPDoc should be ordered so that `@param` annotations come first, then `@return` annotations, then `@throws` annotations.',
+            [
+                new CodeSample(
+                    '<?php
+/**
+ * Hello there!
+ *
+ * @throws Exception|RuntimeException foo
+ * @custom Test!
+ * @return int  Return the number of changes.
+ * @param string $foo
+ * @param bool   $bar Bar
+ */
+'
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Must run before PhpdocAlignFixer, PhpdocSeparationFixer, PhpdocTrimFixer.
+     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, PhpdocAddMissingParamAnnotationFixer, PhpdocIndentFixer, PhpdocNoEmptyReturnFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     */
+    public function getPriority(): int
+    {
+        return -2;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        foreach ($tokens as $index => $token) {
+            if (! $token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
+            $content = $token->getContent();
+            // move param to start, throws to end, leave return in the middle
+            $content = $this->moveParamAnnotations($content);
+            // we're parsing the content again to make sure the internal
+            // state of the docblock is correct after the modifications
+            $content = $this->moveThrowsAnnotations($content);
+            // persist the content at the end
+            $tokens[$index] = new Token([T_DOC_COMMENT, $content]);
+        }
+    }
+
+    /**
+     * Move all param annotations in before throws and return annotations.
+     */
+    private function moveParamAnnotations(string $content): string
+    {
+        $doc = new DocBlock($content);
+        $params = $doc->getAnnotationsOfType('param');
+
+        // nothing to do if there are no param annotations
+        if (0 === \count($params)) {
+            return $content;
+        }
+
+        $others = $doc->getAnnotationsOfType(['throws', 'return']);
+
+        if (0 === \count($others)) {
+            return $content;
+        }
+
+        // get the index of the final line of the final param annotation
+        $end = end($params)->getEnd();
+
+        $line = $doc->getLine($end);
+
+        // move stuff about if required
+        foreach ($others as $other) {
+            if ($other->getStart() < $end) {
+                // we're doing this to maintain the original line indices
+                $line->setContent($line->getContent().$other->getContent());
+                $other->remove();
+            }
+        }
+
+        return $doc->getContent();
+    }
+
+    /**
+     * Move all return annotations after param and throws annotations.
+     */
+    private function moveThrowsAnnotations(string $content): string
+    {
+        $doc = new DocBlock($content);
+        $throws = $doc->getAnnotationsOfType('throws');
+
+        // nothing to do if there are no return annotations
+        if (0 === \count($throws)) {
+            return $content;
+        }
+
+        $others = $doc->getAnnotationsOfType(['param', 'return']);
+
+        // nothing to do if there are no other annotations
+        if (0 === \count($others)) {
+            return $content;
+        }
+
+        // get the index of the first line of the first return annotation
+        $start = $throws[0]->getStart();
+        $line = $doc->getLine($start);
+
+        // move stuff about if required
+        foreach (array_reverse($others) as $other) {
+            if ($other->getEnd() > $start) {
+                // we're doing this to maintain the original line indices
+                $line->setContent($other->getContent().$line->getContent());
+                $other->remove();
+            }
+        }
+
+        return $doc->getContent();
+    }
+}

--- a/app/Fixers/LaravelPhpdocSeparationFixer.php
+++ b/app/Fixers/LaravelPhpdocSeparationFixer.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Fixers;
+
+use App\Fixers\Utils\PhpdocTagComperator;
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\DocBlock\Annotation;
+use PhpCsFixer\DocBlock\DocBlock;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class LaravelPhpdocSeparationFixer extends AbstractFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'LaravelCodeStyle/laravel_phpdoc_separation';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other, and annotations of a different type are separated by a single blank line. @param and @return are of the same type',
+            [
+                new CodeSample(
+                    '<?php
+/**
+ * Description.
+ * @param string $foo
+ *
+ *
+ * @param bool   $bar Bar
+ * @throws Exception|RuntimeException
+ * @return bool
+ */
+function fnc($foo, $bar) {}
+'
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Must run before PhpdocAlignFixer.
+     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, GeneralPhpdocAnnotationRemoveFixer, PhpdocIndentFixer, PhpdocNoAccessFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocOrderFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     */
+    public function getPriority(): int
+    {
+        return -3;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        foreach ($tokens as $index => $token) {
+            if (! $token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
+            $doc = new DocBlock($token->getContent());
+            $this->fixDescription($doc);
+            $this->fixAnnotations($doc);
+
+            $tokens[$index] = new Token([T_DOC_COMMENT, $doc->getContent()]);
+        }
+    }
+
+    /**
+     * Make sure the description is separated from the annotations.
+     */
+    private function fixDescription(DocBlock $doc): void
+    {
+        foreach ($doc->getLines() as $index => $line) {
+            if ($line->containsATag()) {
+                break;
+            }
+
+            if ($line->containsUsefulContent()) {
+                $next = $doc->getLine($index + 1);
+
+                if (null !== $next && $next->containsATag()) {
+                    $line->addBlank();
+
+                    break;
+                }
+            }
+        }
+    }
+
+    /**
+     * Make sure the annotations are correctly separated.
+     */
+    private function fixAnnotations(DocBlock $doc): void
+    {
+        foreach ($doc->getAnnotations() as $index => $annotation) {
+            $next = $doc->getAnnotation($index + 1);
+
+            if (null === $next) {
+                break;
+            }
+
+            if (true === $next->getTag()->valid()) {
+                if (PhpdocTagComperator::shouldBeTogether($annotation->getTag(), $next->getTag())) {
+                    $this->ensureAreTogether($doc, $annotation, $next);
+                } else {
+                    $this->ensureAreSeparate($doc, $annotation, $next);
+                }
+            }
+        }
+    }
+
+    /**
+     * Force the given annotations to immediately follow each other.
+     */
+    private function ensureAreTogether(DocBlock $doc, Annotation $first, Annotation $second): void
+    {
+        $pos = $first->getEnd();
+        $final = $second->getStart();
+
+        for ($pos = $pos + 1; $pos < $final; $pos++) {
+            $doc->getLine($pos)->remove();
+        }
+    }
+
+    /**
+     * Force the given annotations to have one empty line between each other.
+     */
+    private function ensureAreSeparate(DocBlock $doc, Annotation $first, Annotation $second): void
+    {
+        $pos = $first->getEnd();
+        $final = $second->getStart() - 1;
+
+        // check if we need to add a line, or need to remove one or more lines
+        if ($pos === $final) {
+            $doc->getLine($pos)->addBlank();
+
+            return;
+        }
+
+        for ($pos = $pos + 1; $pos < $final; $pos++) {
+            $doc->getLine($pos)->remove();
+        }
+    }
+}

--- a/app/Fixers/LaravelPhpdocSeparationFixer.php
+++ b/app/Fixers/LaravelPhpdocSeparationFixer.php
@@ -71,6 +71,8 @@ function fnc($foo, $bar) {}
      * - PhpdocScalarFixer
      * - PhpdocToCommentFixer
      * - PhpdocTypesFixer.
+     *
+     * @return int
      */
     public function getPriority(): int
     {
@@ -87,7 +89,7 @@ function fnc($foo, $bar) {}
      * need a fixing, but when this method returns false then the Tokens collection
      * need no fixing for sure.
      *
-     * @param  \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @param  \PhpCsFixer\Tokenizer\Tokens  $tokens
      * @return bool
      */
     public function isCandidate(Tokens $tokens): bool
@@ -98,8 +100,8 @@ function fnc($foo, $bar) {}
     /**
      * Fixes a file.
      *
-     * @param  \SplFileInfo $file
-     * @param  \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @param  \SplFileInfo  $file
+     * @param  \PhpCsFixer\Tokenizer\Tokens  $tokens
      * @return void
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
@@ -120,7 +122,7 @@ function fnc($foo, $bar) {}
     /**
      * Make sure the description is separated from the annotations.
      *
-     * @param \PhpCsFixer\DocBlock\DocBlock $doc
+     * @param  \PhpCsFixer\DocBlock\DocBlock  $doc
      * @return void
      */
     private function fixDescription($doc)
@@ -145,7 +147,7 @@ function fnc($foo, $bar) {}
     /**
      * Make sure the annotations are correctly separated.
      *
-     * @param \PhpCsFixer\DocBlock\DocBlock $doc
+     * @param  \PhpCsFixer\DocBlock\DocBlock  $doc
      * @return void
      */
     private function fixAnnotations($doc)
@@ -171,9 +173,9 @@ function fnc($foo, $bar) {}
      * Force the given annotations to immediately follow each other.
      * This is done by removing the blank lines between them.
      *
-     * @param  \PhpCsFixer\DocBlock\DocBlock $doc
-     * @param  \PhpCsFixer\DocBlock\Annotation $annotation
-     * @param  \PhpCsFixer\DocBlock\Annotation $next
+     * @param  \PhpCsFixer\DocBlock\DocBlock  $doc
+     * @param  \PhpCsFixer\DocBlock\Annotation  $annotation
+     * @param  \PhpCsFixer\DocBlock\Annotation  $next
      * @return void
      */
     private function ensureAreTogether($doc, $annotation, $next)
@@ -191,9 +193,9 @@ function fnc($foo, $bar) {}
      * This is done by adding a blank line between them or reducing the number
      * of blank lines between them to one.
      *
-     * @param  \PhpCsFixer\DocBlock\DocBlock $doc
-     * @param  \PhpCsFixer\DocBlock\Annotation $annotation
-     * @param  \PhpCsFixer\DocBlock\Annotation $next
+     * @param  \PhpCsFixer\DocBlock\DocBlock  $doc
+     * @param  \PhpCsFixer\DocBlock\Annotation  $annotation
+     * @param  \PhpCsFixer\DocBlock\Annotation  $next
      * @return void
      */
     private function ensureAreSeparate($doc, $annotation, $next)

--- a/app/Fixers/LaravelPhpdocSeparationFixer.php
+++ b/app/Fixers/LaravelPhpdocSeparationFixer.php
@@ -2,7 +2,7 @@
 
 namespace App\Fixers;
 
-use App\Fixers\Utils\PhpdocTagComperator;
+use App\Fixers\Utils\PhpdocTagComparator;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\DocBlock\Annotation;
 use PhpCsFixer\DocBlock\DocBlock;
@@ -120,7 +120,7 @@ function fnc($foo, $bar) {}
             }
 
             if (true === $next->getTag()->valid()) {
-                if (PhpdocTagComperator::shouldBeTogether($annotation->getTag(), $next->getTag())) {
+                if (PhpdocTagComparator::shouldBeTogether($annotation->getTag(), $next->getTag())) {
                     $this->ensureAreTogether($doc, $annotation, $next);
                 } else {
                     $this->ensureAreSeparate($doc, $annotation, $next);

--- a/app/Fixers/LaravelPhpdocSeparationFixer.php
+++ b/app/Fixers/LaravelPhpdocSeparationFixer.php
@@ -4,7 +4,6 @@ namespace App\Fixers;
 
 use App\Fixers\Utils\PhpdocTagComparator;
 use PhpCsFixer\AbstractFixer;
-use PhpCsFixer\DocBlock\Annotation;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
@@ -15,15 +14,20 @@ use PhpCsFixer\Tokenizer\Tokens;
 class LaravelPhpdocSeparationFixer extends AbstractFixer
 {
     /**
-     * {@inheritdoc}
+     * Returns the name of the fixer.
+     * The name must match the pattern /^[A-Z][a-zA-Z0-9]*\/[a-z][a-z0-9_]*$/
+     *
+     * @return string
      */
     public function getName(): string
     {
-        return 'LaravelCodeStyle/laravel_phpdoc_separation';
+        return 'Laravel/laravel_phpdoc_separation';
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the definition of the fixer.
+     *
+     * @return \PhpCsFixer\FixerDefinition\FixerDefinitionInterface
      */
     public function getDefinition(): FixerDefinitionInterface
     {
@@ -49,18 +53,42 @@ function fnc($foo, $bar) {}
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the priority of the fixer.
      *
-     * Must run before PhpdocAlignFixer.
-     * Must run after AlignMultilineCommentFixer, CommentToPhpdocFixer, GeneralPhpdocAnnotationRemoveFixer, PhpdocIndentFixer, PhpdocNoAccessFixer, PhpdocNoEmptyReturnFixer, PhpdocNoPackageFixer, PhpdocOrderFixer, PhpdocScalarFixer, PhpdocToCommentFixer, PhpdocTypesFixer.
+     * The default priority is 0 and higher priorities are executed first.
+     *
+     * Must run before
+     * - PhpdocAlignFixer
+     *
+     * Must run after
+     * - AlignMultilineCommentFixer
+     * - CommentToPhpdocFixer
+     * - GeneralPhpdocAnnotationRemoveFixer
+     * - PhpdocIndentFixer, PhpdocNoAccessFixer
+     * - PhpdocNoEmptyReturnFixer
+     * - PhpdocNoPackageFixer
+     * - PhpdocOrderFixer
+     * - PhpdocScalarFixer
+     * - PhpdocToCommentFixer
+     * - PhpdocTypesFixer.
      */
     public function getPriority(): int
     {
         return -3;
     }
 
+
     /**
-     * {@inheritdoc}
+     * Check if the fixer is a candidate for given Tokens collection.
+     *
+     * Fixer is a candidate when the collection contains tokens that may be fixed
+     * during fixer work. This could be considered as some kind of bloom filter.
+     * When this method returns true then to the Tokens collection may or may not
+     * need a fixing, but when this method returns false then the Tokens collection
+     * need no fixing for sure.
+     *
+     * @param  \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @return bool
      */
     public function isCandidate(Tokens $tokens): bool
     {
@@ -68,7 +96,11 @@ function fnc($foo, $bar) {}
     }
 
     /**
-     * {@inheritdoc}
+     * Fixes a file.
+     *
+     * @param  \SplFileInfo $file
+     * @param  \PhpCsFixer\Tokenizer\Tokens $tokens
+     * @return void
      */
     protected function applyFix(\SplFileInfo $file, Tokens $tokens): void
     {
@@ -87,8 +119,11 @@ function fnc($foo, $bar) {}
 
     /**
      * Make sure the description is separated from the annotations.
+     *
+     * @param \PhpCsFixer\DocBlock\DocBlock $doc
+     * @return void
      */
-    private function fixDescription(DocBlock $doc): void
+    private function fixDescription($doc)
     {
         foreach ($doc->getLines() as $index => $line) {
             if ($line->containsATag()) {
@@ -109,8 +144,11 @@ function fnc($foo, $bar) {}
 
     /**
      * Make sure the annotations are correctly separated.
+     *
+     * @param \PhpCsFixer\DocBlock\DocBlock $doc
+     * @return void
      */
-    private function fixAnnotations(DocBlock $doc): void
+    private function fixAnnotations($doc)
     {
         foreach ($doc->getAnnotations() as $index => $annotation) {
             $next = $doc->getAnnotation($index + 1);
@@ -131,8 +169,14 @@ function fnc($foo, $bar) {}
 
     /**
      * Force the given annotations to immediately follow each other.
+     * This is done by removing the blank lines between them.
+     *
+     * @param  \PhpCsFixer\DocBlock\DocBlock $doc
+     * @param  \PhpCsFixer\DocBlock\Annotation $annotation
+     * @param  \PhpCsFixer\DocBlock\Annotation $next
+     * @return void
      */
-    private function ensureAreTogether(DocBlock $doc, Annotation $first, Annotation $second): void
+    private function ensureAreTogether($doc, $first, $second)
     {
         $pos = $first->getEnd();
         $final = $second->getStart();
@@ -144,8 +188,15 @@ function fnc($foo, $bar) {}
 
     /**
      * Force the given annotations to have one empty line between each other.
+     * This is done by adding a blank line between them or reducing the number
+     * of blank lines between them to one.
+     *
+     * @param  \PhpCsFixer\DocBlock\DocBlock $doc
+     * @param  \PhpCsFixer\DocBlock\Annotation $annotation
+     * @param  \PhpCsFixer\DocBlock\Annotation $next
+     * @return void
      */
-    private function ensureAreSeparate(DocBlock $doc, Annotation $first, Annotation $second): void
+    private function ensureAreSeparate($doc, $first, $second)
     {
         $pos = $first->getEnd();
         $final = $second->getStart() - 1;

--- a/app/Fixers/LaravelPhpdocSeparationFixer.php
+++ b/app/Fixers/LaravelPhpdocSeparationFixer.php
@@ -176,10 +176,10 @@ function fnc($foo, $bar) {}
      * @param  \PhpCsFixer\DocBlock\Annotation $next
      * @return void
      */
-    private function ensureAreTogether($doc, $first, $second)
+    private function ensureAreTogether($doc, $annotation, $next)
     {
-        $pos = $first->getEnd();
-        $final = $second->getStart();
+        $pos = $annotation->getEnd();
+        $final = $next->getStart();
 
         for ($pos = $pos + 1; $pos < $final; $pos++) {
             $doc->getLine($pos)->remove();
@@ -196,10 +196,10 @@ function fnc($foo, $bar) {}
      * @param  \PhpCsFixer\DocBlock\Annotation $next
      * @return void
      */
-    private function ensureAreSeparate($doc, $first, $second)
+    private function ensureAreSeparate($doc, $annotation, $next)
     {
-        $pos = $first->getEnd();
-        $final = $second->getStart() - 1;
+        $pos = $annotation->getEnd();
+        $final = $next->getStart() - 1;
 
         // check if we need to add a line, or need to remove one or more lines
         if ($pos === $final) {

--- a/app/Fixers/LaravelPhpdocSeparationFixer.php
+++ b/app/Fixers/LaravelPhpdocSeparationFixer.php
@@ -12,7 +12,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 
-final class LaravelPhpdocSeparationFixer extends AbstractFixer
+class LaravelPhpdocSeparationFixer extends AbstractFixer
 {
     /**
      * {@inheritdoc}

--- a/app/Fixers/LaravelPhpdocSeparationFixer.php
+++ b/app/Fixers/LaravelPhpdocSeparationFixer.php
@@ -79,7 +79,6 @@ function fnc($foo, $bar) {}
         return -3;
     }
 
-
     /**
      * Check if the fixer is a candidate for given Tokens collection.
      *

--- a/app/Fixers/Utils/PhpdocTagComparator.php
+++ b/app/Fixers/Utils/PhpdocTagComparator.php
@@ -22,8 +22,8 @@ class PhpdocTagComparator
     /**
      * Should the given tags be kept together, or kept apart?
      *
-     * @param  Tag $first
-     * @param  Tag $second
+     * @param  \PhpCsFixer\DocBlock\Tag $first
+     * @param  \PhpCsFixer\DocBlock\Tag $second
      * @return bool
      */
     public static function shouldBeTogether($first, $second)

--- a/app/Fixers/Utils/PhpdocTagComparator.php
+++ b/app/Fixers/Utils/PhpdocTagComparator.php
@@ -20,8 +20,8 @@ class PhpdocTagComparator
     /**
      * Decide if the the given tags be kept together or kept apart?
      *
-     * @param  \PhpCsFixer\DocBlock\Tag $first
-     * @param  \PhpCsFixer\DocBlock\Tag $second
+     * @param  \PhpCsFixer\DocBlock\Tag  $first
+     * @param  \PhpCsFixer\DocBlock\Tag  $second
      * @return bool
      */
     public static function shouldBeTogether($first, $second)

--- a/app/Fixers/Utils/PhpdocTagComparator.php
+++ b/app/Fixers/Utils/PhpdocTagComparator.php
@@ -4,7 +4,7 @@ namespace App\Fixers\Utils;
 
 use PhpCsFixer\DocBlock\Tag;
 
-final class PhpdocTagComparator
+class PhpdocTagComparator
 {
     /**
      * Groups of tags that should be allowed to immediately follow each other.
@@ -21,6 +21,10 @@ final class PhpdocTagComparator
 
     /**
      * Should the given tags be kept together, or kept apart?
+     *
+     * @param  Tag $first
+     * @param  Tag $second
+     * @return bool
      */
     public static function shouldBeTogether(Tag $first, Tag $second): bool
     {

--- a/app/Fixers/Utils/PhpdocTagComparator.php
+++ b/app/Fixers/Utils/PhpdocTagComparator.php
@@ -2,8 +2,6 @@
 
 namespace App\Fixers\Utils;
 
-use PhpCsFixer\DocBlock\Tag;
-
 class PhpdocTagComparator
 {
     /**
@@ -20,7 +18,7 @@ class PhpdocTagComparator
     ];
 
     /**
-     * Should the given tags be kept together, or kept apart?
+     * Decide if the the given tags be kept together or kept apart?
      *
      * @param  \PhpCsFixer\DocBlock\Tag $first
      * @param  \PhpCsFixer\DocBlock\Tag $second

--- a/app/Fixers/Utils/PhpdocTagComparator.php
+++ b/app/Fixers/Utils/PhpdocTagComparator.php
@@ -26,7 +26,7 @@ class PhpdocTagComparator
      * @param  Tag $second
      * @return bool
      */
-    public static function shouldBeTogether(Tag $first, Tag $second): bool
+    public static function shouldBeTogether($first, $second)
     {
         $firstName = $first->getName();
         $secondName = $second->getName();

--- a/app/Fixers/Utils/PhpdocTagComperator.php
+++ b/app/Fixers/Utils/PhpdocTagComperator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Fixers\Utils;
+
+use PhpCsFixer\DocBlock\Tag;
+
+final class PhpdocTagComperator
+{
+    /**
+     * Groups of tags that should be allowed to immediately follow each other.
+     *
+     * @var array
+     */
+    private static $groups = [
+        ['deprecated', 'link', 'see', 'since'],
+        ['author', 'copyright', 'license'],
+        ['category', 'package', 'subpackage'],
+        ['property', 'property-read', 'property-write'],
+        ['param', 'return'],
+    ];
+
+    /**
+     * Should the given tags be kept together, or kept apart?
+     */
+    public static function shouldBeTogether(Tag $first, Tag $second): bool
+    {
+        $firstName = $first->getName();
+        $secondName = $second->getName();
+
+        if ($firstName === $secondName) {
+            return true;
+        }
+
+        foreach (self::$groups as $group) {
+            if (\in_array($firstName, $group, true) && \in_array($secondName, $group, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Fixers/Utils/PhpdocTagComperator.php
+++ b/app/Fixers/Utils/PhpdocTagComperator.php
@@ -4,7 +4,7 @@ namespace App\Fixers\Utils;
 
 use PhpCsFixer\DocBlock\Tag;
 
-final class PhpdocTagComperator
+final class PhpdocTagComparator
 {
     /**
      * Groups of tags that should be allowed to immediately follow each other.

--- a/app/Fixers/Utils/PhpdocTagComperator.php
+++ b/app/Fixers/Utils/PhpdocTagComperator.php
@@ -9,7 +9,7 @@ final class PhpdocTagComperator
     /**
      * Groups of tags that should be allowed to immediately follow each other.
      *
-     * @var array
+     * @var array<string[]>
      */
     private static $groups = [
         ['deprecated', 'link', 'see', 'since'],

--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -155,7 +155,7 @@ return ConfigurationFactory::preset([
     'whitespace_after_comma_in_array' => true,
 
     // Custom Laravel Fixers which are not included in the PHP CS Fixer
-    'LaravelCodeStyle/laravel_phpdoc_alignment' => true,
-    'LaravelCodeStyle/laravel_phpdoc_order' => true,
-    'LaravelCodeStyle/laravel_phpdoc_separation' => true,
+    'Laravel/laravel_phpdoc_alignment' => true,
+    'Laravel/laravel_phpdoc_order' => true,
+    'Laravel/laravel_phpdoc_separation' => true,
 ]);

--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -153,4 +153,9 @@ return ConfigurationFactory::preset([
         'elements' => ['method', 'property'],
     ],
     'whitespace_after_comma_in_array' => true,
+
+    // Custom Laravel Fixers which are not included in the PHP CS Fixer
+    'LaravelCodeStyle/laravel_phpdoc_alignment' => true,
+    'LaravelCodeStyle/laravel_phpdoc_order' => true,
+    'LaravelCodeStyle/laravel_phpdoc_separation' => true,
 ]);


### PR DESCRIPTION
Fixes #1 

The Laravel Code Style has the following style throughout the source code, which currently can not be described with PHP-CS-Fixer alone. This PR adds three new custom fixers for the laravel preset, which of course can be added to psr12 or symfony if the user wants to.

The Fixers are mostly copies with changes from the PHP-CS-Fixer Source Code.

### `Laravel/laravel_phpdoc_alignment`
After `@param` should be two spaces then a `type-hint` then another two spaces and then the `$variable`
```diff
  /**
   * Here is a description for what the function does
-  * @param string $foo
+  * @param  string  $foo
   * @return string
   */
  public function bar($foo) {}
```

#### `Laravel/laravel_phpdoc_order`
First should be the `description` after that `@param` then `@return` and at last `@throws`
The default rule `phpdoc_order` has a different order: `description`, `@param`, `@throws`, `@return`
```diff
  /**
   * Here is a description for what the function does
   * @param string $foo
   * @param  string  $foo
-  * @throws \Exception
   * @return string
+  * @throws \Exception
   */
  public function bar($foo) {}
```

#### `Laravel/laravel_phpdoc_seperation `
Between each group of tags should be an empty line for seperation. `@param` and `@return` are always of the same group and are not to be seperated with an empty line.
The default behaviour for `phpdoc_seperation` is also an empty line between `@param` and `@return`.
```diff
  /**
   * Here is a description for what the function does
+  *
   * @param string $foo
   * @param  string  $foo
-  *
   * @return string
+  *
   * @throws \Exception
   */
  public function bar($foo) {}
```

## Additional Note:
There is still some Fixers which need to be implemented, e.g. that in the PHPDoc is full quantified class name is used, which also cannot be described by PHP-CS-Fixer alone:
You may take a look at https://github.com/adamwojs/php-cs-fixer-phpdoc-force-fqcn
though the complex type formatting is not tagged yet and there are still some problems with classes which are in the same namespace.