### PR TITLE
Remove unused $path variable

### DIFF
--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -44,7 +44,6 @@ class ConfigurationFactory
      */
     public static function preset($rules)
     {
-        $path = Project::path();
         $localConfiguration = resolve(ConfigurationJsonRepository::class);
 
         $finder = Finder::create()


### PR DESCRIPTION
This small PR remove unused `$path` variable from `Factories\ConfigurationFactory.php`.