### PR TITLE
Fix phpdoc alignment when no hint is present

### DIFF
--- a/app/Fixers/LaravelPhpdocAlignmentFixer.php
+++ b/app/Fixers/LaravelPhpdocAlignmentFixer.php
@@ -71,7 +71,17 @@ class LaravelPhpdocAlignmentFixer implements FixerInterface
 
             $newContent = preg_replace_callback(
                 '/(?P<tag>@param)\s+(?P<hint>(?:'.TypeExpression::REGEX_TYPES.')?)\s+(?P<var>(?:&|\.{3})?\$\S+)/ux',
-                fn ($matches) => $matches['tag'].'  '.$matches['hint'].'  '.$matches['var'],
+                function ($matches) {
+                    $result = $matches['tag'].'  ';
+
+                    if($matches['hint'] != '') {
+                        $result .= $matches['hint'].'  ';
+                    }
+
+                    $result .= $matches['var'];
+
+                    return $result;
+                },
                 $tokens[$index]->getContent()
             );
 


### PR DESCRIPTION
Fixes https://github.com/laravel/pint/issues/1#issuecomment-1174207786

There seems to be a Problem with `@param` annotations, where no hint is present.
This should resolve into two spaces and not four.

Example:
```diff
 /**
- * @param    $var
+ * @param  $var
  * @return bool
  */