### PR TITLE
Add `no_unneeded_import_alias` rule

### DIFF
--- a/resources/presets/laravel.php
+++ b/resources/presets/laravel.php
@@ -127,6 +127,7 @@ return ConfigurationFactory::preset([
         'statements' => ['break', 'clone', 'continue', 'echo_print', 'return', 'switch_case', 'yield'],
     ],
     'no_unneeded_braces' => true,
+    'no_unneeded_import_alias' => true,
     'no_unreachable_default_argument_value' => true,
     'no_unset_cast' => true,
     'no_unused_imports' => true,


### PR DESCRIPTION
This PR serves as a QoL for PHPStorm users, as well as for situations where you might accidentally import a class as it's own name: https://cs.symfony.com/doc/rules/import/no_unneeded_import_alias.html

![CleanShot 2025-01-16 at 12 05 41](https://github.com/user-attachments/assets/3a12c893-b26c-4095-8b72-7905e3984f7a)
