### PR TITLE
Allow pint.php config file

### DIFF
--- a/app/Providers/RepositoriesServiceProvider.php
+++ b/app/Providers/RepositoriesServiceProvider.php
@@ -29,8 +29,14 @@ class RepositoriesServiceProvider extends ServiceProvider
         $this->app->singleton(ConfigurationJsonRepository::class, function () {
             $input = resolve(InputInterface::class);
 
+            if (file_exists(Project::path().'/pint.php') && ! file_exists(Project::path().'/pint.json')) {
+                $config = Project::path().'/pint.php';
+            } else {
+                $config = Project::path().'/pint.json';
+            }
+
             return new ConfigurationJsonRepository(
-                $input->getOption('config') ?: Project::path().'/pint.json',
+                $input->getOption('config') ?: $config,
                 $input->getOption('preset'),
             );
         });

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -2,6 +2,8 @@
 
 namespace App\Repositories;
 
+use Illuminate\Support\Str;
+
 class ConfigurationJsonRepository
 {
     /**
@@ -60,18 +62,25 @@ class ConfigurationJsonRepository
     }
 
     /**
-     * Gets the configuration from the "pint.json" file.
+     * Gets the configuration from the "pint.json" or "pint.php" file.
      *
      * @return array<string, array<int, string>|string>
      */
     protected function get()
     {
-        if (file_exists((string) $this->path)) {
+        if (! file_exists((string) $this->path)) {
+            return [];
+        }
+
+        if (Str::endsWith($this->path, '.json')) {
             return tap(json_decode(file_get_contents($this->path), true), function ($configuration) {
                 if (! is_array($configuration)) {
                     abort(1, sprintf('The configuration file [%s] is not valid JSON.', $this->path));
                 }
             });
+        }
+        if (Str::endsWith($this->path, '.php')) {
+            return require $this->path;
         }
 
         return [];

--- a/tests/Fixtures/php-config/pint.php
+++ b/tests/Fixtures/php-config/pint.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'preset' => 'psr12',
+    'rules' => [
+        'no_unused_imports' => false,
+    ],
+];

--- a/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
+++ b/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
@@ -38,3 +38,12 @@ it('may have a preset option', function () {
 
     expect($repository->preset())->toBe('laravel');
 });
+
+it('works with php file', function () {
+    $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/php-config/pint.php', null);
+
+    expect($repository->preset())->toBe('psr12')
+        ->and($repository->rules())->toBe([
+            'no_unused_imports' => false,
+        ]);
+});


### PR DESCRIPTION
This PR allows the configuration to be defined in a php file, because php is prettier than json. :wink: 

As the config gets executed, it also allows the developer to have dynamic control over the configuration, if needed.

It also allows to fetch external config (which was already tried in #89 and #97) :
```php
<?php

return [
    'preset' => 'laravel',
    'rules' => require __DIR__.'/vendor/spatie/pint-rules/rules.php',
];
```

`pint.json` has precedence over `pint.php` if both configs exist.

