### PR TITLE
[1.x] Adds `--diff` option

### DIFF
--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -41,6 +41,7 @@ class DefaultCommand extends Command
                     new InputOption('test', '', InputOption::VALUE_NONE, 'Test for code style errors without fixing them'),
                     new InputOption('bail', '', InputOption::VALUE_NONE, 'Test for code style errors without fixing them and stop on first error'),
                     new InputOption('repair', '', InputOption::VALUE_NONE, 'Fix code style errors but exit with status 1 if there were any changes made'),
+                    new InputOption('diff', '', InputOption::VALUE_REQUIRED, 'Only fix files that have changed since branching off from the given branch', null, ['main', 'master', 'origin/main', 'origin/master']),
                     new InputOption('dirty', '', InputOption::VALUE_NONE, 'Only fix files that have uncommitted changes'),
                     new InputOption('format', '', InputOption::VALUE_REQUIRED, 'The output format that should be used'),
                     new InputOption('cache-file', '', InputArgument::OPTIONAL, 'The path to the cache file'),

--- a/app/Contracts/PathsRepository.php
+++ b/app/Contracts/PathsRepository.php
@@ -13,7 +13,7 @@ interface PathsRepository
 
     /**
      * Determine the files that have changed since branching off from the given branch.
-     * 
+     *
      * @param  string  $branch
      * @return array<int, string>
      */

--- a/app/Contracts/PathsRepository.php
+++ b/app/Contracts/PathsRepository.php
@@ -10,4 +10,12 @@ interface PathsRepository
      * @return array<int, string>
      */
     public function dirty();
+
+    /**
+     * Determine the files that have changed since branching off from the given branch.
+     * 
+     * @param  string  $branch
+     * @return array<int, string>
+     */
+    public function diff($branch);
 }

--- a/app/Project.php
+++ b/app/Project.php
@@ -18,6 +18,10 @@ class Project
             return static::resolveDirtyPaths();
         }
 
+        if ($diff = $input->getOption('diff')) {
+            return static::resolveDiffPaths($diff);
+        }
+
         return $input->getArgument('path');
     }
 
@@ -42,6 +46,23 @@ class Project
 
         if (empty($files)) {
             abort(0, 'No dirty files found.');
+        }
+
+        return $files;
+    }
+
+    /**
+     * Resolves the paths that have changed since branching off from the given branch, if any.
+     *
+     * @param  string  $branch
+     * @return array<int, string>
+     */
+    public static function resolveDiffPaths($branch)
+    {
+        $files = app(PathsRepository::class)->diff($branch);
+
+        if (empty($files)) {
+            abort(0, "No files have changed since branching off of {$branch}.");
         }
 
         return $files;

--- a/app/Repositories/GitPathsRepository.php
+++ b/app/Repositories/GitPathsRepository.php
@@ -42,7 +42,7 @@ class GitPathsRepository implements PathsRepository
             ->mapWithKeys(fn ($file) => [substr($file, 3) => trim(substr($file, 0, 3))])
             ->reject(fn ($status) => $status === 'D')
             ->map(fn ($status, $file) => $status === 'R' ? Str::after($file, ' -> ') : $file);
-        
+
         return $this->processFileNames($dirtyFiles);
     }
 
@@ -68,7 +68,7 @@ class GitPathsRepository implements PathsRepository
             ->flatten()
             ->filter()
             ->values();
-        
+
         return $this->processFileNames($files);
     }
 

--- a/app/Repositories/GitPathsRepository.php
+++ b/app/Repositories/GitPathsRepository.php
@@ -55,6 +55,7 @@ class GitPathsRepository implements PathsRepository
             'committed' => tap(new Process(['git', 'diff', '--name-only', '--diff-filter=AM', "{$branch}...HEAD", '--', '**.php']))->run(),
             'staged' => tap(new Process(['git', 'diff', '--name-only', '--diff-filter=AM', '--cached', '--', '**.php']))->run(),
             'unstaged' => tap(new Process(['git', 'diff', '--name-only', '--diff-filter=AM', '--', '**.php']))->run(),
+            'untracked' => tap(new Process(['git', 'ls-files', '--others', '--exclude-standard', '--', '**.php']))->run(),
         ];
 
         $files = collect($files)

--- a/app/Repositories/GitPathsRepository.php
+++ b/app/Repositories/GitPathsRepository.php
@@ -67,6 +67,7 @@ class GitPathsRepository implements PathsRepository
             ->map(fn ($output) => explode(PHP_EOL, $output))
             ->flatten()
             ->filter()
+            ->unique()
             ->values();
 
         return $this->processFileNames($files);

--- a/app/Repositories/GitPathsRepository.php
+++ b/app/Repositories/GitPathsRepository.php
@@ -77,12 +77,12 @@ class GitPathsRepository implements PathsRepository
     /**
      * Process the files.
      *
-     * @param  \Illuminate\Support\Collection  $files
-     * @return array
+     * @param  \Illuminate\Support\Collection<int|string, string>  $fileNames
+     * @return array<int, string>
      */
     protected function processFileNames(Collection $fileNames)
     {
-        return $fileNames
+        $processedFileNames = $fileNames
             ->map(function ($file) {
                 if (PHP_OS_FAMILY === 'Windows') {
                     $file = str_replace('/', DIRECTORY_SEPARATOR, $file);
@@ -100,6 +100,6 @@ class GitPathsRepository implements PathsRepository
             ->files()
         )));
 
-        return array_values(array_intersect($files, $dirtyFiles));
+        return array_values(array_intersect($files, $processedFileNames));
     }
 }

--- a/app/Repositories/GitPathsRepository.php
+++ b/app/Repositories/GitPathsRepository.php
@@ -4,6 +4,7 @@ namespace App\Repositories;
 
 use App\Contracts\PathsRepository;
 use App\Factories\ConfigurationFactory;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
 
@@ -40,7 +41,20 @@ class GitPathsRepository implements PathsRepository
         $dirtyFiles = collect(preg_split('/\R+/', $process->getOutput(), flags: PREG_SPLIT_NO_EMPTY))
             ->mapWithKeys(fn ($file) => [substr($file, 3) => trim(substr($file, 0, 3))])
             ->reject(fn ($status) => $status === 'D')
-            ->map(fn ($status, $file) => $status === 'R' ? Str::after($file, ' -> ') : $file)
+            ->map(fn ($status, $file) => $status === 'R' ? Str::after($file, ' -> ') : $file);
+        
+        return $this->processFileNames($dirtyFiles);
+    }
+
+    /**
+     * Process the files.
+     *
+     * @param  \Illuminate\Support\Collection  $files
+     * @return array
+     */
+    protected function processFileNames(Collection $fileNames)
+    {
+        return $fileNames
             ->map(function ($file) {
                 if (PHP_OS_FAMILY === 'Windows') {
                     $file = str_replace('/', DIRECTORY_SEPARATOR, $file);

--- a/app/Repositories/GitPathsRepository.php
+++ b/app/Repositories/GitPathsRepository.php
@@ -41,7 +41,8 @@ class GitPathsRepository implements PathsRepository
         $dirtyFiles = collect(preg_split('/\R+/', $process->getOutput(), flags: PREG_SPLIT_NO_EMPTY))
             ->mapWithKeys(fn ($file) => [substr($file, 3) => trim(substr($file, 0, 3))])
             ->reject(fn ($status) => $status === 'D')
-            ->map(fn ($status, $file) => $status === 'R' ? Str::after($file, ' -> ') : $file);
+            ->map(fn ($status, $file) => $status === 'R' ? Str::after($file, ' -> ') : $file)
+            ->values();
 
         return $this->processFileNames($dirtyFiles);
     }
@@ -69,7 +70,8 @@ class GitPathsRepository implements PathsRepository
             ->flatten()
             ->filter()
             ->unique()
-            ->values();
+            ->values()
+            ->map(fn ($s) => (string) $s);
 
         return $this->processFileNames($files);
     }
@@ -77,7 +79,7 @@ class GitPathsRepository implements PathsRepository
     /**
      * Process the files.
      *
-     * @param  \Illuminate\Support\Collection<int|string, string>  $fileNames
+     * @param  \Illuminate\Support\Collection<int, string>  $fileNames
      * @return array<int, string>
      */
     protected function processFileNames(Collection $fileNames)
@@ -90,7 +92,6 @@ class GitPathsRepository implements PathsRepository
 
                 return $this->path.DIRECTORY_SEPARATOR.$file;
             })
-            ->values()
             ->all();
 
         $files = array_values(array_map(function ($splFile) {

--- a/tests/Feature/DiffTest.php
+++ b/tests/Feature/DiffTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Contracts\PathsRepository;
+
+it('determines diff files', function () {
+    $paths = Mockery::mock(PathsRepository::class);
+
+    $paths
+        ->shouldReceive('diff')
+        ->with('main')
+        ->once()
+        ->andReturn([
+            base_path('tests/Fixtures/without-issues-laravel/file.php'),
+        ]);
+
+    $this->swap(PathsRepository::class, $paths);
+
+    [$statusCode, $output] = run('default', ['--diff' => 'main']);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('── Laravel', ' 1 file');
+});
+
+it('ignores the path argument', function () {
+    $paths = Mockery::mock(PathsRepository::class);
+
+    $paths
+        ->shouldReceive('diff')
+        ->once()
+        ->andReturn([
+            base_path('tests/Fixtures/without-issues-laravel/file.php'),
+        ]);
+
+    $this->swap(PathsRepository::class, $paths);
+
+    [$statusCode, $output] = run('default', [
+        '--diff' => 'main',
+        'path' => base_path(),
+    ]);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('── Laravel', ' 1 file');
+});
+
+it('does not abort when there are no diff files', function () {
+    $paths = Mockery::mock(PathsRepository::class);
+
+    $paths
+        ->shouldReceive('diff')
+        ->once()
+        ->andReturn([]);
+
+    $this->swap(PathsRepository::class, $paths);
+
+    [$statusCode, $output] = run('default', [
+        '--diff' => 'main',
+    ]);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('── Laravel', ' 0 files');
+});
+
+it('parses nested branch names', function () {
+    $paths = Mockery::mock(PathsRepository::class);
+
+    $paths
+        ->shouldReceive('diff')
+        ->with('origin/main')
+        ->once()
+        ->andReturn([
+            base_path('tests/Fixtures/without-issues-laravel/file.php'),
+        ]);
+
+    $this->swap(PathsRepository::class, $paths);
+
+    [$statusCode, $output] = run('default', [
+        '--diff' => 'origin/main',
+    ]);
+
+    expect($statusCode)->toBe(0)
+        ->and($output)
+        ->toContain('── Laravel', ' 1 file');
+});


### PR DESCRIPTION
This PR is how I've always _wished_ the `--dirty` flag worked.

`pint --dirty` will lint _staged_ and _unstaged_ files (and possibly _untracked_?). But once a file is _committed_, it will not be touched again by `pint --dirty`, whether or not it passes. The only time it will be linted is when we run pint on the **whole** project again.

This _also_ means that running `pint --dirty` in CI is pointless, since all the files have already been *committed*, meaning we'll lint **nothing**. But running Pint without any flags can take upto **five minutes** in a large project, and that feedback cycle **sucks**.

`pint --diff=main` will collect **all** committed, staged, unstaged, and untracked files that **differ from the provided branch**. Meaning that if we've got a PR that only touches 5 files, we can now run `pint --diff=main` in CI, and we're only going to look at those 5 files, saving **a ton** of time.

We can _also_ use this effectively locally. If your regular workflow is to create a branch from within a new issue, then check that branch out locally, your `main` branch might not be up to date with `origin`. Running `pint --diff=main` might not give you the results you'd expect then. However using `pint --diff=origin/main` can help speed up your feedback cycle dramatically.

> [!NOTE]
> I added a new method to the `PathsRepository` contract, which _could_ be considered a breaking change.
> Here's the commit to revert if you need to:
> 
> `git revert e295403a66c145e9b5530d3e5f9614875fc90162`