### PR TITLE
Ignore _ide_helper_models.php

### DIFF
--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -14,6 +14,7 @@ class ConfigurationFactory
      * @var array<int, string>
      */
     protected static $notName = [
+        '_ide_helper_models.php',
         '_ide_helper.php',
         '*.blade.php',
     ];


### PR DESCRIPTION
This will ignore the `_ide_helper_models.php` file which also can be generated with `barryvdh/laravel-ide-helper`.