### PR TITLE
Add Rule: type_declaration_spaces

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -188,6 +188,7 @@ return ConfigurationFactory::preset([
     'ternary_operator_spaces' => true,
     'trailing_comma_in_multiline' => ['elements' => ['arrays']],
     'trim_array_spaces' => true,
+    'type_declaration_spaces' => true,
     'types_spaces' => true,
     'unary_operator_spaces' => true,
     'visibility_required' => [


### PR DESCRIPTION
PHP-CS-Fixer Rule: [type_declaration_spaces](https://cs.symfony.com/doc/rules/whitespace/type_declaration_spaces.html)

With the given configuration this will change it like this (Taken from the PHP-CS-Fixer Page):
```diff
--- Original
+++ New
 <?php
 class Bar
 {
-    private string    $a;
-    private bool   $b;
+    private string $a;
+    private bool $b;

-    public function __invoke(array   $c) {}
+    public function __invoke(array $c) {}
 }
```