### PR TITLE
remove unnecessary line in 1_Bug_report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.yml
@@ -30,4 +30,3 @@ body:
       description: Provide detailed steps to reproduce your issue. If necessary, please provide a GitHub repository to demonstrate your issue using `laravel new bug-report --github="--public"`.
     validations:
       required: true
-      


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
I found an unnecessary line in 1_Bug_report.yml and removed it.

<img width="373" alt="image" src="https://github.com/laravel/pint/assets/44424270/3ff30e8b-4fc5-4214-8a1f-bce52cc78345">
