### PR TITLE
[0.x] Ignore Laravel actions IDE helper file

### DIFF
--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -18,6 +18,7 @@ class ConfigurationFactory
      * @var array<int, string>
      */
     protected static $notName = [
+        '_ide_helper_actions.php',
         '_ide_helper_models.php',
         '_ide_helper.php',
         '.phpstorm.meta.php',


### PR DESCRIPTION
This will add the [Laravel actions](https://laravelactions.com/2.x/installation.html#install-ide-helper-for-autocomplete-optional) IDE help file to the list of ignored files.