### PR TITLE
Show warning regarding PHP 8.4 support

### DIFF
--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -57,6 +57,14 @@ class DefaultCommand extends Command
      */
     public function handle($fixCode, $elaborateSummary)
     {
+        if (! ($_ENV['PINT_IGNORE_ENV'] ?? false) && version_compare(PHP_VERSION, '8.4.0', '>=')) {
+            $this->warn('PHP 8.4 is not supported yet. Please downgrade to PHP 8.3 or lower.');
+            $this->warn('You can still run (though not recommended) by setting the environment variable:');
+            $this->warn('PINT_IGNORE_ENV=1 vendor/bin/pint');
+
+            return 1;
+        }
+
         [$totalFiles, $changes] = $fixCode->execute();
 
         return $elaborateSummary->execute($totalFiles, $changes);


### PR DESCRIPTION
The underlying library PHP-CS-Fixer is currently working on PHP 8.4 compatibility (this does not include PHP 8.4 syntax specific fixers).
See the following milestone for more information:
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/milestone/173

It is therefor not recommended to run on PHP 8.4.

This PR implements a similar approach to was PHP-CS-Fixer does:

```
PHP_CS_FIXER_IGNORE_ENV=1 php php-cs-fixer.phar fix /path/to/dir
```

https://cs.symfony.com/doc/usage.html#environment-options