### PR TITLE
feat: multiple configurations

### DIFF
--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -35,7 +35,7 @@ class DefaultCommand extends Command
             ->setDefinition(
                 [
                     new InputArgument('path', InputArgument::IS_ARRAY, 'The path to fix', [(string) getcwd()]),
-                    new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The configuration that should be used'),
+                    new InputOption('config', '', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'The configuration that should be used'),
                     new InputOption('preset', '', InputOption::VALUE_REQUIRED, 'The preset that should be used'),
                     new InputOption('test', '', InputOption::VALUE_NONE, 'Test for code style errors without fixing them'),
                     new InputOption('dirty', '', InputOption::VALUE_NONE, 'Only fix files that have uncommitted changes'),

--- a/tests/Fixtures/multiple/pint-1.json
+++ b/tests/Fixtures/multiple/pint-1.json
@@ -1,0 +1,6 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "braces": true
+    }
+}

--- a/tests/Fixtures/multiple/pint-2.json
+++ b/tests/Fixtures/multiple/pint-2.json
@@ -1,0 +1,9 @@
+{
+    "rules": {
+        "simplified_null_return": true,
+        "braces": false
+    },
+    "exclude": [
+        "my-dir"
+    ]
+}

--- a/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
+++ b/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
@@ -38,3 +38,20 @@ it('may have a preset option', function () {
 
     expect($repository->preset())->toBe('laravel');
 });
+
+it('works with multiple configurations', function () {
+    $repository = new ConfigurationJsonRepository([
+        dirname(__DIR__, 2).'/Fixtures/multiple/pint-1.json',
+        dirname(__DIR__, 2).'/Fixtures/multiple/pint-2.json',
+    ], null);
+
+    expect($repository->preset())->toBe('laravel')
+        ->and($repository->finder())->toBe([
+            'exclude' => [
+                'my-dir',
+            ]])
+        ->and($repository->rules())->toBe([
+            'simplified_null_return' => true,
+            'braces' => false,
+        ]);
+});


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR is based on the idea of #174, allowing to use multiple configuration files with pint. This allows the user to use a global configuration file from composer, and extend it with configurations only relevant for the consuming repository.

This implementation should be backwards compatible, has basic tests added and closes #174.