### PR TITLE
[1.x] Ignores `build` folder by default

### DIFF
--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -30,9 +30,10 @@ class ConfigurationFactory
      * @var array<int, string>
      */
     protected static $exclude = [
-        'storage',
         'bootstrap/cache',
+        'build',
         'node_modules',
+        'storage',
     ];
 
     /**


### PR DESCRIPTION
This pull request makes `pint` to ignore the `build` folder by default. Usually, this folder is used for `.phar` files that don't actually need any kind of lint.