### PR TITLE
Add the possibility to override the cache file path in command line

### DIFF
--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -41,6 +41,7 @@ class DefaultCommand extends Command
                     new InputOption('test', '', InputOption::VALUE_NONE, 'Test for code style errors without fixing them'),
                     new InputOption('dirty', '', InputOption::VALUE_NONE, 'Only fix files that have uncommitted changes'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'The output format that should be used'),
+                    new InputOption('cache-file', '', InputArgument::OPTIONAL, 'The path to the cache file'),
                 ]
             );
     }

--- a/app/Factories/ConfigurationResolverFactory.php
+++ b/app/Factories/ConfigurationResolverFactory.php
@@ -57,7 +57,7 @@ class ConfigurationResolverFactory
                 'dry-run' => $input->getOption('test'),
                 'path' => $path,
                 'path-mode' => ConfigurationResolver::PATH_MODE_OVERRIDE,
-                'cache-file' => $localConfiguration->cacheFile() ?? implode(DIRECTORY_SEPARATOR, [
+                'cache-file' => $input->getOption('cache-file') ?? $localConfiguration->cacheFile() ?? implode(DIRECTORY_SEPARATOR, [
                     realpath(sys_get_temp_dir()),
                     md5(
                         app()->isProduction()


### PR DESCRIPTION
Hi,

We have a internal bundle that defined the code style for all our projects. This bundle is therefore shared by multiple projects. 

We need to have the possibility to define, by project, the path of the pint cache file.

This pull request allow the user to do it by given the path of the cache file in the command line.