### PR TITLE
add configuration option to overwrite cache file location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-.idea
 /phpunit.xml
 /vendor
 composer.lock
 .phpunit.result.cache
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
+.idea
 /phpunit.xml
 /vendor
 composer.lock
 .phpunit.result.cache
-

--- a/app/Factories/ConfigurationResolverFactory.php
+++ b/app/Factories/ConfigurationResolverFactory.php
@@ -34,7 +34,8 @@ class ConfigurationResolverFactory
     {
         $path = $input->getArgument('path');
 
-        $preset = resolve(ConfigurationJsonRepository::class)->preset();
+        $localConfiguration = resolve(ConfigurationJsonRepository::class);
+        $preset = $localConfiguration->preset();
 
         if (! in_array($preset, static::$presets)) {
             abort(1, 'Preset not found.');
@@ -54,7 +55,7 @@ class ConfigurationResolverFactory
                 'dry-run' => $input->getOption('test'),
                 'path' => $path,
                 'path-mode' => ConfigurationResolver::PATH_MODE_OVERRIDE,
-                'cache-file' => implode(DIRECTORY_SEPARATOR, [
+                'cache-file' => $localConfiguration->cacheFile() ?? implode(DIRECTORY_SEPARATOR, [
                     realpath(sys_get_temp_dir()),
                     md5(
                         app()->isProduction()

--- a/app/Factories/ConfigurationResolverFactory.php
+++ b/app/Factories/ConfigurationResolverFactory.php
@@ -35,6 +35,7 @@ class ConfigurationResolverFactory
         $path = $input->getArgument('path');
 
         $localConfiguration = resolve(ConfigurationJsonRepository::class);
+
         $preset = $localConfiguration->preset();
 
         if (! in_array($preset, static::$presets)) {

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -50,6 +50,16 @@ class ConfigurationJsonRepository
     }
 
     /**
+     * Gets the cache file.
+     *
+     * @return string|null
+     */
+    public function cacheFile()
+    {
+        return $this->get()['cache-file'] ?? null;
+    }
+
+    /**
      * Gets the preset option.
      *
      * @return string

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -16,7 +16,7 @@ class ConfigurationJsonRepository
     ];
 
     /**
-     * Creates a new Configuration Json Repository instance.
+     * Create a new Configuration Json Repository instance.
      *
      * @param  string|null  $path
      * @param  string|null  $preset
@@ -28,7 +28,7 @@ class ConfigurationJsonRepository
     }
 
     /**
-     * Gets the finder options.
+     * Get the finder options.
      *
      * @return array<string, array<int, string>|string>
      */
@@ -40,7 +40,7 @@ class ConfigurationJsonRepository
     }
 
     /**
-     * Gets the rules options.
+     * Get the rules options.
      *
      * @return array<int, string>
      */
@@ -50,7 +50,7 @@ class ConfigurationJsonRepository
     }
 
     /**
-     * Gets the cache file.
+     * Get the cache file location.
      *
      * @return string|null
      */
@@ -60,7 +60,7 @@ class ConfigurationJsonRepository
     }
 
     /**
-     * Gets the preset option.
+     * Get the preset option.
      *
      * @return string
      */
@@ -70,7 +70,7 @@ class ConfigurationJsonRepository
     }
 
     /**
-     * Gets the configuration from the "pint.json" file.
+     * Get the configuration from the "pint.json" file.
      *
      * @return array<string, array<int, string>|string>
      */


### PR DESCRIPTION
By default Pint creates a cache file in the /tmp directory of the system. This directory is cleared on reboot (at least on Linux). For some larger repositories, this means that the first run after a reboot is significantly longer.

I was previously using php cs fixer with a cache file in the root of the project (excluded via a gitignore).

This update allows you to have the cache file at the root of a project again.

```
{
  "cache-file": ".pint.json"
}
```