### PR TITLE
Add single_line_comment_spacing rule

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -190,6 +190,7 @@ return ConfigurationFactory::preset([
     ],
     'single_import_per_statement' => true,
     'single_line_after_imports' => true,
+    'single_line_comment_spacing' => true,
     'single_line_comment_style' => [
         'comment_types' => ['hash'],
     ],


### PR DESCRIPTION
This PR proposes to enable the [`single_line_comment_spacing`](//cs.symfony.com/doc/rules/comment/single_line_comment_spacing.html) fixer in the laravel preset.

