### PR TITLE
[1.x] Allows to specify the line ending

### DIFF
--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -58,7 +58,7 @@ class ConfigurationFactory
             $finder->{$method}($arguments);
         }
 
-        return (new Config())
+        return tap((new Config())
             ->setFinder($finder)
             ->setRules(array_merge($rules, $localConfiguration->rules()))
             ->setRiskyAllowed(true)
@@ -66,6 +66,10 @@ class ConfigurationFactory
             ->registerCustomFixers([
                 // Laravel...
                 new LaravelPhpdocAlignmentFixer(),
-            ]);
+            ]), function ($config) use ($localConfiguration) {
+                if ($localConfiguration->lineEnding()) {
+                    $config->setLineEnding($localConfiguration->lineEnding());
+                }
+            });
     }
 }

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -56,7 +56,17 @@ class ConfigurationJsonRepository
      */
     public function cacheFile()
     {
-        return $this->get()['cache-file'] ?? null;
+        return $this->get()['cache-file'] ?? $this->get()['cacheFile'] ?? null;
+    }
+
+    /**
+     * Get the line ending option.
+     *
+     * @return string|null
+     */
+    public function lineEnding()
+    {
+        return $this->get()['lineEnding'] ?? null;
     }
 
     /**

--- a/tests/Fixtures/line-ending/pint.json
+++ b/tests/Fixtures/line-ending/pint.json
@@ -1,0 +1,3 @@
+{
+    "lineEnding": "\r\n"
+}

--- a/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
+++ b/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
@@ -17,6 +17,16 @@ it('may have rules options', function () {
     ]);
 });
 
+it('may have line ending options', function () {
+    $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/line-ending/pint.json', 'psr12');
+
+    expect($repository->lineEnding())->toBe("\r\n");
+
+    $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/finder/pint.json', null);
+
+    expect($repository->lineEnding())->toBeNull();
+});
+
 it('may have finder options', function () {
     $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/finder/pint.json', null);
 


### PR DESCRIPTION
This pull request allows to specify the line ending directly in the `pint.json` file via:

```json
{
    "lineEnding": "\r\n"
}
```

It address https://github.com/laravel/pint/issues/134.