### PR TITLE
[1.x] Fixes `--dirty` detection of subfolders on Ubuntu

### DIFF
--- a/app/Repositories/GitPathsRepository.php
+++ b/app/Repositories/GitPathsRepository.php
@@ -31,7 +31,7 @@ class GitPathsRepository implements PathsRepository
      */
     public function dirty()
     {
-        $process = tap(new Process(['git', 'status', '--short', '--', '*.php']))->run();
+        $process = tap(new Process(['git', 'status', '--short', '--', '**.php']))->run();
 
         if (! $process->isSuccessful()) {
             abort(1, 'The [--dirty] option is only available when using Git.');


### PR DESCRIPTION
This pull request fixes `--dirty` detection of subfolders on Ubuntu. Closes https://github.com/laravel/pint/issues/160