### PR TITLE
[1.x] Enforce visibility for PHPUnit `setUp` and `tearDown` methods.

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -142,6 +142,7 @@ return ConfigurationFactory::preset([
     'ordered_interfaces' => true,
     'ordered_traits' => true,
     'php_unit_method_casing' => ['case' => 'snake_case'],
+    'php_unit_set_up_tear_down_visibility' => true,
     'phpdoc_align' => [
         'align' => 'left',
         'spacing' => [


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR enforces visibility for PHPUnit `setUp` and `tearDown` methods.

See https://mlocati.github.io/php-cs-fixer-configurator/#version:3.8|fixer:php_unit_set_up_tear_down_visibility

