### PR TITLE
Feature allow configuration extension from a different base file

### DIFF
--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -109,7 +109,7 @@ class ConfigurationJsonRepository
     /**
      * Resolve the file to extend.
      *
-     * @param array<string, array<int, string>|string> $baseConfig
+     * @param  array<string, array<int, string>|string>  $baseConfig
      * @return array<string, array<int, string>|string>
      */
     private function resolveExtend(array $baseConfig)

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -2,8 +2,6 @@
 
 namespace App\Repositories;
 
-use Illuminate\Support\Collection;
-
 class ConfigurationJsonRepository
 {
     /**
@@ -126,5 +124,4 @@ class ConfigurationJsonRepository
 
         return array_replace_recursive($extended, $configuration);
     }
-
 }

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -119,7 +119,7 @@ class ConfigurationJsonRepository
         $extended = json_decode(file_get_contents($path), true);
 
         if (isset($extended['extend'])) {
-            throw new \LogicException('Configuration cannot extend from more than 1 config');
+            throw new \LogicException('Pint configuration cannot extend from more than 1 file.');
         }
 
         return array_replace_recursive($extended, $configuration);

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -105,6 +105,7 @@ class ConfigurationJsonRepository
             default => file_exists($path)
         };
     }
+
     /**
      * Resolve the file to extend.
      *
@@ -112,7 +113,7 @@ class ConfigurationJsonRepository
      */
     private function resolveExtend(array $baseConfig)
     {
-        $extended = json_decode(file_get_contents(realpath(dirname($this->path) . DIRECTORY_SEPARATOR . $baseConfig['extend'])), true);
+        $extended = json_decode(file_get_contents(realpath(dirname($this->path).DIRECTORY_SEPARATOR.$baseConfig['extend'])), true);
 
         if (isset($extended['extend'])) {
             throw new \LogicException('Configuration cannot extend from more than 1 config');

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -2,6 +2,8 @@
 
 namespace App\Repositories;
 
+use Illuminate\Support\Collection;
+
 class ConfigurationJsonRepository
 {
     /**
@@ -109,24 +111,20 @@ class ConfigurationJsonRepository
     /**
      * Resolve the file to extend.
      *
-     * @param  array<string, array<int, string>|string>  $baseConfig
+     * @param  array<string, array<int, string>|string>  $configuration
      * @return array<string, array<int, string>|string>
      */
-    private function resolveExtend(array $baseConfig)
+    private function resolveExtend(array $configuration)
     {
-        $extended = json_decode(file_get_contents(realpath(dirname($this->path).DIRECTORY_SEPARATOR.$baseConfig['extend'])), true);
+        $path = realpath(dirname($this->path).DIRECTORY_SEPARATOR.$configuration['extend']);
+
+        $extended = json_decode(file_get_contents($path), true);
 
         if (isset($extended['extend'])) {
             throw new \LogicException('Configuration cannot extend from more than 1 config');
         }
 
-        $baseConfig = array_merge(
-            $extended,
-            $baseConfig,
-        );
-
-        unset($baseConfig['extend']);
-
-        return $baseConfig;
+        return array_replace_recursive($extended, $configuration);
     }
+
 }

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -109,7 +109,8 @@ class ConfigurationJsonRepository
     /**
      * Resolve the file to extend.
      *
-     * @return array
+     * @param array<string, array<int, string>|string> $baseConfig
+     * @return array<string, array<int, string>|string>
      */
     private function resolveExtend(array $baseConfig)
     {

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -106,7 +106,7 @@ class ConfigurationJsonRepository
         };
     }
     /**
-     * Resolve the file the extent.
+     * Resolve the file to extend.
      *
      * @return array
      */

--- a/tests/Fixtures/extend/base.json
+++ b/tests/Fixtures/extend/base.json
@@ -1,6 +1,15 @@
 {
     "preset": "psr12",
-    "exclude": [
-        "my-dir"
-    ]
+    "rules": {
+        "array_push": true,
+        "backtick_to_shell_exec": true,
+        "date_time_immutable": true,
+        "final_internal_class": true,
+        "final_public_method_for_abstract_class": true,
+        "fully_qualified_strict_types": true,
+        "global_namespace_import": {
+            "import_classes": true,
+            "import_constants": true
+        }
+    }
 }

--- a/tests/Fixtures/extend/base.json
+++ b/tests/Fixtures/extend/base.json
@@ -1,0 +1,6 @@
+{
+    "preset": "psr12",
+    "exclude": [
+        "my-dir"
+    ]
+}

--- a/tests/Fixtures/extend/pint.json
+++ b/tests/Fixtures/extend/pint.json
@@ -1,0 +1,4 @@
+{
+    "extend": "./base.json",
+    "preset": "laravel"
+}

--- a/tests/Fixtures/extend/pint.json
+++ b/tests/Fixtures/extend/pint.json
@@ -1,4 +1,14 @@
 {
     "extend": "./base.json",
-    "preset": "laravel"
+    "preset": "laravel",
+    "rules": {
+        "declare_strict_types": true,
+        "lowercase_keywords": true,
+        "lowercase_static_reference": true,
+        "final_class": true,
+        "fully_qualified_strict_types": false,
+        "global_namespace_import": {
+            "import_functions": true
+        }
+    }
 }

--- a/tests/Fixtures/extend_recursive/base.json
+++ b/tests/Fixtures/extend_recursive/base.json
@@ -1,0 +1,3 @@
+{
+    "extend": "./config.json"
+}

--- a/tests/Fixtures/extend_recursive/config.json
+++ b/tests/Fixtures/extend_recursive/config.json
@@ -1,0 +1,3 @@
+{
+    "preset": "laravel"
+}

--- a/tests/Fixtures/extend_recursive/pint.json
+++ b/tests/Fixtures/extend_recursive/pint.json
@@ -1,0 +1,3 @@
+{
+    "extend": "./base.json"
+}

--- a/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
+++ b/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
@@ -52,6 +52,6 @@ it('properly extend the base config file', function () {
 
     expect($repository->preset())->toBe('laravel')
         ->and($repository->finder()['exclude'])->toBe([
-            "my-dir"
+            'my-dir',
         ]);
 });

--- a/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
+++ b/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
@@ -46,3 +46,12 @@ it('may have a preset option', function () {
 
     expect($repository->preset())->toBe('laravel');
 });
+
+it('properly extend the base config file', function () {
+    $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/extend/pint.json', null);
+
+    expect($repository->preset())->toBe('laravel')
+        ->and($repository->finder()['exclude'])->toBe([
+            "my-dir"
+        ]);
+});

--- a/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
+++ b/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
@@ -51,7 +51,27 @@ it('properly extend the base config file', function () {
     $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/extend/pint.json', null);
 
     expect($repository->preset())->toBe('laravel')
-        ->and($repository->finder()['exclude'])->toBe([
-            'my-dir',
+        ->and($repository->rules())->toBe([
+            'array_push' => true,
+            'backtick_to_shell_exec' => true,
+            'date_time_immutable' => true,
+            'final_internal_class' => true,
+            'final_public_method_for_abstract_class' => true,
+            'fully_qualified_strict_types' => false,
+            'global_namespace_import' => [
+                'import_classes' => true,
+                'import_constants' => true,
+                'import_functions' => true,
+            ],
+            'declare_strict_types' => true,
+            'lowercase_keywords' => true,
+            'lowercase_static_reference' => true,
+            'final_class' => true,
         ]);
 });
+
+it('throw an error if the extended configuration also has an extend', function () {
+    $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/extend_recursive/pint.json', null);
+
+    $repository->finder();
+})->throws(LogicException::class);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I have a use case where my company uses a global pint config, this work fine if the config doesn't need to change per project, but if we need to have project specific configuration, it becomes impossible to have them isolated.

It partially solves #174 

I purposefully chose to only allow 1 extend to avoid recursion issues (though it could be fixed through a fixed set of extent)
