### PR TITLE
Fix publishing phar to releases

### DIFF
--- a/.github/workflows/publish-phar.yml
+++ b/.github/workflows/publish-phar.yml
@@ -31,8 +31,13 @@ jobs:
       - name: Create the PHAR file.
         run: ./pint app:build pint.phar --build-version=${{ steps.tag.outputs.tag }}
 
-      - name: Upload the PHAR to release
+      - name: Upload the PHAR artifact
         uses: actions/upload-artifact@v3
         with:
           name: pint.phar
           path: builds/pint.phar
+
+      - name: Upload the PHAR to release
+        run: gh release upload v${{ steps.tag.outputs.tag }} builds/pint.phar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In #92 the action used to upload the phar was changed to `actions/upload-artifact`. This action only uploads the files as a build artifact, not to releases.

This PR adds a step to upload the phar to the release also.