### PR TITLE
Add interactive .pint.json configuration generator

### DIFF
--- a/app/Commands/ConfigCommand.php
+++ b/app/Commands/ConfigCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Commands;
+
+use LaravelZero\Framework\Commands\Command;
+use Illuminate\Support\Facades\File;
+
+class ConfigCommand extends Command
+{
+    protected $signature = 'config';
+    protected $description = 'Interactively generate a .pint.json configuration file';
+
+    public function handle()
+    {
+        $config = [
+            'preset' => $this->choice(
+                'Select a preset',
+                ['laravel', 'psr12', 'symfony'],
+                'laravel'
+            ),
+        ];
+
+        if ($this->confirm('Do you want to customize rules?', false)) {
+            $config['rules'] = $this->customizeRules();
+        }
+
+        $config['exclude'] = $this->askExcludedPaths();
+
+        $this->writeConfigFile($config);
+
+        $this->info('.pint.json file has been generated successfully!');
+    }
+
+    private function customizeRules()
+    {
+        $rules = [];
+        $commonRules = [
+            'array_syntax' => ['short_syntax', 'long_syntax'],
+            'ordered_imports' => ['sort_algorithm' => ['alpha', 'length', 'none']],
+            'no_unused_imports' => true,
+            'not_operator_with_successor_space' => true,
+            // Add more common rules here
+        ];
+
+        while ($this->confirm('Add a custom rule?', false)) {
+            $ruleName = $this->choice('Select or enter a rule name', array_merge(array_keys($commonRules), ['custom']));
+
+            if ($ruleName === 'custom') {
+                $ruleName = $this->ask('Enter the custom rule name');
+            }
+
+            if (isset($commonRules[$ruleName]) && is_array($commonRules[$ruleName])) {
+                $ruleValue = $this->choice("Select a value for $ruleName", $commonRules[$ruleName]);
+            } elseif (isset($commonRules[$ruleName])) {
+                $ruleValue = $commonRules[$ruleName];
+            } else {
+                $ruleValue = $this->ask("Enter the value for $ruleName");
+            }
+
+            $rules[$ruleName] = $ruleValue;
+        }
+        return $rules;
+    }
+
+
+    private function askExcludedPaths()
+    {
+        $excludedPaths = [];
+        while ($this->confirm('Add a path to exclude?', false)) {
+            $excludedPaths[] = $this->ask('Enter the path to exclude');
+        }
+        return $excludedPaths;
+    }
+
+    private function writeConfigFile($config)
+    {
+        $jsonContent = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        File::put(getcwd() . '/.pint.json', $jsonContent);
+    }
+}

--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -44,6 +44,8 @@ class DefaultCommand extends Command
                     new InputOption('dirty', '', InputOption::VALUE_NONE, 'Only fix files that have uncommitted changes'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'The output format that should be used'),
                     new InputOption('cache-file', '', InputArgument::OPTIONAL, 'The path to the cache file'),
+                    new InputOption('generate-config', '', InputOption::VALUE_NONE, 'Generate a .pint.json configuration file interactively'),
+
                 ]
             );
     }
@@ -57,6 +59,10 @@ class DefaultCommand extends Command
      */
     public function handle($fixCode, $elaborateSummary)
     {
+        if ($this->option('generate-config')) {
+            return $this->call('config');
+        }
+
         [$totalFiles, $changes] = $fixCode->execute();
 
         return $elaborateSummary->execute($totalFiles, $changes);


### PR DESCRIPTION

## Description
This PR adds a new feature to Laravel Pint that allows users to interactively generate a `.pint.json` configuration file. This makes it easier for users to set up and customize their Pint configuration without needing to manually create and edit the JSON file.

## New Features
- New `ConfigCommand` that handles the interactive generation of `.pint.json`
- Added `--generate-config` option to the main Pint command
- Interactive prompts for selecting preset, customizing rules, and specifying excluded paths
- Direct access to the config generator via `pint config` or `pint --generate-config`

## Implementation Details
- Created `app/Commands/ConfigCommand.php` to handle the interactive configuration process
- Modified `app/Commands/DefaultCommand.php` to include the new `--generate-config` option
- The config generator allows users to:
  - Select a preset (laravel, psr12, or symfony)
  - Add custom rules (with common rules suggested)
  - Specify paths to exclude from Pint's processing

## How to Use
Users can generate a config file in two ways:
1. `pint --generate-config`
2. `pint config`

Both methods will start an interactive process to create a `.pint.json` file in the current working directory.
