### PR TITLE
[1.x] Enforce `snake_case` methods for PHPUnit method in Laravel preset

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -176,6 +176,7 @@ return ConfigurationFactory::preset([
     'phpdoc_trim' => true,
     'phpdoc_types' => true,
     'phpdoc_var_without_name' => true,
+    'php_unit_method_casing' => ['case' => 'snake_case'],
     'psr_autoloading' => false,
     'return_type_declaration' => ['space_before' => 'none'],
     'self_accessor' => false,

--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -141,6 +141,7 @@ return ConfigurationFactory::preset([
     'ordered_imports' => ['sort_algorithm' => 'alpha', 'imports_order' => ['const', 'class', 'function']],
     'ordered_interfaces' => true,
     'ordered_traits' => true,
+    'php_unit_method_casing' => ['case' => 'snake_case'],
     'phpdoc_align' => [
         'align' => 'left',
         'spacing' => [
@@ -176,7 +177,6 @@ return ConfigurationFactory::preset([
     'phpdoc_trim' => true,
     'phpdoc_types' => true,
     'phpdoc_var_without_name' => true,
-    'php_unit_method_casing' => ['case' => 'snake_case'],
     'psr_autoloading' => false,
     'return_type_declaration' => ['space_before' => 'none'],
     'self_accessor' => false,

--- a/tests/Feature/Fixers/PhpUnitCasingTest.php
+++ b/tests/Feature/Fixers/PhpUnitCasingTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use function Illuminate\Filesystem\join_paths;
+
+it('fixes the code', function () {
+    [$statusCode, $output] = run('default', [
+        'path' => base_path('tests/Fixtures/fixers/phpunit_method_casing.php'),
+        '--preset' => 'laravel',
+    ]);
+
+    expect($statusCode)->toBe(1)
+        ->and($output)
+        ->toContain('  ⨯ '.join_paths('tests', 'Fixtures', 'fixers', 'phpunit_method_casing.php'))
+        ->toContain(<<<'DIFF'
+              -    public function testItConvertsToSnakeCase()
+              +    public function test_it_converts_to_snake_case()
+            DIFF);
+});

--- a/tests/Fixtures/fixers/phpunit_method_casing.php
+++ b/tests/Fixtures/fixers/phpunit_method_casing.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class PhpUnitCasingTest extends TestCase
+{
+    public function testItConvertsToSnakeCase()
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
The Laravel preset should have an opinion on testsuite method casing.

There is always overhead involved working out what casing the testsuite is using. Often there can be multiple casings within a single testsuite. Even in our own ecosystem's packages, when contributions come from different people, we can see different casings within the one project.

The Laravel framework ships with snake casing, so I am proposing we stick with that and never have to waste brain cycles on this again for PHPUnit based testsuites.

<img width="463" alt="Screenshot 2024-10-10 at 09 28 07" src="https://github.com/user-attachments/assets/cb017a5b-c955-469f-ae28-d5da56100f81">
