### PR TITLE
Run release workflow only on created event

### DIFF
--- a/.github/workflows/publish-phar.yml
+++ b/.github/workflows/publish-phar.yml
@@ -1,6 +1,8 @@
 name: Publish the released PHAR
 
-on: release
+on:
+  release:
+    types: [created]
 
 jobs:
   publish:


### PR DESCRIPTION
Currently, the `publish-phar.yml` workflow is run thrice on each release.
https://github.com/laravel/pint/actions/workflows/publish-phar.yml

This PR limits it to run only when the release is "created".
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release