### PR TITLE
[1.x] Update `method_argument_space rule` in Laravel preset

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -71,9 +71,7 @@ return ConfigurationFactory::preset([
     'lowercase_static_reference' => true,
     'magic_method_casing' => true,
     'magic_constant_casing' => true,
-    'method_argument_space' => [
-        'on_multiline' => 'ignore',
-    ],
+    'method_argument_space' => true,
     'multiline_whitespace_before_semicolons' => [
         'strategy' => 'no_multi_line',
     ],


### PR DESCRIPTION
This PR updates the `method_argument_space` rule in the Laravel preset.

Currently, when having arguments on multiple lines, Pint doesn't enforce all arguments to be on its own line. I couldn't find any cases where the old formatting behavior is used in a new Laravel project. That's why I think it's better to use the default PHP CS Fixer value for this rule.