### PR TITLE
[1.x] Adds `--bail` flag

### DIFF
--- a/app/Actions/ElaborateSummary.php
+++ b/app/Actions/ElaborateSummary.php
@@ -41,7 +41,7 @@ class ElaborateSummary
             0,
             0,
             $this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE,
-            $this->input->getOption('test'),
+            $this->input->getOption('test') || $this->input->getOption('bail'),
             $this->output->isDecorated()
         );
 

--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -35,6 +35,7 @@ class DefaultCommand extends Command
             ->setDefinition(
                 [
                     new InputArgument('path', InputArgument::IS_ARRAY, 'The path to fix', [(string) getcwd()]),
+                    new InputOption('bail', '', InputOption::VALUE_NONE, 'Test for code style errors without fixing them and stop on first error'),
                     new InputOption('config', '', InputOption::VALUE_REQUIRED, 'The configuration that should be used'),
                     new InputOption('no-config', '', InputOption::VALUE_NONE, 'Disable loading any configuration file'),
                     new InputOption('preset', '', InputOption::VALUE_REQUIRED, 'The preset that should be used'),

--- a/app/Factories/ConfigurationResolverFactory.php
+++ b/app/Factories/ConfigurationResolverFactory.php
@@ -54,7 +54,7 @@ class ConfigurationResolverFactory
                     sprintf('%s.php', $preset),
                 ]),
                 'diff' => $output->isVerbose(),
-                'dry-run' => $input->getOption('test'),
+                'dry-run' => $input->getOption('test') || $input->getOption('bail'),
                 'path' => $path,
                 'path-mode' => ConfigurationResolver::PATH_MODE_OVERRIDE,
                 'cache-file' => $input->getOption('cache-file') ?? $localConfiguration->cacheFile() ?? implode(DIRECTORY_SEPARATOR, [
@@ -65,7 +65,7 @@ class ConfigurationResolverFactory
                         : (string) microtime()
                     ),
                 ]),
-                'stop-on-violation' => false,
+                'stop-on-violation' => $input->getOption('bail'),
                 'verbosity' => $output->getVerbosity(),
                 'show-progress' => 'true',
             ],

--- a/app/Output/Concerns/InteractsWithSymbols.php
+++ b/app/Output/Concerns/InteractsWithSymbols.php
@@ -39,7 +39,7 @@ trait InteractsWithSymbols
         $statusSymbol = $this->statuses[$status];
 
         if (! isset($statusSymbol['symbol'])) {
-            $statusSymbol = $this->input->getOption('test')
+            $statusSymbol = ($this->input->getOption('test') || $this->input->getOption('bail'))
                 ? $statusSymbol[0]
                 : $statusSymbol[1];
         }


### PR DESCRIPTION
This pull request adds the `--bail` flag to Pint, that allows to stop Pint on first failure:

<img width="824" alt="Screenshot 2024-03-20 at 16 44 31" src="https://github.com/laravel/pint/assets/5457236/81cf2175-096d-475a-8eb7-11e46d5a0951">
