### PR TITLE
Change default for nullable_type_declaration_for_default_null_value

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -132,9 +132,7 @@ return ConfigurationFactory::preset([
     'normalize_index_brace' => true,
     'not_operator_with_successor_space' => true,
     'nullable_type_declaration' => true,
-    'nullable_type_declaration_for_default_null_value' => [
-        'use_nullable_type_declaration' => false,
-    ],
+    'nullable_type_declaration_for_default_null_value' => true,
     'object_operator_without_whitespace' => true,
     'ordered_imports' => ['sort_algorithm' => 'alpha', 'imports_order' => ['const', 'class', 'function']],
     'ordered_interfaces' => true,


### PR DESCRIPTION
Because support for implicit support for implicit nullability exists only for backwards compatibility reasons and will be removed in the future. See https://github.com/laravel/pint/issues/235.