### PR TITLE
Remove deprecated function_typehint_space rule

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -57,7 +57,6 @@ return ConfigurationFactory::preset([
     'full_opening_tag' => true,
     'fully_qualified_strict_types' => true,
     'function_declaration' => true,
-    'function_typehint_space' => true,
     'general_phpdoc_tag_rename' => true,
     'heredoc_to_nowdoc' => true,
     'include' => true,


### PR DESCRIPTION
PHP-CS-Fixer Rule: [function_typehint_space](https://cs.symfony.com/doc/rules/function_notation/function_typehint_space.html)

This rule is deprecated and superseded by [type_declaration_spaces](https://cs.symfony.com/doc/rules/whitespace/type_declaration_spaces.html).

Since we have added the type_declaration_spaces rule in https://github.com/laravel/pint/pull/194,
we can safely remove this rule.

https://github.com/laravel/pint/blob/07a28868cb59448b6ab1365dfb0f09e02cda8f9b/resources/presets/laravel.php#L195