### PR TITLE
Add ability to use custom preset

### DIFF
--- a/app/Factories/ConfigurationResolverFactory.php
+++ b/app/Factories/ConfigurationResolverFactory.php
@@ -84,6 +84,10 @@ class ConfigurationResolverFactory
             ]);
         }
 
-        abort(1, 'Preset not found.');
+        if (! file_exists($preset) || ($config = json_decode(file_get_contents($preset), true)) === null) {
+            abort(1, 'Preset not found.');
+        }
+
+        return ConfigurationFactory::preset($config);
     }
 }

--- a/app/Factories/ConfigurationResolverFactory.php
+++ b/app/Factories/ConfigurationResolverFactory.php
@@ -37,7 +37,7 @@ class ConfigurationResolverFactory
         $preset = resolve(ConfigurationJsonRepository::class)->preset();
 
         $resolver = new ConfigurationResolver(
-            static::config($preset),
+            self::config($preset),
             [
                 'allow-risky' => 'yes',
                 'diff' => $output->isVerbose(),
@@ -71,7 +71,7 @@ class ConfigurationResolverFactory
      * Get the config from the preset.
      *
      * @param  string  $preset
-     * @return \PhpCsFixer\Config
+     * @return \PhpCsFixer\ConfigInterface
      */
     private static function config($preset)
     {

--- a/app/Factories/ConfigurationResolverFactory.php
+++ b/app/Factories/ConfigurationResolverFactory.php
@@ -36,20 +36,10 @@ class ConfigurationResolverFactory
 
         $preset = resolve(ConfigurationJsonRepository::class)->preset();
 
-        if (! in_array($preset, static::$presets)) {
-            abort(1, 'Preset not found.');
-        }
-
         $resolver = new ConfigurationResolver(
-            new Config('default'),
+            static::config($preset),
             [
                 'allow-risky' => 'yes',
-                'config' => implode(DIRECTORY_SEPARATOR, [
-                    dirname(__DIR__, 2),
-                    'resources',
-                    'presets',
-                    sprintf('%s.php', $preset),
-                ]),
                 'diff' => $output->isVerbose(),
                 'dry-run' => $input->getOption('test'),
                 'path' => $path,
@@ -75,5 +65,25 @@ class ConfigurationResolverFactory
         )));
 
         return [$resolver, $totalFiles];
+    }
+
+    /**
+     * Get the config from the preset.
+     *
+     * @param  string  $preset
+     * @return \PhpCsFixer\Config
+     */
+    private static function config($preset)
+    {
+        if (in_array($preset, static::$presets)) {
+            return require implode(DIRECTORY_SEPARATOR, [
+                dirname(__DIR__, 2),
+                'resources',
+                'presets',
+                sprintf('%s.php', $preset),
+            ]);
+        }
+
+        abort(1, 'Preset not found.');
     }
 }

--- a/app/Output/SummaryOutput.php
+++ b/app/Output/SummaryOutput.php
@@ -60,7 +60,7 @@ class SummaryOutput
                 'totalFiles' => $totalFiles,
                 'issues' => $issues,
                 'testing' => $summary->isDryRun(),
-                'preset' => $this->presets[$this->config->preset()],
+                'preset' => $this->presets[$this->config->preset()] ?? $this->config->preset(),
             ]),
         );
 

--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -13,7 +13,7 @@ return ConfigurationFactory::preset([
     'blank_line_before_statement' => [
         'statements' => [
             'continue',
-            'return'
+            'return',
         ],
     ],
     'braces' => [

--- a/tests/Feature/PresetTest.php
+++ b/tests/Feature/PresetTest.php
@@ -42,3 +42,16 @@ it('may use the Symfony preset', function () {
         ->and($output)
         ->toContain('── Symfony');
 });
+
+it('may use custom preset', function () {
+    chdir(base_path('tests/Fixtures/custom-preset'));
+
+    [$statusCode, $output] = run('default', [
+        'path' => base_path('tests/Fixtures/custom-preset'),
+        '--preset' => 'preset.json',
+    ]);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('── preset.json');
+});

--- a/tests/Fixtures/custom-preset/file.php
+++ b/tests/Fixtures/custom-preset/file.php
@@ -1,0 +1,3 @@
+<?php
+
+use Illuminate\Support\Collection;

--- a/tests/Fixtures/custom-preset/preset.json
+++ b/tests/Fixtures/custom-preset/preset.json
@@ -1,0 +1,3 @@
+{
+  "no_unused_imports": false
+}


### PR DESCRIPTION
This PR aims to be able to define a custom preset reusable in different project. It is like https://github.com/laravel/pint/pull/89 but in a different way.

It allows the developer to define a `pint.json` like 
```json
{
    "preset": "vendor/spatie/pint-preset/preset.json",
    "rules": {
        "declare_strict_types": true
    }
}
```
Where the preset is the extraction of the `rules` key in a `pint.json`.

For example : 
```json
{
    "@PSR12": true,
    "no_unused_imports": true,
    "declare_strict_types":  true
}
```

The custom preset can also be used through `--preset` option : `pint --preset=vendor/spatie/pint-preset/preset.json`


