### PR TITLE
Add Rule: nullable_type_declaration

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -132,6 +132,7 @@ return ConfigurationFactory::preset([
     'no_whitespace_in_blank_line' => true,
     'normalize_index_brace' => true,
     'not_operator_with_successor_space' => true,
+    'nullable_type_declaration' => true,
     'object_operator_without_whitespace' => true,
     'ordered_imports' => ['sort_algorithm' => 'alpha'],
     'psr_autoloading' => false,


### PR DESCRIPTION
PHP-CS-Fixer Rule: [nullable_type_declaration](https://cs.symfony.com/doc/rules/language_construct/nullable_type_declaration.html) 

With the given configuration this will change it like this (Taken from the PHP-CS-Fixer Page):
```diff
--- Original
+++ New
 <?php
-function bar(null|int $value, null|\Closure $callable): void {}
+function bar(?int $value, ?\Closure $callable): void {}
```
```diff
--- Original
+++ New
 <?php
 class ValueObject
 {
-    public null|string $name;
+    public ?string $name;
     public ?int $count;
-    public null|bool $internal;
-    public null|\Closure $callback;
+    public ?bool $internal;
+    public ?\Closure $callback;
 }
```