### PR TITLE
Add a `--commit` option to automatically commit fixes

### DIFF
--- a/app/Actions/GitCommitter.php
+++ b/app/Actions/GitCommitter.php
@@ -3,27 +3,12 @@
 namespace App\Actions;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Process;
 
 use function Termwind\render;
 
 class GitCommitter
 {
-    /**
-     * Creates a new Git Committer instance.
-     *
-     * @param  \Symfony\Component\Console\Input\InputInterface  $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @return void
-     */
-    public function __construct(
-        protected $input,
-        protected $output,
-    ) {
-        //
-    }
-
     /**
      * Commit the changes to Git.
      *
@@ -36,9 +21,9 @@ class GitCommitter
 
         if (empty($files)) {
             render(<<<'HTML'
-                <div class="mx-2">
-                    <span class="px-2 bg-green text-gray uppercase font-bold mr-1">Info:</span>
-                    <span>Nothing to commit, working tree clean.</span>
+                <div class="mx-2 mb-1">
+                <span class="px-2 bg-blue text-white uppercase font-bold mr-1">Info</span>
+                    <span>Nothing to commit.</span>
                 </div>
                 HTML
             );
@@ -61,8 +46,8 @@ class GitCommitter
 
         if ($process->failed()) {
             render(<<<HTML
-                <div class="mx-2">
-                    <span class="px-2 bg-red text-white uppercase font-bold mr-1">Error:</span>
+                <div class="mx-2 mb-1">
+                    <span class="px-2 bg-red text-white uppercase font-bold mr-1">Error</span>
                     <span>{$process->errorOutput()}</span>
                 </div>
                 HTML
@@ -71,12 +56,12 @@ class GitCommitter
             return Command::FAILURE;
         }
 
-        render(sprintf(<<<'HTML'
-            <div class="mx-2">
-                <span class="px-2 bg-green text-gray uppercase font-bold mr-1">Success:</span>
-                <span>%s</span>
+        render(<<<'HTML'
+            <div class="mx-2 mb-1">
+                <span class="px-2 bg-blue text-white uppercase font-bold mr-1">Info</span>
+                <span>Changes committed to Git.</span>
             </div>
-            HTML, trim(Arr::last(explode("\n", trim($process->output())))))
+            HTML
         );
 
         return Command::SUCCESS;

--- a/app/Actions/GitCommitter.php
+++ b/app/Actions/GitCommitter.php
@@ -3,6 +3,7 @@
 namespace App\Actions;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Process;
 
 use function Termwind\render;
@@ -69,11 +70,11 @@ class GitCommitter
             return Command::FAILURE;
         }
 
-        render(<<<'HTML'
+        render(sprintf(<<<'HTML'
             <div class="mx-2">
-                <span class="text-green-500">Changes committed successfully!</span>
+                <span class="text-green-500">%s</span>
             </div>
-            HTML
+            HTML, trim(Arr::last(explode("\n", trim($process->output())))))
         );
 
         return Command::SUCCESS;

--- a/app/Actions/GitCommitter.php
+++ b/app/Actions/GitCommitter.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Actions;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Process;
+
+use function Termwind\render;
+
+class GitCommitter
+{
+    /**
+     * Creates a new Git Committer instance.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    public function __construct(
+        protected $input,
+        protected $output,
+    ) {
+        //
+    }
+
+    /**
+     * Commit the changes to Git.
+     *
+     * @param  array<string, array{appliedFixers: array<int, string>, diff: string}>  $changes
+     * @return int
+     */
+    public function execute($changes)
+    {
+        $files = array_keys($changes);
+
+        if (empty($files)) {
+            render(<<<'HTML'
+                <div class="mx-2">
+                    <span class="text-green-500">No changes to commit!</span>
+                </div>
+                HTML
+            );
+
+            return Command::SUCCESS;
+        }
+
+        return $this->makeCommit($files);
+    }
+
+    /**
+     * Make the Git commit.
+     *
+     * @param  array<string>  $files
+     * @return int
+     */
+    protected function makeCommit(array $files)
+    {
+        $process = Process::run(sprintf('git commit -m "Apply style fixes from Laravel Pint" %s', implode(' ', $files)));
+
+        if ($process->failed()) {
+            render(<<<HTML
+                <div class="mx-2">
+                    <span class="px-2 bg-red text-white uppercase font-bold mr-1">Error:</span>
+                    <span>{$process->errorOutput()}</span>
+                </div>
+                HTML
+            );
+
+            return Command::FAILURE;
+        }
+
+        render(<<<'HTML'
+            <div class="mx-2">
+                <span class="text-green-500">Changes committed successfully!</span>
+            </div>
+            HTML
+        );
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Actions/GitCommitter.php
+++ b/app/Actions/GitCommitter.php
@@ -59,7 +59,7 @@ class GitCommitter
         render(<<<'HTML'
             <div class="mx-2 mb-1">
                 <span class="px-2 bg-blue text-white uppercase font-bold mr-1">Info</span>
-                <span>Changes committed to Git.</span>
+                <span>Changes committed.</span>
             </div>
             HTML
         );

--- a/app/Actions/GitCommitter.php
+++ b/app/Actions/GitCommitter.php
@@ -36,7 +36,7 @@ class GitCommitter
         if (empty($files)) {
             render(<<<'HTML'
                 <div class="mx-2">
-                    <span class="text-green-500">No changes to commit!</span>
+                    <span class="text-green-500">Nothing to commit, working tree clean.</span>
                 </div>
                 HTML
             );
@@ -44,16 +44,16 @@ class GitCommitter
             return Command::SUCCESS;
         }
 
-        return $this->makeCommit($files);
+        return $this->commit($files);
     }
 
     /**
      * Make the Git commit.
      *
-     * @param  array<string>  $files
+     * @param  array<int, string>  $files
      * @return int
      */
-    protected function makeCommit(array $files)
+    protected function commit(array $files)
     {
         $process = Process::run(sprintf('git commit -m "Apply style fixes from Laravel Pint" %s', implode(' ', $files)));
 

--- a/app/Actions/GitCommitter.php
+++ b/app/Actions/GitCommitter.php
@@ -37,7 +37,8 @@ class GitCommitter
         if (empty($files)) {
             render(<<<'HTML'
                 <div class="mx-2">
-                    <span class="text-green-500">Nothing to commit, working tree clean.</span>
+                    <span class="px-2 bg-green text-gray uppercase font-bold mr-1">Info:</span>
+                    <span>Nothing to commit, working tree clean.</span>
                 </div>
                 HTML
             );
@@ -72,7 +73,8 @@ class GitCommitter
 
         render(sprintf(<<<'HTML'
             <div class="mx-2">
-                <span class="text-green-500">%s</span>
+                <span class="px-2 bg-green text-gray uppercase font-bold mr-1">Success:</span>
+                <span>%s</span>
             </div>
             HTML, trim(Arr::last(explode("\n", trim($process->output())))))
         );

--- a/app/Providers/ActionsServiceProvider.php
+++ b/app/Providers/ActionsServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Actions\ElaborateSummary;
 use App\Actions\FixCode;
+use App\Actions\GitCommitter;
 use App\Output\ProgressOutput;
 use App\Output\SummaryOutput;
 use App\Repositories\ConfigurationJsonRepository;
@@ -57,6 +58,13 @@ class ActionsServiceProvider extends ServiceProvider
                     resolve(InputInterface::class),
                     resolve(OutputInterface::class),
                 )
+            );
+        });
+
+        $this->app->singleton(GitCommitter::class, function () {
+            return new GitCommitter(
+                resolve(InputInterface::class),
+                resolve(OutputInterface::class),
             );
         });
     }

--- a/app/Providers/ActionsServiceProvider.php
+++ b/app/Providers/ActionsServiceProvider.php
@@ -4,7 +4,6 @@ namespace App\Providers;
 
 use App\Actions\ElaborateSummary;
 use App\Actions\FixCode;
-use App\Actions\GitCommitter;
 use App\Output\ProgressOutput;
 use App\Output\SummaryOutput;
 use App\Repositories\ConfigurationJsonRepository;
@@ -58,13 +57,6 @@ class ActionsServiceProvider extends ServiceProvider
                     resolve(InputInterface::class),
                     resolve(OutputInterface::class),
                 )
-            );
-        });
-
-        $this->app->singleton(GitCommitter::class, function () {
-            return new GitCommitter(
-                resolve(InputInterface::class),
-                resolve(OutputInterface::class),
             );
         });
     }

--- a/tests/Feature/GitCommitterTest.php
+++ b/tests/Feature/GitCommitterTest.php
@@ -20,7 +20,7 @@ it('handles clean working tree', function () {
 
     expect($statusCode)->toBe(0)
         ->and($output)
-        ->toContain('Nothing to commit, working tree clean.');
+        ->toContain('    INFO:   Nothing to commit, working tree clean.');
 });
 
 it('prints process error', function () {
@@ -118,5 +118,5 @@ it('commits the changes', function () {
 
     expect($statusCode)->toBe(0)
         ->and($renderer->fetch())
-        ->toBe('  1 file changed, 1 insertion(+), 1 deletion(-)  '.PHP_EOL);
+        ->toBe('    SUCCESS:   1 file changed, 1 insertion(+), 1 deletion(-)  '.PHP_EOL);
 });

--- a/tests/Feature/GitCommitterTest.php
+++ b/tests/Feature/GitCommitterTest.php
@@ -101,7 +101,15 @@ it('commits the changes', function () {
     Process::shouldReceive('run')
         ->once()
         ->with('git commit -m "Apply style fixes from Laravel Pint" '.base_path('tests/Fixtures/with-fixable-issues/file.php'))
-        ->andReturn(new FakeProcessResult());
+        ->andReturn(tap(Mockery::mock(FakeProcessResult::class), fn ($process) => $process
+            ->shouldReceive('failed')
+            ->once()
+            ->andReturn(false)
+            ->shouldReceive('output')
+            ->once()
+            ->andReturn('[main 123fff] Apply style fixes from Laravel Pint'."\n".
+                '1 file changed, 1 insertion(+), 1 deletion(-)')
+        ));
 
     [$statusCode, $output] = run('default', [
         '--commit' => true,
@@ -110,5 +118,5 @@ it('commits the changes', function () {
 
     expect($statusCode)->toBe(0)
         ->and($renderer->fetch())
-        ->toBe('  Changes committed successfully!  '.PHP_EOL);
+        ->toBe('  1 file changed, 1 insertion(+), 1 deletion(-)  '.PHP_EOL);
 });

--- a/tests/Feature/GitCommitterTest.php
+++ b/tests/Feature/GitCommitterTest.php
@@ -20,7 +20,7 @@ it('handles clean working tree', function () {
 
     expect($statusCode)->toBe(0)
         ->and($output)
-        ->toContain('    INFO:   Nothing to commit, working tree clean.');
+        ->toContain('    INFO   Nothing to commit.');
 });
 
 it('prints process error', function () {
@@ -68,7 +68,7 @@ it('prints process error', function () {
 
     expect($statusCode)->toBe(1)
         ->and($renderer->fetch())
-        ->toBe('    ERROR:   Example Git error  '.PHP_EOL)
+        ->toBe('    ERROR   Example Git error  '.PHP_EOL.PHP_EOL)
         ->and($output)
         ->not()->toContain('Apply style fixes from Laravel Pint');
 });
@@ -104,11 +104,7 @@ it('commits the changes', function () {
         ->andReturn(tap(Mockery::mock(FakeProcessResult::class), fn ($process) => $process
             ->shouldReceive('failed')
             ->once()
-            ->andReturn(false)
-            ->shouldReceive('output')
-            ->once()
-            ->andReturn('[main 123fff] Apply style fixes from Laravel Pint'."\n".
-                '1 file changed, 1 insertion(+), 1 deletion(-)')
+            ->andReturn(false),
         ));
 
     [$statusCode, $output] = run('default', [
@@ -118,5 +114,5 @@ it('commits the changes', function () {
 
     expect($statusCode)->toBe(0)
         ->and($renderer->fetch())
-        ->toBe('    SUCCESS:   1 file changed, 1 insertion(+), 1 deletion(-)  '.PHP_EOL);
+        ->toBe('    INFO   Changes committed.  '.PHP_EOL.PHP_EOL);
 });

--- a/tests/Feature/GitCommitterTest.php
+++ b/tests/Feature/GitCommitterTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use App\Actions\ElaborateSummary;
+use App\Actions\FixCode;
+use Illuminate\Process\FakeProcessResult;
+use Illuminate\Support\Facades\Process;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+use function Termwind\renderUsing;
+
+beforeEach(function () {
+    Process::preventStrayProcesses();
+});
+
+it('handles clean working tree', function () {
+    [$statusCode, $output] = run('default', [
+        '--commit' => true,
+        'path' => base_path('tests/Fixtures/without-issues'),
+    ]);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('Nothing to commit, working tree clean.');
+});
+
+it('prints process error', function () {
+    // For some reason, the output is not captured by the buffer when a non-zero exit code is returned, so we have to check the renderer directly.
+    renderUsing($renderer = new BufferedOutput());
+
+    $basePath = base_path('tests/Fixtures/with-fixable-issues/file.php');
+
+    $fixerOutput = [
+        $basePath => [
+            'appliedFixers' => ['psr12'],
+            'diff' => '',
+        ],
+    ];
+
+    $this->swap(FixCode::class, tap(Mockery::mock(FixCode::class), fn ($fixer) => $fixer
+        ->shouldReceive('execute')
+        ->once()
+        ->andReturn([1, $fixerOutput])
+    ));
+
+    $this->swap(ElaborateSummary::class, tap(Mockery::mock(ElaborateSummary::class), fn ($summary) => $summary
+        ->shouldReceive('execute')
+        ->once()
+        ->with(1, $fixerOutput)
+        ->andReturn(0)
+    ));
+
+    Process::shouldReceive('run')
+        ->once()
+        ->with(sprintf('git commit -m "Apply style fixes from Laravel Pint" %s', $basePath))
+        ->andReturn(tap(Mockery::mock(FakeProcessResult::class), fn ($process) => $process
+            ->shouldReceive('failed')
+            ->once()
+            ->andReturn(true)
+            ->shouldReceive('errorOutput')
+            ->once()
+            ->andReturn('Example Git error')
+        ));
+
+    [$statusCode, $output] = run('default', [
+        '--commit' => true,
+        'path' => $basePath,
+    ]);
+
+    expect($statusCode)->toBe(1)
+        ->and($renderer->fetch())
+        ->toBe('    ERROR:   Example Git error  '.PHP_EOL)
+        ->and($output)
+        ->not()->toContain('Apply style fixes from Laravel Pint');
+});
+
+it('commits the changes', function () {
+    renderUsing($renderer = new BufferedOutput());
+
+    $basePath = base_path('tests/Fixtures/with-fixable-issues/file.php');
+
+    $fixerOutput = [
+        $basePath => [
+            'appliedFixers' => ['psr12'],
+            'diff' => '',
+        ],
+    ];
+
+    $this->swap(FixCode::class, tap(Mockery::mock(FixCode::class), fn ($fixer) => $fixer
+        ->shouldReceive('execute')
+        ->once()
+        ->andReturn([1, $fixerOutput])
+    ));
+
+    $this->swap(ElaborateSummary::class, tap(Mockery::mock(ElaborateSummary::class), fn ($summary) => $summary
+        ->shouldReceive('execute')
+        ->once()
+        ->with(1, $fixerOutput)
+        ->andReturn(0)
+    ));
+
+    Process::shouldReceive('run')
+        ->once()
+        ->with('git commit -m "Apply style fixes from Laravel Pint" '.base_path('tests/Fixtures/with-fixable-issues/file.php'))
+        ->andReturn(new FakeProcessResult());
+
+    [$statusCode, $output] = run('default', [
+        '--commit' => true,
+        'path' => base_path('tests/Fixtures/with-fixable-issues/file.php'),
+    ]);
+
+    expect($statusCode)->toBe(0)
+        ->and($renderer->fetch())
+        ->toBe('  Changes committed successfully!  '.PHP_EOL);
+});


### PR DESCRIPTION
## Abstract

This pull request adds a `--commit` option to the Pint command, making it easy to commit style changes to Git!

### Development

I tried to match the output formatting and code style to the rest of the codebase, as best I could. The implementation could probably be simplified, instead of using the new action class.

#### Tests

I have not yet added tests, as I first want to know if this is of interest to the maintainers. When given the go-ahead I'm more than happy to add them.

### Screenshots

**Success:**

![image](https://github.com/laravel/pint/assets/95144705/13168e56-0e7c-471f-8abd-dd93d5606d1f)

**Nothing to change:**

![image](https://github.com/laravel/pint/assets/95144705/1ff5eab1-45ac-4f17-836a-e4a054efbabe)

**Error:**

![image](https://github.com/laravel/pint/assets/95144705/53eb2720-58c6-405c-a120-f92e2052343f)
