### PR TITLE
Enable types_spaces rule in Laravel preset

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -170,6 +170,7 @@ return ConfigurationFactory::preset([
     'ternary_operator_spaces' => true,
     'trailing_comma_in_multiline' => ['elements' => ['arrays']],
     'trim_array_spaces' => true,
+    'types_spaces' => true,
     'unary_operator_spaces' => true,
     'visibility_required' => [
         'elements' => ['method', 'property'],


### PR DESCRIPTION
This rule was missing from the Laravel preset. The Laravel codebase uses no space around types. Introducing this rule (default value matches desired formatting) makes it easier to keep your code formatted according to Laravel's style.

Rule reference: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/whitespace/types_spaces.rst.