### PR TITLE
[1.x] Laravel Preset - include `continue` in `blank_line_before_statement`

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -11,7 +11,10 @@ return ConfigurationFactory::preset([
     'blank_line_after_namespace' => true,
     'blank_line_after_opening_tag' => true,
     'blank_line_before_statement' => [
-        'statements' => ['return'],
+        'statements' => [
+            'continue',
+            'return'
+        ],
     ],
     'braces' => [
         'allow_single_line_anonymous_class_with_empty_body' => true,


### PR DESCRIPTION
This PR addresses an implied syntax rule of framework for the `continue` keyword.

When `continue` does not follow a control structure, a blank line is used to provide some breathing room.

[Illuminate\Auth\Access\Gate](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Auth/Access/Gate.php#L549-L551)

```php
if (! $this->canBeCalledWithUser($user, $before)) {
    continue;
}
```

[Illuminate\Collections\Arr](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Collections/Arr.php#L275-L279)
```php
if (static::exists($array, $key)) {
    unset($array[$key]);

    continue;
}
```

For reference (see Example 3): [PHPCS blank_line_before_statement](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.8|fixer:blank_line_before_statement)

