### PR TITLE
Split files based on `/\R+/` regex for `--diff`, same as `--dirty`

### DIFF
--- a/app/Repositories/GitPathsRepository.php
+++ b/app/Repositories/GitPathsRepository.php
@@ -66,10 +66,8 @@ class GitPathsRepository implements PathsRepository
                 code: 1,
                 message: 'The [--diff] option is only available when using Git.',
             ))
-            ->map(fn ($process) => $process->getOutput())
-            ->map(fn ($output) => explode(PHP_EOL, $output))
+            ->map(fn ($process) => preg_split('/\R+/', $process->getOutput(), flags: PREG_SPLIT_NO_EMPTY))
             ->flatten()
-            ->filter()
             ->unique()
             ->values()
             ->map(fn ($s) => (string) $s);


### PR DESCRIPTION
- **Fix for #327**

`/\R+/` matches any type of line break, including:
- `\n` (LF - Unix/Linux)
- `\r\n` (CRLF - Windows)
- `\r` (CR - old macOS)
- Other uncommon variations

`PREG_SPLIT_NO_EMPTY`: Prevents empty elements in the result when consecutive line breaks are found

**NOTE:** Same as dirty
https://github.com/laravel/pint/blob/7afe4d284ef782dbbaf3c6a08d813ef8beab4e1f/app/Repositories/GitPathsRepository.php#L41