### PR TITLE
Laravel preset class parentheses

### DIFF
--- a/app/Actions/ElaborateSummary.php
+++ b/app/Actions/ElaborateSummary.php
@@ -69,12 +69,12 @@ class ElaborateSummary
     protected function displayUsingFormatter($summary, $totalFiles)
     {
         $reporter = match ($format = $this->input->getOption('format')) {
-            'checkstyle' => new FixReport\CheckstyleReporter(),
-            'gitlab' => new FixReport\GitlabReporter(),
-            'json' => new FixReport\JsonReporter(),
-            'junit' => new FixReport\JunitReporter(),
-            'txt' => new FixReport\TextReporter(),
-            'xml' => new FixReport\XmlReporter(),
+            'checkstyle' => new FixReport\CheckstyleReporter,
+            'gitlab' => new FixReport\GitlabReporter,
+            'json' => new FixReport\JsonReporter,
+            'junit' => new FixReport\JunitReporter,
+            'txt' => new FixReport\TextReporter,
+            'xml' => new FixReport\XmlReporter,
             default => abort(1, sprintf('Format [%s] is not supported.', $format)),
         };
 

--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -42,7 +42,7 @@ class ConfigurationFactory
      */
     public static function preset($rules)
     {
-        return (new Config())
+        return (new Config)
             ->setParallelConfig(ParallelConfigFactory::detect())
             ->setFinder(self::finder())
             ->setRules(array_merge($rules, resolve(ConfigurationJsonRepository::class)->rules()))

--- a/app/Factories/ConfigurationResolverFactory.php
+++ b/app/Factories/ConfigurationResolverFactory.php
@@ -70,7 +70,7 @@ class ConfigurationResolverFactory
                 'show-progress' => 'true',
             ],
             Project::path(),
-            new ToolInfo(),
+            new ToolInfo,
         );
 
         $totalFiles = count(new ArrayIterator(iterator_to_array(

--- a/app/Output/ProgressOutput.php
+++ b/app/Output/ProgressOutput.php
@@ -37,7 +37,7 @@ class ProgressOutput
         protected $input,
         protected $output,
     ) {
-        $this->symbolsPerLine = (new Terminal())->getWidth() - 4;
+        $this->symbolsPerLine = (new Terminal)->getWidth() - 4;
     }
 
     /**
@@ -70,7 +70,7 @@ class ProgressOutput
     {
         $symbolsOnCurrentLine = $this->processed % $this->symbolsPerLine;
 
-        if ($symbolsOnCurrentLine >= (new Terminal())->getWidth() - 4) {
+        if ($symbolsOnCurrentLine >= (new Terminal)->getWidth() - 4) {
             $symbolsOnCurrentLine = 0;
         }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -26,11 +26,11 @@ class AppServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton(ErrorsManager::class, function () {
-            return new ErrorsManager();
+            return new ErrorsManager;
         });
 
         $this->app->singleton(EventDispatcher::class, function () {
-            return new EventDispatcher();
+            return new EventDispatcher;
         });
     }
 }

--- a/app/ValueObjects/Issue.php
+++ b/app/ValueObjects/Issue.php
@@ -74,7 +74,7 @@ class Issue
 
             $exception = $this->payload['source']->getPrevious() ?: $this->payload['source'];
 
-            return (new Highlighter())->highlight($content, $exception->getLine());
+            return (new Highlighter)->highlight($content, $exception->getLine());
         }
 
         return $this->diff();
@@ -98,7 +98,7 @@ class Issue
     protected function diff()
     {
         if ($this->payload['diff']) {
-            $highlighter = new Highlighter();
+            $highlighter = new Highlighter;
             $reflector = new ReflectionClass($highlighter);
 
             $diff = $this->payload['diff'];

--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -82,6 +82,10 @@ return ConfigurationFactory::preset([
     ],
     'native_function_casing' => true,
     'native_type_declaration_casing' => true,
+    'new_with_parentheses' => [
+        'named_class' => false,
+        'anonymous_class' => false,
+    ],
     'no_alias_functions' => true,
     'no_alias_language_construct_call' => true,
     'no_alternative_syntax' => true,

--- a/tests/Feature/DirtyTest.php
+++ b/tests/Feature/DirtyTest.php
@@ -9,7 +9,7 @@ it('determines dirty files', function () {
         ->shouldReceive('dirty')
         ->once()
         ->andReturn([
-            base_path('tests/Fixtures/without-issues/file.php'),
+            base_path('tests/Fixtures/without-issues-laravel/file.php'),
         ]);
 
     $this->swap(PathsRepository::class, $paths);
@@ -28,7 +28,7 @@ it('ignores the path argument', function () {
         ->shouldReceive('dirty')
         ->once()
         ->andReturn([
-            base_path('tests/Fixtures/without-issues/file.php'),
+            base_path('tests/Fixtures/without-issues-laravel/file.php'),
         ]);
 
     $this->swap(PathsRepository::class, $paths);

--- a/tests/Feature/PresetTest.php
+++ b/tests/Feature/PresetTest.php
@@ -2,7 +2,7 @@
 
 it('uses the laravel preset by default', function () {
     [$statusCode, $output] = run('default', [
-        'path' => base_path('tests/Fixtures/without-issues'),
+        'path' => base_path('tests/Fixtures/without-issues-laravel'),
     ]);
 
     expect($statusCode)->toBe(0)
@@ -34,7 +34,7 @@ it('may use the PER preset', function () {
 
 it('may use the Laravel preset', function () {
     [$statusCode, $output] = run('default', [
-        'path' => base_path('tests/Fixtures/without-issues'),
+        'path' => base_path('tests/Fixtures/without-issues-laravel'),
         '--preset' => 'laravel',
     ]);
 

--- a/tests/Feature/RepairTest.php
+++ b/tests/Feature/RepairTest.php
@@ -23,7 +23,7 @@ it('exits with status 1 with fixes', function () {
 
 it('exits with status 0 without fixes', function () {
     [$statusCode, $output] = run('default', [
-        'path' => base_path('tests/Fixtures/without-issues'),
+        'path' => base_path('tests/Fixtures/without-issues-laravel'),
         '--repair' => true,
         '--test' => false,
     ]);

--- a/tests/Feature/SummaryTest.php
+++ b/tests/Feature/SummaryTest.php
@@ -31,7 +31,7 @@ it('may fail with errors', function () {
 
 it('may pass', function () {
     [$statusCode, $output] = run('default', [
-        'path' => base_path('tests/Fixtures/without-issues'),
+        'path' => base_path('tests/Fixtures/without-issues-laravel'),
     ]);
 
     expect($statusCode)->toBe(0)

--- a/tests/Fixtures/without-issues-laravel/file.php
+++ b/tests/Fixtures/without-issues-laravel/file.php
@@ -1,0 +1,3 @@
+<?php
+
+$a = new stdClass;

--- a/tests/Fixtures/without-issues/file.php
+++ b/tests/Fixtures/without-issues/file.php
@@ -1,3 +1,3 @@
 <?php
 
-$a = new stdClass;
+$a = new stdClass();

--- a/tests/Fixtures/without-issues/file.php
+++ b/tests/Fixtures/without-issues/file.php
@@ -1,3 +1,3 @@
 <?php
 
-$a = new stdClass();
+$a = new stdClass;


### PR DESCRIPTION
This PR adds the rule `new_with_parentheses` to the Laravel preset with the configuration. It's a followup for https://github.com/laravel/pint/issues/284. The PR also runs Pint with the new rule over it's own codebase.

In after this change, running Pint with the Laravel Preset will make sure empty parentheses `()` will be removed from class Instantiations. 

```php
// the following line ...
$item = new Item();

// will become
$item = new Item;
```