### PR TITLE
Support custom rules

### DIFF
--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -59,9 +59,13 @@ class ConfigurationFactory
             $finder->{$method}($arguments);
         }
 
+        $custom = $localConfiguration->custom();
+        $customRules = array_map(fn () => true, array_flip($custom));
+        $customFixers = array_map(fn ($fixer) => (new $fixer), array_keys($custom));
+
         return (new Config())
             ->setFinder($finder)
-            ->setRules(array_merge($rules, $localConfiguration->rules()))
+            ->setRules(array_merge($rules, $localConfiguration->rules(), $customRules))
             ->setRiskyAllowed(true)
             ->setUsingCache(true)
             ->registerCustomFixers([
@@ -69,6 +73,7 @@ class ConfigurationFactory
                 new LaravelPhpdocOrderFixer(),
                 new LaravelPhpdocSeparationFixer(),
                 new LaravelPhpdocAlignmentFixer(),
+                ...$customFixers
             ]);
     }
 }

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -50,6 +50,16 @@ class ConfigurationJsonRepository
     }
 
     /**
+     * Gets the custom rules options.
+     *
+     * @return array<int, string>
+     */
+    public function custom()
+    {
+        return $this->get()['custom'] ?? [];
+    }
+
+    /**
      * Gets the preset option.
      *
      * @return string

--- a/tests/Feature/CustomRulesTest.php
+++ b/tests/Feature/CustomRulesTest.php
@@ -1,0 +1,13 @@
+<?php
+
+it('uses a specified custom rule', function () {
+    [$statusCode, $output] = run('default', [
+        'path' => base_path('tests/Fixtures/custom-rules'),
+    ]);
+
+    expect($statusCode)->toBe(1)
+        ->and($output)
+        ->toContain('── PSR 12')
+        ->toContain('  ⨯')
+        ->toContain("+//\n");
+});

--- a/tests/Fixtures/CustomFixer.php
+++ b/tests/Fixtures/CustomFixer.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+class CustomFixer implements FixerInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function getName(): string
+    {
+        return 'ACMECorp/custom_rule';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        for ($index = $tokens->count() - 1; $index > 0; $index--) {
+            if (! $tokens[$index]->isGivenKind([\T_COMMENT])) {
+                continue;
+            }
+
+            $content = preg_replace('/^\/\/\s/', "//\n// ", $tokens[$index]->getContent(), 1);
+
+            $tokens[$index] = new Token([T_COMMENT, $content]);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition('Lines starting with single-line comments as first characters should be converted to double-line comments.', []);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function supports(SplFileInfo $file): bool
+    {
+        return true;
+    }
+}

--- a/tests/Fixtures/custom-rules/double_line_comments.php
+++ b/tests/Fixtures/custom-rules/double_line_comments.php
@@ -1,0 +1,3 @@
+<?php
+
+// custom fixer test

--- a/tests/Fixtures/custom-rules/pint.json
+++ b/tests/Fixtures/custom-rules/pint.json
@@ -1,0 +1,6 @@
+{
+    "preset": "psr12",
+    "custom": {
+        "\\Tests\\Fixtures\\CustomFixer": "ACMECorp/custom_rule"
+    }
+}

--- a/tests/Fixtures/rules/pint.json
+++ b/tests/Fixtures/rules/pint.json
@@ -1,8 +1,5 @@
 {
     "rules": {
         "no_unused_imports": false
-    },
-    "custom": {
-        "\\ACMECorp\\Fixers\\MyCustomFixer": "ACMECorp/my_custom_rule"
     }
 }

--- a/tests/Fixtures/rules/pint.json
+++ b/tests/Fixtures/rules/pint.json
@@ -1,5 +1,8 @@
 {
     "rules": {
         "no_unused_imports": false
+    },
+    "custom": {
+        "\\ACMECorp\\Fixers\\MyCustomFixer": "ACMECorp/my_custom_rule"
     }
 }

--- a/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
+++ b/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
@@ -17,6 +17,14 @@ it('may have rules options', function () {
     ]);
 });
 
+it('may have custom rules options', function () {
+    $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/rules/pint.json', null);
+
+    expect($repository->custom())->toBe([
+        '\ACMECorp\Fixers\MyCustomFixer' => 'ACMECorp/my_custom_rule',
+    ]);
+});
+
 it('may have finder options', function () {
     $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/finder/pint.json', null);
 

--- a/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
+++ b/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
@@ -18,10 +18,10 @@ it('may have rules options', function () {
 });
 
 it('may have custom rules options', function () {
-    $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/rules/pint.json', null);
+    $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/custom-rules/pint.json', null);
 
     expect($repository->custom())->toBe([
-        '\ACMECorp\Fixers\MyCustomFixer' => 'ACMECorp/my_custom_rule',
+        '\Tests\Fixtures\CustomFixer' => 'ACMECorp/custom_rule',
     ]);
 });
 


### PR DESCRIPTION
Hey pinters,

I wanted to use a linter since forever, however wasn't really satisfied with PHP-CS-Fixer as a standalone package. I wouldn't be able to use it out of the box either way because I use a unique – malicious gossip has it that it's a _weird_ – coding style.

```php
// psr 12
public function foo(): array
{
    $this->bar();

    // this returns something
    return array_map(fn($value) => ucwords($value), ['one', 'two', 'three']);
}
```

```php
// my weird style
public function foo () : array {
    $this->bar();

    //
    // this returns something
    return array_map(fn ($value) => ucwords($value), [ 'one', 'two', 'three' ]);
}
```

Anyway, now with pint I just got to implement a linter. This PR is my attempt to implement custom rules, so I can start writing my own and use them with pint.

The configuration now accepts a new property where the fixers FQCN and the name of the rule can be specified:
```json
{
    "custom": {
        "\\ACMECorp\\Fixers\\MyCustomFixer": "ACMECorp/my_custom_rule"
    }
}
```

The key is the FQCN to the fixer class and the value is the rule name which should be used for the configuration. I added two tests:

1. Check if the `custom` property can be read by the `ConfigurationJsonRepository`
2. Check if a custom fixer is being applied when specified. (The actual fixer is nonsense, but we know that the fixer is being applied)

I don't know if custom rules are even a desired feature for pint and if this gets closed I will still be waiting excitedly for custom rules. However, I'd love to hear some thoughts on this. 🙃