### PR TITLE
[1.x] Rename rule set `@PER` to `@PER-CS`

### DIFF
--- a/resources/presets/per.php
+++ b/resources/presets/per.php
@@ -3,6 +3,6 @@
 use App\Factories\ConfigurationFactory;
 
 return ConfigurationFactory::preset([
-    '@PER' => true,
+    '@PER-CS' => true,
     'no_unused_imports' => true,
 ]);


### PR DESCRIPTION
Hi,

`@PER` rule set is deprecated and will be removed in the next major version.

You should use `@PER-CS` instead.