### PR TITLE
Support Windows paths for --dirty option

### DIFF
--- a/app/Repositories/GitPathsRepository.php
+++ b/app/Repositories/GitPathsRepository.php
@@ -41,7 +41,13 @@ class GitPathsRepository implements PathsRepository
             ->mapWithKeys(fn ($file) => [substr($file, 3) => trim(substr($file, 0, 3))])
             ->reject(fn ($status) => $status === 'D')
             ->map(fn ($status, $file) => $status === 'R' ? Str::after($file, ' -> ') : $file)
-            ->map(fn ($file) => $this->path.DIRECTORY_SEPARATOR.$file)
+            ->map(function ($file) {
+                if (PHP_OS_FAMILY === 'Windows') {
+                    $file = str_replace('/', DIRECTORY_SEPARATOR, $file);
+                }
+
+                return $this->path.DIRECTORY_SEPARATOR.$file;
+            })
             ->values()
             ->all();
 


### PR DESCRIPTION
Currently the --dirty option does not work on Windows, no files are processed regardless of their status within git.

This appears to be caused by the paths being returned by the git status process using different slashes than than those returned from the `ConfigurationFactory::finder()` which results in the `array_intersect` returning an empty array.

### Git Status Results

```
C:\...\project-path>git status --short -- *.php
 M app/Models/ModelA.php
 M app/Models/ModelB.php
 M app/Models/ModelC.php
```

### Before Changes

Array of Files from the Git Status Process Output -

```php
array:16 [
  0 => "<project path>\app/Models/ModelA.php"
  1 => "<project path>\app/Models/ModelB.php"
  2 => "<project path>\app/Models/ModelC.php"
	...
]
```

Array of Files returned by the finder (To show slashes) -

```php
array:10 [
  0 => "<project path>\app\Actions\Fortify\CreateNewUser.php"
  1 => "<project path>\app\Actions\Fortify\PasswordValidationRules.php"
  2 => "<project path>\app\Actions\Fortify\ResetUserPassword.php"
	...
]
```

Array of intersected values -

```php
[]
```

### After Changes

Array of Files from the Git Status Process Output -

```php
array:16 [
  0 => "<project path>\app\Models\ModelA.php"
  1 => "<project path>\app\Models\ModelB.php"
  2 => "<project path>\app\Models\ModelC.php"
  ...
]
```

Array of Files returned by the finder -

```php
array:10 [
  0 => "<project path>\app\Actions\Fortify\CreateNewUser.php"
  1 => "<project path>\app\Actions\Fortify\PasswordValidationRules.php"
  2 => "<project path>\app\Actions\Fortify\ResetUserPassword.php"
	...
]
```

Array of intersected values -
```php
array:16 [
  0 => "<project path>\app\Models\ModelA.php"
  1 => "<project path>\app\Models\ModelB.php"
  2 => "<project path>\app\Models\ModelC.php"
  ...
]
```

I'm not sold on this solution in terms of whether to change the slashes on the git status result or the results of the finder; however in either case it's a similar fix to one which was achieved in Vapor CLI from several years ago https://github.com/laravel/vapor-cli/pull/10