### PR TITLE
[1.x] Orders interfaces and traits

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -168,6 +168,8 @@ return ConfigurationFactory::preset([
     'phpdoc_trim' => true,
     'phpdoc_types' => true,
     'phpdoc_var_without_name' => true,
+    'ordered_interfaces' => true,
+    'ordered_traits' => true,
     'return_type_declaration' => ['space_before' => 'none'],
     'self_accessor' => false,
     'self_static_accessor' => true,


### PR DESCRIPTION
This pull request makes Pint's Laravel preset order interfaces and traits:

```diff
-new class implements B, A
+new class implements A, B
{
-   use B, A;
+   use A, B;

// ...
```