### PR TITLE
Add `--no-config` option

### DIFF
--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -36,6 +36,7 @@ class DefaultCommand extends Command
                 [
                     new InputArgument('path', InputArgument::IS_ARRAY, 'The path to fix', [(string) getcwd()]),
                     new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The configuration that should be used'),
+                    new InputOption('no-config', '', InputOption::VALUE_NONE, 'Disable loading any configuration file'),
                     new InputOption('preset', '', InputOption::VALUE_REQUIRED, 'The preset that should be used'),
                     new InputOption('test', '', InputOption::VALUE_NONE, 'Test for code style errors without fixing them'),
                     new InputOption('dirty', '', InputOption::VALUE_NONE, 'Only fix files that have uncommitted changes'),

--- a/app/Providers/RepositoriesServiceProvider.php
+++ b/app/Providers/RepositoriesServiceProvider.php
@@ -30,9 +30,10 @@ class RepositoriesServiceProvider extends ServiceProvider
     {
         $this->app->singleton(ConfigurationJsonRepository::class, function () {
             $input = resolve(InputInterface::class);
+            $config = $input->getOption('config') ?: Project::path().'/pint.json';
 
             return new ConfigurationJsonRepository(
-                $input->getOption('config') ?: Project::path().'/pint.json',
+                $input->getOption('no-config') ? null : $config,
                 $input->getOption('preset'),
             );
         });

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -76,7 +76,7 @@ class ConfigurationJsonRepository
      */
     protected function get()
     {
-        if ($this->fileExists((string) $this->path)) {
+        if (! is_null($this->path) && $this->fileExists((string) $this->path)) {
             return tap(json_decode(file_get_contents($this->path), true), function ($configuration) {
                 if (! is_array($configuration)) {
                     abort(1, sprintf('The configuration file [%s] is not valid JSON.', $this->path));

--- a/tests/Feature/PresetTest.php
+++ b/tests/Feature/PresetTest.php
@@ -53,3 +53,19 @@ it('may use the Symfony preset', function () {
         ->and($output)
         ->toContain('── Symfony');
 });
+
+it('ignores config when using no config option', function () {
+    $cwd = getcwd();
+    chdir(base_path('tests/Fixtures/no-config'));
+
+    [$statusCode, $output] = run('default', [
+        '--preset' => 'psr12',
+        '--no-config' => true,
+    ]);
+
+    chdir($cwd);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('── PSR 12');
+});

--- a/tests/Fixtures/no-config/pint.json
+++ b/tests/Fixtures/no-config/pint.json
@@ -1,0 +1,7 @@
+{
+    "rules": {
+        "concat_space": {
+            "spacing": "none"
+        }
+    }
+}

--- a/tests/Fixtures/no-config/with-fixes-based-on-config.php
+++ b/tests/Fixtures/no-config/with-fixes-based-on-config.php
@@ -1,0 +1,3 @@
+<?php
+
+$a = 'This has a fix for the ' . 'laravel preset';


### PR DESCRIPTION
Currently, `pint` will merge any project config with the `--preset` option. This was slightly unexpected and makes it difficult to quickly use one of the presents from within a project that has a custom `pint.json` config.

You can get around this by passing an invalid path to `--config`. But that's a bit hacky. I felt a `--no-config` option was nice and provides an explicit way to prevent `pint` from merging any project config.

For example, to apply the `laravel` preset to a set of stub files:

```sh
pint --no-config --preset laravel -- stubs
```

This is indeed a real world use case where a project has it's own rules configured within `pint.json`, but contains stub files which are formatted to the `laravel` preset.