### PR TITLE
Ignore .phpstorm.meta.php

### DIFF
--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -16,6 +16,7 @@ class ConfigurationFactory
     protected static $notName = [
         '_ide_helper_models.php',
         '_ide_helper.php',
+        '.phpstorm.meta.php',
         '*.blade.php',
     ];
 


### PR DESCRIPTION
This PR simply ignores `.phpstorm.meta.php` which is generated by PhpStorm automatically when using barryvdh/laravel-ide-helper: https://github.com/barryvdh/laravel-ide-helper#phpstorm-meta-for-container-instances