### PR TITLE
Create empty preset

### DIFF
--- a/resources/presets/empty.php
+++ b/resources/presets/empty.php
@@ -1,0 +1,5 @@
+<?php
+
+use App\Factories\ConfigurationFactory;
+
+return ConfigurationFactory::preset([]);


### PR DESCRIPTION
For a dirty big project, it is not possible to reformat all at once, but rather we need to apply rule by rule and make small PRs that are easy to review and merge.
Currently, I find no way to apply only a single rule on the project and avoid all the other rules.
This way we incrementally add rules to the pint.json in each PR and apply the modification on the entire project.

```json
{
  "preset": "empty",
  "rules": {
     "no_empty_comment": true
  }
}
```
