### PR TITLE
Fix git tag in publish-phar workflow

### DIFF
--- a/.github/workflows/publish-phar.yml
+++ b/.github/workflows/publish-phar.yml
@@ -19,13 +19,15 @@ jobs:
       - name: Extract the tag version
         id: tag
         run: |
-          if [ "${{ github.event_name == 'workflow_dispatch' }}" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             GITHUB_REF=${{ github.event.inputs.tag }}
           fi          
           echo "tag=${GITHUB_REF##*v}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout the code
         uses: actions/checkout@v3
+        with:
+          ref: v${{ steps.tag.outputs.tag }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
This PR fixes the following in the `publish-phar` workflow.
- Reading the git tag from `GITHUB_REF` in the `release` event.
- The correct git ref is checked out on `workflow_dispatch` event.