### PR TITLE
Added PER preset

### DIFF
--- a/app/Factories/ConfigurationResolverFactory.php
+++ b/app/Factories/ConfigurationResolverFactory.php
@@ -18,6 +18,7 @@ class ConfigurationResolverFactory
      */
     public static $presets = [
         'laravel',
+        'per',
         'psr12',
         'symfony',
     ];

--- a/app/Output/SummaryOutput.php
+++ b/app/Output/SummaryOutput.php
@@ -19,6 +19,7 @@ class SummaryOutput
      * @var array<string, string>
      */
     protected $presets = [
+        'per' => 'PER',
         'psr12' => 'PSR 12',
         'laravel' => 'Laravel',
         'symfony' => 'Symfony',

--- a/resources/presets/per.php
+++ b/resources/presets/per.php
@@ -1,0 +1,8 @@
+<?php
+
+use App\Factories\ConfigurationFactory;
+
+return ConfigurationFactory::preset([
+    '@PER' => true,
+    'no_unused_imports' => true,
+]);

--- a/tests/Feature/PresetTest.php
+++ b/tests/Feature/PresetTest.php
@@ -21,6 +21,17 @@ it('may use the PSR 12 preset', function () {
         ->toContain('── PSR 12');
 });
 
+it('may use the PER preset', function () {
+    [$statusCode, $output] = run('default', [
+        'path' => base_path('tests/Fixtures/without-issues'),
+        '--preset' => 'per',
+    ]);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('── PER');
+});
+
 it('may use the Laravel preset', function () {
     [$statusCode, $output] = run('default', [
         'path' => base_path('tests/Fixtures/without-issues'),


### PR DESCRIPTION
PHP Evolving Recommendation (PER) is allowed to be updated and versioned, as opposed to PHP Standard Recommendation (PSR). [PER Coding Style](https://www.php-fig.org/per/coding-style/) is meant to be a successor of PSR-12, with v1.0 having the same rules. It should replace PSR-12 one day.

This PR introduces a PER preset, as [php-fig/per-coding-style@1.0.0 (release)](https://github.com/php-fig/per-coding-style/releases/tag/1.0.0) was tagged in 2022.

Discussed in #153