### PR TITLE
Rules are not applied when "empty" is specified for the preset

### DIFF
--- a/app/Factories/ConfigurationResolverFactory.php
+++ b/app/Factories/ConfigurationResolverFactory.php
@@ -21,6 +21,7 @@ class ConfigurationResolverFactory
         'per',
         'psr12',
         'symfony',
+        'empty',
     ];
 
     /**


### PR DESCRIPTION
I discovered a bug where the rules written in the rules section are not applied when the following settings are written in pint.json:

```json
{
    "preset": "empty",
    "rules": {
        "array_syntax": true
    }
}
```

I made a fix because `ConfigurationFactory::preset([])` is not called unless "empty" is added to the available presets.


I tried writing the following code and compared the cases where "empty" is not present in $presets and where it is present:
```php
$example = array();
```

When "empty" is not present:
```shell
❯ ./pint -v --preset=empty --test


  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Empty
    PASS   ........................................................................................................................................................................................................................................................... 0 files

```

When "empty" is present:
```shell
❯ ./pint -v --preset=empty --test

  .............⨯................................

  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Empty
    FAIL   ........................................................................................................................................................................................................................................... 46 files, 1 style issue
  ⨯ app/Factories/ConfigurationResolverFactory.php                                                                                                                                                                                                                array_syntax
  @@ -34,7 +34,7 @@
        */
       public static function fromIO($input, $output)
       {
  -        $example = array();
  +        $example = [];
           $path = Project::paths($input);

           $localConfiguration = resolve(ConfigurationJsonRepository::class);

```

It can be seen that the rules are correctly applied.