### PR TITLE
Deps: Switch PHP CS Fixer to a fork compatible with Unfinalize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-xml": "*"
     },
     "require-dev": {
-        "stevebauman/php-cs-fixer": "^3.26.1",
+        "stevebauman/php-cs-fixer": "^3.34.0",
         "illuminate/view": "^10.23.1",
         "laravel-zero/framework": "^10.1.2",
         "mockery/mockery": "^1.6.6",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-xml": "*"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.26.1",
+        "stevebauman/php-cs-fixer": "^3.26.1",
         "illuminate/view": "^10.23.1",
         "laravel-zero/framework": "^10.1.2",
         "mockery/mockery": "^1.6.6",


### PR DESCRIPTION
This PR switches the PHP-CS-Fixer used to [this fork](https://github.com/stevebauman/PHP-CS-Fixer) by @stevebauman.

The purpose of this PR is to use Steve's fork to maintain the ability of devs using Pint to also use Unfinalize.

### Background

Steve made a package called [unfinalize](https://github.com/stevebauman/unfinalize) which used a custom PHP-CS-Fixer rule to remove final from dependencies allowing a developer to extend classes as they determined they needed to.

One of the maintainers of PHP-CS-Fixer went so far as to block the use of unfinalize by [marking it as a conflict](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7343) within PHP-CS-Fixer.

As a result, Steve has made a fork of PHP-CS-Fixer with the conflict removed.

![image](https://github.com/laravel/pint/assets/1036407/eac9db3c-4bb0-4441-ba51-6f2841749b47)

**NOTE:** There is [currently a PR](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7348) to revert the change in the official PHP-CS-Fixer repo. Therefore you may wish to wait on a result from that PR before deciding if it'll be necessary long term to merge this.
