### PR TITLE
Add `parameters` to `trailing_comma_in_multiline` rule

### DIFF
--- a/app/ValueObjects/Issue.php
+++ b/app/ValueObjects/Issue.php
@@ -20,7 +20,7 @@ class Issue
         protected $path,
         protected $file,
         protected $symbol,
-        protected $payload
+        protected $payload,
     ) {
         // ..
     }

--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -204,7 +204,9 @@ return ConfigurationFactory::preset([
     'switch_case_semicolon_to_colon' => true,
     'switch_case_space' => true,
     'ternary_operator_spaces' => true,
-    'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+    'trailing_comma_in_multiline' => [
+        'elements' => ['arrays', 'parameters'],
+    ],
     'trim_array_spaces' => true,
     'type_declaration_spaces' => true,
     'types_spaces' => true,


### PR DESCRIPTION
This request enables the [`trailing_comma_in_multiline`](https://cs.symfony.com/doc/rules/control_structure/trailing_comma_in_multiline.html) rule for `parameters`.