### PR TITLE
feat: Add a --with-exit-status flag

### DIFF
--- a/app/Actions/ElaborateSummary.php
+++ b/app/Actions/ElaborateSummary.php
@@ -51,7 +51,7 @@ class ElaborateSummary
             $this->summaryOutput->handle($summary, $totalFiles);
         }
 
-        $failure = (($summary->isDryRun() || $this->input->getOption('with-exit-status')) && count($changes) > 0)
+        $failure = (($summary->isDryRun() || $this->input->getOption('repair')) && count($changes) > 0)
             || count($this->errors->getInvalidErrors()) > 0
             || count($this->errors->getExceptionErrors()) > 0
             || count($this->errors->getLintErrors()) > 0;

--- a/app/Actions/ElaborateSummary.php
+++ b/app/Actions/ElaborateSummary.php
@@ -51,7 +51,7 @@ class ElaborateSummary
             $this->summaryOutput->handle($summary, $totalFiles);
         }
 
-        $failure = ($summary->isDryRun() && count($changes) > 0)
+        $failure = (($summary->isDryRun() || $this->input->getOption('with-exit-status')) && count($changes) > 0)
             || count($this->errors->getInvalidErrors()) > 0
             || count($this->errors->getExceptionErrors()) > 0
             || count($this->errors->getLintErrors()) > 0;

--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -43,7 +43,7 @@ class DefaultCommand extends Command
                     new InputOption('dirty', '', InputOption::VALUE_NONE, 'Only fix files that have uncommitted changes'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'The output format that should be used'),
                     new InputOption('cache-file', '', InputArgument::OPTIONAL, 'The path to the cache file'),
-                    new InputOption('with-exit-status', '', InputOption::VALUE_NONE, 'Only fix files that have uncommitted changes'),
+                    new InputOption('with-exit-status', '', InputOption::VALUE_NONE, 'Exit with status 1 if there were any changes made, 0 otherwise'),
                 ]
             );
     }

--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -40,10 +40,10 @@ class DefaultCommand extends Command
                     new InputOption('preset', '', InputOption::VALUE_REQUIRED, 'The preset that should be used'),
                     new InputOption('test', '', InputOption::VALUE_NONE, 'Test for code style errors without fixing them'),
                     new InputOption('bail', '', InputOption::VALUE_NONE, 'Test for code style errors without fixing them and stop on first error'),
+                    new InputOption('repair', '', InputOption::VALUE_NONE, 'Fix code style errors but exit with status 1 if there were any changes made'),
                     new InputOption('dirty', '', InputOption::VALUE_NONE, 'Only fix files that have uncommitted changes'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'The output format that should be used'),
                     new InputOption('cache-file', '', InputArgument::OPTIONAL, 'The path to the cache file'),
-                    new InputOption('with-exit-status', '', InputOption::VALUE_NONE, 'Exit with status 1 if there were any changes made, 0 otherwise'),
                 ]
             );
     }

--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -43,6 +43,7 @@ class DefaultCommand extends Command
                     new InputOption('dirty', '', InputOption::VALUE_NONE, 'Only fix files that have uncommitted changes'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'The output format that should be used'),
                     new InputOption('cache-file', '', InputArgument::OPTIONAL, 'The path to the cache file'),
+                    new InputOption('with-exit-status', '', InputOption::VALUE_NONE, 'Only fix files that have uncommitted changes'),
                 ]
             );
     }

--- a/tests/Feature/RepairTest.php
+++ b/tests/Feature/RepairTest.php
@@ -12,7 +12,7 @@ it('exits with status 1 with fixes', function () {
     [$statusCode, $output] = run('default', [
         'path' => base_path('tests/Fixtures/with-fixable-issues'),
         '--preset' => 'psr12',
-        '--with-exit-status' => true,
+        '--repair' => true,
         '--test' => false,
     ]);
 
@@ -24,7 +24,7 @@ it('exits with status 1 with fixes', function () {
 it('exits with status 0 without fixes', function () {
     [$statusCode, $output] = run('default', [
         'path' => base_path('tests/Fixtures/without-issues'),
-        '--with-exit-status' => true,
+        '--repair' => true,
         '--test' => false,
     ]);
 

--- a/tests/Feature/WithExitStatusTest.php
+++ b/tests/Feature/WithExitStatusTest.php
@@ -1,0 +1,34 @@
+<?php
+
+beforeEach(function () {
+    $this->contents = file_get_contents(base_path('tests/Fixtures/with-fixable-issues/file.php'));
+});
+
+afterEach(function () {
+    file_put_contents(base_path('tests/Fixtures/with-fixable-issues/file.php'), $this->contents);
+});
+
+it('exits with status 1 with fixes', function () {
+    [$statusCode, $output] = run('default', [
+        'path' => base_path('tests/Fixtures/with-fixable-issues'),
+        '--preset' => 'psr12',
+        '--with-exit-status' => true,
+        '--test' => false,
+    ]);
+
+    expect($statusCode)->toBe(1)
+        ->and($output)
+        ->toContain('FIXED');
+});
+
+it('exits with status 0 without fixes', function () {
+    [$statusCode, $output] = run('default', [
+        'path' => base_path('tests/Fixtures/without-issues'),
+        '--with-exit-status' => true,
+        '--test' => false,
+    ]);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('PASS');
+});


### PR DESCRIPTION
This adds a small feature, `--with-exit-status` that will exit with either 1 or 0 if there are changed files or not. Essentially this is the same as running with the `--test` flag except that it _also_ changes the files.

This is helpful for tools such as Captain Hook (or really any pre-commit hook) which rely on the exit code to know if there were changes, so that it will fail and allow amending the commit manually.

it should be noted that while it seems the prevailing consensus is that you should just run `pint` and then automatically add the changed files to the commit, however if you have additional working changes (e.g. you only staged part of the file, _or_ made changes after staging it) then those changes would now be inadvertently included in the commit.

Happy to add tests if this is a feature you feel would be worth contributing.

Docs PR: laravel/docs#9606
