### PR TITLE
🔧 add no-useless-else

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -106,6 +106,7 @@ return ConfigurationFactory::preset([
     'no_unused_imports' => true,
     'no_unreachable_default_argument_value' => true,
     'no_useless_return' => true,
+    'no_useless_else' => true,
     'no_whitespace_before_comma_in_array' => true,
     'no_whitespace_in_blank_line' => true,
     'normalize_index_brace' => true,


### PR DESCRIPTION
I'd like to add this rule to cleanup code like this:

```php
function()
{
  if ($foo == $bar)
  {
    return true
  } else {
    return false
  }
}
```

in favor of having code like this:

```php
function()
{
  if ($foo == $bar)
  {
    return true
  }
  return false
}
```
