### PR TITLE
List syntax rule

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -57,6 +57,7 @@ return ConfigurationFactory::preset([
     'lambda_not_used_import' => true,
     'linebreak_after_opening_tag' => true,
     'line_ending' => true,
+    'list_syntax' => true,
     'lowercase_cast' => true,
     'lowercase_keywords' => true,
     'lowercase_static_reference' => true,


### PR DESCRIPTION
This PR address the `list_syntax` rule.

`list()` is not used anywhere in the Laravel code base while the shortened syntax is. Adding this rule not only conforms to the existing Laravel syntax usage, but ensures other code bases using Pint conform to that syntax as well.

For reference: [PHPCS list_syntax](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.8|fixer:list_syntax)