### PR TITLE
Ignore `node_modules` folder

### DIFF
--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -32,6 +32,7 @@ class ConfigurationFactory
     protected static $exclude = [
         'storage',
         'bootstrap/cache',
+        'node_modules',
     ];
 
     /**


### PR DESCRIPTION
Hi there, thanks for releasing Pint! 

As the title states, this PR simply excludes the `node_modules` folder. Some packages we use actually ship JS and PHP from one repo so Pint is picking them up and reformatting them, eg: https://github.com/rialto-php/rialto.

Let me know if there's any feedback, thanks!