### PR TITLE
Enhancement: Enable self_static_accessor fixer

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -165,6 +165,7 @@ return ConfigurationFactory::preset([
     'phpdoc_var_without_name' => true,
     'return_type_declaration' => ['space_before' => 'none'],
     'self_accessor' => false,
+    'self_static_accessor' => true,
     'short_scalar_cast' => true,
     'simplified_null_return' => false,
     'single_blank_line_at_eof' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `self_static_accessor` fixer for the `laravel` preset

💁‍♂️ For reference, see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/v3.15.1/doc/rules/class_notation/self_static_accessor.rst.

I have noticed use of `static` inside classes declared as `final` in

- https://github.com/pestphp/pest/blob/f52d4392a60456ba383636f2731e03b4eea796c6/src/Support/Arr.php#L76
- https://github.com/pestphp/pest/blob/f52d4392a60456ba383636f2731e03b4eea796c6/src/Expectation.php#L67
- https://github.com/pestphp/pest/blob/f52d4392a60456ba383636f2731e03b4eea796c6/src/Support/Reflection.php#L45
- https://github.com/pestphp/pest/blob/f52d4392a60456ba383636f2731e03b4eea796c6/src/Support/Reflection.php#L75

so perhaps it makes sense to enable the fixer for all users of the `laravel` preset instead of fixing these issues manually?