### PR TITLE
[1.x] Fix the rules overwriting

### DIFF
--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -59,9 +59,15 @@ class ConfigurationFactory
             $finder->{$method}($arguments);
         }
 
+        foreach ($localConfiguration->rules() as $rule => $value) {
+            if (array_key_exists($rule, $rules)) unset($rules[$rule]);
+
+            $rules[$rule] = $value;
+        }
+
         return (new Config())
             ->setFinder($finder)
-            ->setRules(array_merge($rules, $localConfiguration->rules()))
+            ->setRules($rules)
             ->setRiskyAllowed(true)
             ->setUsingCache(true)
             ->registerCustomFixers([


### PR DESCRIPTION
Fixes #77 

when a rule exists in the selected preset (e.g. `single_import_per_statement`) and separately inherits from another preset containing the same (e.g. `@PSR12`) along with overwriting that [`single_import_per_statement`] rule, the value from `@PSR12` is eventually used instead of the value specified by the user.

meaning what with the following config for Pint:

```json
{
    "preset": "laravel",
    "rules": {
        "@PSR12": true,
        "single_import_per_statement": false
    }
}

```

the final value of the `single_import_per_statement` rule will be `['group_to_single_imports' => false]` instead of just `false`.

this is caused by using `array_merge` to combine the preset for Pint and the rules specified by the user, because if there is a matching key, it changes the value of that key without moving it to the end of the config. And  PHP-CS-Fixer gets the following config:

```jsonc
{
    // Laravel Preset ...
    "single_import_per_statement": false,
    // ...

    // User rules with ruleset that overwrite anything above
    "@PSR12": true
}
```