### PR TITLE
Add "Custom fixers" option

### DIFF
--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -2,7 +2,6 @@
 
 namespace App\Factories;
 
-use App\Fixers\LaravelPhpdocAlignmentFixer;
 use App\Repositories\ConfigurationJsonRepository;
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
@@ -42,15 +41,14 @@ class ConfigurationFactory
      */
     public static function preset($rules)
     {
+        $localConfiguration = resolve(ConfigurationJsonRepository::class);
+
         return (new Config())
             ->setFinder(self::finder())
-            ->setRules(array_merge($rules, resolve(ConfigurationJsonRepository::class)->rules()))
+            ->setRules(array_merge($rules, $localConfiguration->rules()))
             ->setRiskyAllowed(true)
             ->setUsingCache(true)
-            ->registerCustomFixers([
-                // Laravel...
-                new LaravelPhpdocAlignmentFixer(),
-            ]);
+            ->registerCustomFixers($localConfiguration->customFixers());
     }
 
     /**

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -24,7 +24,7 @@ class ConfigurationJsonRepository
      * @var array<int, string>
      */
     protected $customFixerList = [
-        'App\Fixers\LaravelPhpdocAlignmentFixer'
+        'App\Fixers\LaravelPhpdocAlignmentFixer',
     ];
 
     /**
@@ -104,25 +104,24 @@ class ConfigurationJsonRepository
      */
     protected function getRegisteredClasses(array $classes)
     {
-
         return collect($classes)
             ->map(function ($class) {
-                $file = Project::path() . "/" . $class;
+                $file = Project::path().'/'.$class;
 
-                spl_autoload_register(fn() => require_once($file));
+                spl_autoload_register(fn () => require_once($file));
 
                 $tokens = PhpToken::tokenize(file_get_contents($file));
 
                 $namespace = null;
 
-                foreach($tokens as $key=>$token){
-                    if($token->id == T_NAMESPACE){
-                        $namespace = $tokens[$key+2]->text;
+                foreach ($tokens as $key => $token) {
+                    if ($token->id == T_NAMESPACE) {
+                        $namespace = $tokens[$key + 2]->text;
                         break;
                     }
                 }
 
-                return $namespace ."\\". basename($class, '.php');
+                return $namespace.'\\'.basename($class, '.php');
             })->toArray();
     }
 

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -84,7 +84,7 @@ class ConfigurationJsonRepository
     /**
      * Get the custom fixers.
      *
-     * @return array<int, CustomFixerInterface>
+     * @return array<int, \PhpCsFixer\Fixer\FixerInterface>
      */
     public function customFixers()
     {
@@ -100,7 +100,8 @@ class ConfigurationJsonRepository
     /**
      * Get fixer classes name from the "pint.json" file.
      *
-     * @return array<int, string>
+     * @param  array<int, string>  $classes
+     * @return array<string, string>
      */
     protected function getRegisteredClasses(array $classes)
     {

--- a/tests/Fixtures/custom/IsNotAFixer.php
+++ b/tests/Fixtures/custom/IsNotAFixer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Another\Directory;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Tokens;
+
+class IsNotAFixer implements FixerInterface
+{
+    private $whitespacesConfig;
+
+    public function getName(): string
+    {
+        return 'not_a_fixer';
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition('Is not a fixer', []);
+    }
+
+    public function fix(\SplFileInfo $file, Tokens $tokens): void
+    {
+        // do nothing
+    }
+
+    public function isRisky(): bool
+    {
+        return true;
+    }
+
+    public function supports(\SplFileInfo $file): bool
+    {
+        return true;
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+}

--- a/tests/Fixtures/custom/pint.json
+++ b/tests/Fixtures/custom/pint.json
@@ -1,0 +1,5 @@
+{
+    "custom-fixers": [
+        "tests/Fixtures/custom/IsNotAFixer.php"
+    ]
+}

--- a/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
+++ b/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Another\Directory\IsNotAFixer;
+use App\Fixers\LaravelPhpdocAlignmentFixer;
 use App\Repositories\ConfigurationJsonRepository;
 
 it('works without json file', function () {
@@ -15,6 +17,18 @@ it('may have rules options', function () {
     expect($repository->rules())->toBe([
         'no_unused_imports' => false,
     ]);
+});
+
+it('may have custom fixers options', function () {
+    $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/custom/pint.json', null);
+
+    expect($repository->customFixers())
+        ->ToBeArray()
+        ->toContainOnlyInstancesOf(\PhpCsFixer\Fixer\FixerInterface::class)
+        ->toMatchArray([
+            new LaravelPhpdocAlignmentFixer,
+            new IsNotAFixer,
+        ]);
 });
 
 it('may have finder options', function () {


### PR DESCRIPTION
When using a linter tool, sometimes the project requires a custom rule to meet specific needs. To cover such cases, PHP-CS-Fixer provides a custom fixer feature where you can create your own Fixer and register it in Finder. Today, when using Pint, it's not possible to register a custom rule, so when the project has this type of need, the developer ends up using PHP-CS-Fixer instead of Pint.

This PR adds a new option to the *pint.json* configuration file: **custom-fixers**. This option allows developers to list an array of custom fixer files they want to register and then declare the custom rule in the rules option.

Here is an example of a *pint.json* file with this option set:

```json
  "custom-fixers": [
      "path/to/CustomFixer.php"
  ],
  "rules": {
      "custom-rule": true,
      ...
  }
```

> **Important to mention that the path is not absolute but relative to the root of the project.** 