### PR TITLE
Fix GitHub Action failing 'Publish the released PHAR' due to deprecated action 'actions/upload-artifact'

### DIFF
--- a/.github/workflows/publish-phar.yml
+++ b/.github/workflows/publish-phar.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             GITHUB_REF=${{ github.event.inputs.tag }}
-          fi          
+          fi
           echo "tag=${GITHUB_REF##*v}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout the code
@@ -45,7 +45,7 @@ jobs:
         run: ./pint app:build pint.phar --build-version=${{ steps.tag.outputs.tag }}
 
       - name: Upload the PHAR artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pint.phar
           path: builds/pint.phar


### PR DESCRIPTION
Fixes #348 