### PR TITLE
[1.x] Add ability to extend and reuse an existing configuration file

### DIFF
--- a/tests/Feature/ConfigurationTest.php
+++ b/tests/Feature/ConfigurationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Repositories\ConfigurationJsonRepository;
 use LaravelZero\Framework\Exceptions\ConsoleException;
 
 it('ensures configuration file is valid', function () {
@@ -7,3 +8,19 @@ it('ensures configuration file is valid', function () {
         'path' => base_path('tests/Fixtures/with-invalid-configuration'),
     ]);
 })->throws(ConsoleException::class, 'is not valid JSON.');
+
+it('extends existing configuration', function () {
+    chdir(base_path('tests/Fixtures/with-extended-configuration'));
+
+    expect(new ConfigurationJsonRepository(base_path('tests/Fixtures/with-extended-configuration/pint.json'), null))
+    ->finder()->toBe([
+        'notName' => ['*-my-file.php'],
+        'exclude' => ['my-specific/folder'],
+    ])
+    ->rules()->toBe([
+        'declare_strict_types' => false,
+        'octal_notation' => true,
+        'no_unused_imports' => true,
+    ])
+    ->preset()->toBe('laravel');
+});

--- a/tests/Fixtures/with-extended-configuration/parent-pint.json
+++ b/tests/Fixtures/with-extended-configuration/parent-pint.json
@@ -1,0 +1,10 @@
+{
+  "preset": "laravel",
+  "notName": [
+    "*-my-file.php"
+  ],
+  "rules": {
+    "declare_strict_types": true,
+    "octal_notation": true
+  }
+}

--- a/tests/Fixtures/with-extended-configuration/pint.json
+++ b/tests/Fixtures/with-extended-configuration/pint.json
@@ -1,0 +1,10 @@
+{
+  "extend": "parent-pint.json",
+  "exclude": [
+    "my-specific/folder"
+  ],
+  "rules": {
+    "no_unused_imports": true,
+    "declare_strict_types": false
+  }
+}


### PR DESCRIPTION
This PR adds the ability to reuse an existing configuration and override some parts locally. It can be seen as "custom vendor preset".

The goal here is to be able to publish base config files as composer package allowing the developers to override some parts in their project.

For exemple, you can imagine having a `pint.json` file with 
```json
{
    "extend": "vendor/spatie/pint-config/pint.json",
    "rules": {
        "declare_strict_types": true
    }
}
```
This way, spatie's `pint.json` can be seen as a spatie-specific preset.

For the implementation, `exclude`, `notPath`, `notName`, and `preset` are overrode by child configuration, whereas parent and child `rules` are merged together.


Not sure about the namings and the tests, feel free to ask if you want me to change some parts.
