### PR TITLE
Keep {@inheritdoc} unchanged.

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -129,7 +129,11 @@ return ConfigurationFactory::preset([
     'phpdoc_single_line_var_spacing' => true,
     'phpdoc_summary' => false,
     'phpdoc_to_comment' => false,
-    'phpdoc_tag_type' => true,
+    'phpdoc_tag_type' => [
+        'tags' => [
+            'inheritdoc' => 'inline',
+        ],
+    ],
     'phpdoc_trim' => true,
     'phpdoc_types' => true,
     'phpdoc_var_without_name' => true,


### PR DESCRIPTION
The `laravel` preset wrongfully change `{@inheritdoc}` to `@inheritdoc`.
This PR fixes that