### PR TITLE
remove deprecated config option of phpstan

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,4 +7,3 @@ parameters:
     - config
     - resources
   level: 6
-  checkGenericClassInNonGenericObjectType: false


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When the following steps were followed to run phpstan, a deprecated warning was displayed.
So I remove deprecated config option of phpstan.neon.
```
composer install

./vendor/bin/phpstan --memory-limit=2G

Note: Using configuration file /xxx/pint/phpstan.neon.
⚠️  You're using a deprecated config option checkGenericClassInNonGenericObjectType ⚠️️

It's strongly recommended to remove it from your configuration file
and add the missing generic typehints.

If you want to continue ignoring missing typehints from generics,
add missingType.generics error identifier to your ignoreErrors:

parameters:
	ignoreErrors:
		-
			identifier: missingType.generics

 27/27 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


                                                                                                                        
 [OK] No errors  
```

