### PR TITLE
[0.x] Ignore non-PHP files & vendor files

### DIFF
--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -33,6 +33,7 @@ class ConfigurationFactory
         'storage',
         'bootstrap/cache',
         'node_modules',
+        'vendor',
     ];
 
     /**
@@ -47,6 +48,7 @@ class ConfigurationFactory
         $localConfiguration = resolve(ConfigurationJsonRepository::class);
 
         $finder = Finder::create()
+            ->name('*.php')
             ->notName(static::$notName)
             ->exclude(static::$exclude)
             ->ignoreDotFiles(true)


### PR DESCRIPTION
- It's best to ignore the vendor, both to avoid weird bugs (as it doesn't show up in VCS) as well as to ignore 80%+ of a project's code.
- For the same reasons, it also makes sense to only include `.php` files.