### PR TITLE
Improve workflow to publish the phar to the release.

### DIFF
--- a/.github/workflows/publish-phar.yml
+++ b/.github/workflows/publish-phar.yml
@@ -3,6 +3,11 @@ name: Publish the released PHAR
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag release version'
+        required: true
 
 jobs:
   publish:
@@ -13,7 +18,11 @@ jobs:
     steps:
       - name: Extract the tag version
         id: tag
-        run: echo ::set-output name=tag::${GITHUB_REF##*v}
+        run: |
+          if [ "${{ github.event_name == 'workflow_dispatch' }}" ]; then
+            GITHUB_REF=${{ github.event.inputs.tag }}
+          fi          
+          echo "tag=${GITHUB_REF##*v}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout the code
         uses: actions/checkout@v3

--- a/.github/workflows/publish-phar.yml
+++ b/.github/workflows/publish-phar.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.1
           extensions: dom, curl, libxml, mbstring, zip
           ini-values: error_reporting=E_ALL
           tools: composer:v2


### PR DESCRIPTION
This PR
1) Updates the PHP version in the `publish-phar` workflow to PHP 8.1.
2) Add support to run the `publish-phar` workflow with `workflow-dispatch` event.