### PR TITLE
[1.x] Laravel Preset - include `for` & `foreach` in `blank_line_before_statement`

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -11,7 +11,12 @@ return ConfigurationFactory::preset([
     'blank_line_after_namespace' => true,
     'blank_line_after_opening_tag' => true,
     'blank_line_before_statement' => [
-        'statements' => ['return'],
+        'statements' => [
+            'for',
+            'foreach',
+            'case',
+            'return'
+        ],
     ],
     'braces' => [
         'allow_single_line_anonymous_class_with_empty_body' => true,


### PR DESCRIPTION
This PR addresses an implied syntax rule in the framework for the `for` & `foreach` keywords.

When either of these do not follow a control structure, a blank line is used to provide some breathing room.

**for**

[Illuminate\Collections\LazyCollection](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Collections/LazyCollection.php#L82-L86)

```php
if ($from <= $to) {
    for (; $from <= $to; $from++) {
        yield $from;
    }
} else {
```

[Illuminate\Collections\LazyCollection](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Collections/LazyCollection.php#L1035-L1039)
```php
$skip = $step - $size;

for ($i = 0; $i < $skip && $iterator->valid(); $i++) {
    $iterator->next();
}
```

**foreach**

[Illuminate\Cache\Repository](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Cache/Repository.php#L253-L257)

```php
if ($result) {
    foreach ($values as $key => $value) {
        $this->event(new KeyWritten($key, $value, $seconds));
    }
}
```

[Illuminate\Auth\Access\Gate](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Auth/Access/Gate.php#L111-L117)
```php
$abilities = is_array($ability) ? $ability : func_get_args();

foreach ($abilities as $ability) {
    if (! isset($this->abilities[$ability])) {
        return false;
    }
}
```

For reference: [PHPCS blank_line_before_statement](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.8|fixer:blank_line_before_statement)

