### PR TITLE
[0.x] Braces for anonymous construct - laravel preset

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -14,7 +14,13 @@ return ConfigurationFactory::preset([
     'blank_line_before_statement' => [
         'statements' => ['return'],
     ],
-    'braces' => true,
+    'braces' => [
+        'allow_single_line_anonymous_class_with_empty_body' => true,
+        'allow_single_line_closure' => true,
+        'position_after_control_structures' => 'next',
+        'position_after_functions_and_oop_constructs' => 'next',
+        'position_after_anonymous_constructs' => 'next'
+    ],
     'cast_spaces' => true,
     'class_attributes_separation' => [
         'elements' => [

--- a/tests/Feature/Fixers/AnonymousConstructBracesTest.php
+++ b/tests/Feature/Fixers/AnonymousConstructBracesTest.php
@@ -1,0 +1,14 @@
+<?php
+
+it('fixes the code', function () {
+    [$statusCode, $output] = run('default', [
+        'path' => base_path('tests/Fixtures/with-anonymous-constructs'),
+        '--preset' => 'laravel',
+    ]);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('  .')
+        ->toContain('  PASS')
+        ;
+});

--- a/tests/Fixtures/with-anonymous-constructs/file.php
+++ b/tests/Fixtures/with-anonymous-constructs/file.php
@@ -1,0 +1,6 @@
+<?php
+
+return new class extends stdClass
+{
+    // ....
+};


### PR DESCRIPTION
This PR updates "braces" rule for `--laravel` preset and fix #14 .
