### PR TITLE
Add `--staged` option

### DIFF
--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -42,6 +42,7 @@ class DefaultCommand extends Command
                     new InputOption('bail', '', InputOption::VALUE_NONE, 'Test for code style errors without fixing them and stop on first error'),
                     new InputOption('repair', '', InputOption::VALUE_NONE, 'Fix code style errors but exit with status 1 if there were any changes made'),
                     new InputOption('dirty', '', InputOption::VALUE_NONE, 'Only fix files that have uncommitted changes'),
+                    new InputOption('staged', 's', InputOption::VALUE_NONE, 'Only fix files that have staged changes'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'The output format that should be used'),
                     new InputOption('cache-file', '', InputArgument::OPTIONAL, 'The path to the cache file'),
                 ]

--- a/app/Contracts/PathsRepository.php
+++ b/app/Contracts/PathsRepository.php
@@ -11,7 +11,6 @@ interface PathsRepository
      */
     public function dirty();
 
-
     /**
      * Determine the "staged" files.
      *

--- a/app/Contracts/PathsRepository.php
+++ b/app/Contracts/PathsRepository.php
@@ -10,4 +10,12 @@ interface PathsRepository
      * @return array<int, string>
      */
     public function dirty();
+
+
+    /**
+     * Determine the "staged" files.
+     *
+     * @return array<int, string>
+     */
+    public function staged();
 }

--- a/app/Project.php
+++ b/app/Project.php
@@ -18,6 +18,10 @@ class Project
             return static::resolveDirtyPaths();
         }
 
+        if ($input->getOption('staged')) {
+           return static::resolveStagedPaths();
+        }
+
         return $input->getArgument('path');
     }
 
@@ -42,6 +46,22 @@ class Project
 
         if (empty($files)) {
             abort(0, 'No dirty files found.');
+        }
+
+        return $files;
+    }
+
+    /**
+     * Resolves the staged paths, if any.
+     *
+     * @return array<int, string>
+     */
+    public static function resolveStagedPaths()
+    {
+        $files = app(PathsRepository::class)->staged();
+
+        if (empty($files)) {
+            abort(0, 'No staged files found.');
         }
 
         return $files;

--- a/app/Project.php
+++ b/app/Project.php
@@ -19,7 +19,7 @@ class Project
         }
 
         if ($input->getOption('staged')) {
-           return static::resolveStagedPaths();
+            return static::resolveStagedPaths();
         }
 
         return $input->getArgument('path');

--- a/app/Repositories/GitPathsRepository.php
+++ b/app/Repositories/GitPathsRepository.php
@@ -68,22 +68,22 @@ class GitPathsRepository implements PathsRepository
     {
         $process = tap(new Process(['git', 'diff', '--cached', '--name-only', '--diff-filter=ACM', '--', '**.php']))->run();
 
-       if (! $process->isSuccessful()) {
+        if (! $process->isSuccessful()) {
             abort(1, 'The [--staged] option is only available when using Git.');
-       }
+        }
 
-       $stagedFiles = collect(preg_split('/\R+/', $process->getOutput(), flags: PREG_SPLIT_NO_EMPTY))
+        $stagedFiles = collect(preg_split('/\R+/', $process->getOutput(), flags: PREG_SPLIT_NO_EMPTY))
             ->map(function ($file) {
                 if (PHP_OS_FAMILY === 'Windows') {
                     $file = str_replace('/', DIRECTORY_SEPARATOR, $file);
                 }
 
-                return $this->path . DIRECTORY_SEPARATOR . $file;
+                return $this->path.DIRECTORY_SEPARATOR.$file;
             })
             ->values()
             ->all();
 
-       $files = array_values(array_map(function ($splFile) {
+        $files = array_values(array_map(function ($splFile) {
             return $splFile->getPathname();
         }, iterator_to_array(ConfigurationFactory::finder()
             ->in($this->path)

--- a/tests/Feature/StagedTest.php
+++ b/tests/Feature/StagedTest.php
@@ -9,7 +9,7 @@ it('determines staged files', function () {
         ->shouldReceive('staged')
         ->once()
         ->andReturn([
-           base_path('tests/Fixtures/without-issues-laravel/file.php'),
+            base_path('tests/Fixtures/without-issues-laravel/file.php'),
         ]);
 
     $this->swap(PathsRepository::class, $paths);

--- a/tests/Feature/StagedTest.php
+++ b/tests/Feature/StagedTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Contracts\PathsRepository;
+
+it('determines staged files', function () {
+    $paths = Mockery::mock(PathsRepository::class);
+
+    $paths
+        ->shouldReceive('staged')
+        ->once()
+        ->andReturn([
+           base_path('tests/Fixtures/without-issues-laravel/file.php'),
+        ]);
+
+    $this->swap(PathsRepository::class, $paths);
+
+    [$statusCode, $output] = run('default', ['--staged' => true]);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('── Laravel', ' 1 file');
+});
+
+it('ignores the path argument', function () {
+    $paths = Mockery::mock(PathsRepository::class);
+
+    $paths
+        ->shouldReceive('staged')
+        ->once()
+        ->andReturn([
+            base_path('tests/Fixtures/without-issues-laravel/file.php'),
+        ]);
+
+    $this->swap(PathsRepository::class, $paths);
+
+    [$statusCode, $output] = run('default', [
+        '-s' => true,
+        'path' => base_path(),
+    ]);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('── Laravel', ' 1 file');
+});
+
+it('does not abort when there are no staged files', function () {
+    $paths = Mockery::mock(PathsRepository::class);
+
+    $paths
+        ->shouldReceive('staged')
+        ->once()
+        ->andReturn([]);
+
+    $this->swap(PathsRepository::class, $paths);
+
+    [$statusCode, $output] = run('default', [
+        '--staged' => true,
+    ]);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('── Laravel', ' 0 files');
+});


### PR DESCRIPTION
### Why
As a developer, I often juggle multiple tasks. For example, while working on my branch `xyz`, I was asked to fix an urgent issue. Instead of stashing my changes, I switched branches to address it quickly. After making the fix, I wanted to run Laravel Pint and PHPStan to check for issues, but I needed to focus only on the staged changes.

Currently, there’s a `--dirty` flag, but I propose adding a `--staged` flag. This would allow us to run Pint exclusively on staged files, improving our workflow when context-switching.

```sh
alias pint-staged="vendor/bin/pint $(git diff --cached --name-only --diff-filter=ACM)"
```

I have created this alias to run Pint on staged files. This command lets me quickly validate staged changes without affecting uncommitted work. But after this PR merge, I will remove it from `.zshrc`.