### PR TITLE
Add the directories with the popular IDEs settings to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 /vendor
 composer.lock
 .phpunit.result.cache
+
+# IDEs
+/.fleet
+/.idea
+/.vscode


### PR DESCRIPTION
Most developers use some kind of IDE in their work, and these edits will allow you not to think about the fact that the IDE settings may accidentally get into the final diff of PR.