### PR TITLE
Also ensure that the double arrow has a single space on each side.

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -7,7 +7,6 @@ return ConfigurationFactory::preset([
     'array_syntax' => ['syntax' => 'short'],
     'binary_operator_spaces' => [
         'default' => 'single_space',
-        'operators' => ['=>' => null],
     ],
     'blank_line_after_namespace' => true,
     'blank_line_after_opening_tag' => true,

--- a/tests/Feature/Fixers/BinaryOperatorSpacesFixerTest.php
+++ b/tests/Feature/Fixers/BinaryOperatorSpacesFixerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+it('fixes the code', function () {
+    [$statusCode, $output] = run('default', [
+        'path' => base_path('tests/Fixtures/fixers/binary_operator_spaces.php'),
+        '--preset' => 'laravel',
+    ]);
+
+    expect($statusCode)->toBe(1)
+        ->and($output)
+        ->toContain(
+            <<<'EOF'
+  -    'long_item_name' =>  'value',
+  -    'short'          =>  'value',
+  +    'long_item_name' => 'value',
+  +    'short' => 'value',
+EOF,
+        )->toContain(
+            <<<'EOF'
+  -$array = array_filter($array, fn ($item)  =>  $item === 'value');
+  +$array = array_filter($array, fn ($item) => $item === 'value');
+EOF,
+        );
+});

--- a/tests/Fixtures/fixers/binary_operator_spaces.php
+++ b/tests/Fixtures/fixers/binary_operator_spaces.php
@@ -1,0 +1,8 @@
+<?php
+
+$array = [
+    'long_item_name' =>  'value',
+    'short'          =>  'value',
+];
+
+$array = array_filter($array, fn ($item)  =>  $item === 'value');


### PR DESCRIPTION
This PR addresses the `binary_operator_spaces` rule.

Double arrows `=>` do not use extra spaces anywhere in the codebase. This is even more visible when checking at arrays, where none of the items are aligned, or for arrow function syntax.
