### PR TITLE
[1.x] Improves imports when using `functions`

### DIFF
--- a/app/Output/SummaryOutput.php
+++ b/app/Output/SummaryOutput.php
@@ -6,6 +6,7 @@ use App\Output\Concerns\InteractsWithSymbols;
 use App\Project;
 use App\ValueObjects\Issue;
 use PhpCsFixer\FixerFileProcessedEvent;
+
 use function Termwind\render;
 use function Termwind\renderUsing;
 

--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -16,6 +16,7 @@ return ConfigurationFactory::preset([
             'return',
         ],
     ],
+    'blank_line_between_import_groups' => true,
     'blank_lines_before_namespace' => true,
     'control_structure_braces' => true,
     'control_structure_continuation_position' => [
@@ -136,7 +137,7 @@ return ConfigurationFactory::preset([
         'use_nullable_type_declaration' => false,
     ],
     'object_operator_without_whitespace' => true,
-    'ordered_imports' => ['sort_algorithm' => 'alpha'],
+    'ordered_imports' => ['sort_algorithm' => 'alpha', 'imports_order' => ['const', 'class', 'function']],
     'psr_autoloading' => false,
     'phpdoc_indent' => true,
     'phpdoc_inline_tag_normalizer' => true,


### PR DESCRIPTION
Using Laravel Promps, Volt, and potentially upcoming projects, we might find ourselves utilizing functional APIs through namespaced functions. Today, with the usage of Pint, users will end up with imports like this:

```php
<?php

use Illuminate\Filesystem\Filesystem;
use Illuminate\Support\Str;
use function Laravel\Prompts\confirm;
use function Laravel\Prompts\multiselect;
use function Laravel\Prompts\select;
use RuntimeException;
use Symfony\Component\Console\Command;
use Symfony\Component\Console\Input\InputInterface;

class InstallCommand extends Command
{
    // ...
}
```

So, in order to get things a little bit more organized "visually", this pull request proposes organizing these imports by "type". In other words, classes come first, and then, after a new line, the namespaced functions. Here is an example:

```php
<?php

use Illuminate\Filesystem\Filesystem;
use Illuminate\Support\Str;
use RuntimeException;
use Symfony\Component\Console\Command;
use Symfony\Component\Console\Input\InputInterface;

use function Laravel\Prompts\confirm;
use function Laravel\Prompts\multiselect;
use function Laravel\Prompts\select;

class InstallCommand extends Command
{
    // ...
}
```