### PR TITLE
Introduce `--dirty` for Git projects

### DIFF
--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -38,6 +38,7 @@ class DefaultCommand extends Command
                     new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The configuration that should be used'),
                     new InputOption('preset', '', InputOption::VALUE_REQUIRED, 'The preset that should be used'),
                     new InputOption('test', '', InputOption::VALUE_NONE, 'Test for code style errors without fixing them'),
+                    new InputOption('dirty', '', InputOption::VALUE_NONE, 'Format only the changed files within project'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'The output format that should be used'),
                 ]
             );

--- a/app/Factories/ConfigurationResolverFactory.php
+++ b/app/Factories/ConfigurationResolverFactory.php
@@ -32,7 +32,7 @@ class ConfigurationResolverFactory
      */
     public static function fromIO($input, $output)
     {
-        $path = $input->getArgument('path');
+        $path = Project::paths($input);
 
         $localConfiguration = resolve(ConfigurationJsonRepository::class);
 

--- a/app/Support/Git.php
+++ b/app/Support/Git.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Support;
+
+use Symfony\Component\Process\Process;
+
+class Git
+{
+    /**
+     * Determine the files which were added, modified,
+     * copied, or renamed since the last commit.
+     *
+     * @return array<array<string>, bool>
+     */
+    public function dirtyFiles(): array
+    {
+        $process = new Process(['git', 'diff', '--name-only', '--diff-filter=AMCR', 'HEAD', '--', '*.php']);
+        $process->run();
+
+        return [
+            preg_split('/\R+/', $process->getOutput(), flags: PREG_SPLIT_NO_EMPTY),
+            $process->isSuccessful(),
+        ];
+    }
+}

--- a/app/Support/Git.php
+++ b/app/Support/Git.php
@@ -10,7 +10,7 @@ class Git
      * Determine the files which were added, modified,
      * copied, or renamed since the last commit.
      *
-     * @return array<array<string>, bool>
+     * @return array{string[], bool}
      */
     public function dirtyFiles(): array
     {

--- a/app/Support/Project.php
+++ b/app/Support/Project.php
@@ -9,7 +9,7 @@ class Project
      * based on the options and arguments passed.
      *
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
-     * @return array<string>
+     * @return string[]
      */
     public static function paths(\Symfony\Component\Console\Input\InputInterface $input): array
     {

--- a/app/Support/Project.php
+++ b/app/Support/Project.php
@@ -5,6 +5,32 @@ namespace App\Support;
 class Project
 {
     /**
+     * Determine the project paths to apply the code style
+     * based on the options and arguments passed.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @return array<string>
+     */
+    public static function paths(\Symfony\Component\Console\Input\InputInterface $input): array
+    {
+        if (! $input->getOption('dirty')) {
+            return $input->getArgument('path');
+        }
+
+        [$files, $successful] = \Facades\App\Support\Git::dirtyFiles();
+
+        if (! $successful) {
+            abort(1, 'Option [dirty] must be used within a Git repository.');
+        }
+
+        if (empty($files)) {
+            abort(1, 'No dirty files found.');
+        }
+
+        return $files;
+    }
+
+    /**
      * The project being analysed path.
      *
      * @return string

--- a/storage/framework/cache/.gitignore
+++ b/storage/framework/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Feature/DirtyTest.php
+++ b/tests/Feature/DirtyTest.php
@@ -1,0 +1,40 @@
+<?php
+
+it('uses Git to determine dirty files', function () {
+    \Facades\App\Support\Git::expects('dirtyFiles')
+        ->andReturn([[base_path('tests/fixtures/without-issues/file.php')], true]);
+
+    [$statusCode, $output] = run('default', ['--dirty' => true]);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('── Laravel', ' 1 file');
+});
+
+it('ignores the path argument', function () {
+    \Facades\App\Support\Git::expects('dirtyFiles')
+        ->andReturn([[base_path('tests/fixtures/without-issues/file.php')], true]);
+
+    [$statusCode, $output] = run('default', [
+        '--dirty' => true,
+        'path' => base_path(),
+    ]);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('── Laravel', ' 1 file');
+});
+
+it('fails when not successful', function () {
+    \Facades\App\Support\Git::expects('dirtyFiles')
+        ->andReturn([[], false]);
+
+    run('default', ['--dirty' => true]);
+})->throws(Exception::class, 'Option [dirty] must be used within a Git repository.');
+
+it('aborts when there are no dirty files', function () {
+    \Facades\App\Support\Git::expects('dirtyFiles')
+        ->andReturn([[], true]);
+
+    run('default', ['--dirty' => true]);
+})->throws(Exception::class, 'No dirty files found.');

--- a/tests/Feature/DirtyTest.php
+++ b/tests/Feature/DirtyTest.php
@@ -2,7 +2,7 @@
 
 it('uses Git to determine dirty files', function () {
     \Facades\App\Support\Git::expects('dirtyFiles')
-        ->andReturn([[base_path('tests/fixtures/without-issues/file.php')], true]);
+        ->andReturn([[base_path('tests/Fixtures/without-issues/file.php')], true]);
 
     [$statusCode, $output] = run('default', ['--dirty' => true]);
 
@@ -13,7 +13,7 @@ it('uses Git to determine dirty files', function () {
 
 it('ignores the path argument', function () {
     \Facades\App\Support\Git::expects('dirtyFiles')
-        ->andReturn([[base_path('tests/fixtures/without-issues/file.php')], true]);
+        ->andReturn([[base_path('tests/Fixtures/without-issues/file.php')], true]);
 
     [$statusCode, $output] = run('default', [
         '--dirty' => true,

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -61,9 +61,8 @@ function run($command, $arguments)
 
     if (isset($arguments['path'])) {
         $arguments['--config'] = $arguments['path'].'/pint.json';
+        $arguments['path'] = [$arguments['path']];
     }
-
-    $arguments['path'] = [$arguments['path']];
 
     $commandInstance = match ($command) {
         'default' => resolve(DefaultCommand::class),


### PR DESCRIPTION
This introduces a `--dirty` option to only run `pint` against _changed_ files.

**Motivation** 
Yes, this could be done with other tools. However, that requires intimate knowledge of Git and system commands, as well as some kind of automated runner (e.g. `pre-commit` hook).

Since `pint` is a CI tool, having this built-in provides an out-of-the-box solution to this common developer use case. While not the primary motivation, it also improves performance by running against a subset of files.

**Caveats**
- This has an underlying requirement of the project being within a Git repository. If used outside of a Git repository, an error is output.
- When `--dirty` is used, the `path` argument is ignored. I consider these two use cases mutually exclusive. However, a possible use case may exist where _dirty_ files could be filtered to other those within `path` when used together.
- _changed_ means any tracked file with a status of _added_, _modified_, _copied_, or _renamed_ since the last commit. Basically it ignores _deleted_ and _untracked_ files. The latter may be a technicality. If so, the underlying `git` command could be altered to include _untracked_ files.
