### PR TITLE
Add Rule: nullable_type_declaration_for_default_null_value

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -133,6 +133,9 @@ return ConfigurationFactory::preset([
     'normalize_index_brace' => true,
     'not_operator_with_successor_space' => true,
     'nullable_type_declaration' => true,
+    'nullable_type_declaration_for_default_null_value' => [
+        'use_nullable_type_declaration' => false,
+    ],
     'object_operator_without_whitespace' => true,
     'ordered_imports' => ['sort_algorithm' => 'alpha'],
     'psr_autoloading' => false,


### PR DESCRIPTION
PHP-CS-Fixer Rule: [`nullable_type_declaration_for_default_null_value`](https://cs.symfony.com/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.html)

With the given configuration this will change it like this (Taken from the PHP-CS-Fixer Page):

```diff
--- Original
+++ New
 <?php
-function sample(?string $str = null)
+function sample(string $str = null)
 {}
```

```diff
--- Original
+++ New
 <?php
-function sample(string|int|null $str = null)
+function sample(string|int $str = null)
 {}
```

```diff
--- Original
+++ New
 <?php
-function sample((\Foo&\Bar)|null $str = null)
+function sample(\Foo&\Bar $str = null)
 {}
```

This rule is currently not enforced in `laravel/framework` repository, but I saw some comments in PR's were it was said that the question mark should not be added because of the null default argument:
- Without the question mark: [`Illuminate\Mail\Mailables\Envelope`](https://github.com/laravel/framework/blob/6d690edda8c5b0d400a8753def02d9ecd3e98e40/src/Illuminate/Mail/Mailables/Envelope.php#L286)
- With Question Mark: [`Illuminate\Process\Factory`](https://github.com/laravel/framework/blob/6d690edda8c5b0d400a8753def02d9ecd3e98e40/src/Illuminate/Process/Factory.php#L298)