### PR TITLE
Introduce the `none` preset

### DIFF
--- a/app/Factories/ConfigurationResolverFactory.php
+++ b/app/Factories/ConfigurationResolverFactory.php
@@ -18,6 +18,7 @@ class ConfigurationResolverFactory
      */
     public static $presets = [
         'laravel',
+        'none',
         'per',
         'psr12',
         'symfony',

--- a/app/Output/SummaryOutput.php
+++ b/app/Output/SummaryOutput.php
@@ -20,9 +20,10 @@ class SummaryOutput
      * @var array<string, string>
      */
     protected $presets = [
+        'laravel' => 'Laravel',
+        'none' => 'None',
         'per' => 'PER',
         'psr12' => 'PSR 12',
-        'laravel' => 'Laravel',
         'symfony' => 'Symfony',
     ];
 

--- a/resources/presets/none.php
+++ b/resources/presets/none.php
@@ -1,0 +1,5 @@
+<?php
+
+use App\Factories\ConfigurationFactory;
+
+return ConfigurationFactory::preset([]);

--- a/tests/Feature/PresetTest.php
+++ b/tests/Feature/PresetTest.php
@@ -10,6 +10,17 @@ it('uses the laravel preset by default', function () {
         ->toContain('── Laravel');
 });
 
+it('may use the None preset', function () {
+    [$statusCode, $output] = run('default', [
+        'path' => base_path('tests/Fixtures/without-issues'),
+        '--preset' => 'none',
+    ]);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('── None');
+});
+
 it('may use the PSR 12 preset', function () {
     [$statusCode, $output] = run('default', [
         'path' => base_path('tests/Fixtures/without-issues'),


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In case there is no config file or preset provided, pint will use `laravel` per default.
It comes handy, but this preset will **ALWAYS** be applied if we only want to apply specific rules to fix the code.

This PR introduces a `none` preset, which comes as an empty ruleset, thus providing way more flexibility to the developers to apply cherry-picked rules.

---

**Note:**
This preset could be named differently, I am not really opinionated on that.