### PR TITLE
Add shortcut for parallel linting

### DIFF
--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -47,7 +47,7 @@ class DefaultCommand extends Command
                     new InputOption('output-to-file', '', InputOption::VALUE_REQUIRED, 'Output the test results to a file at this path'),
                     new InputOption('output-format', '', InputOption::VALUE_REQUIRED, 'The format that should be used when outputting the test results to a file'),
                     new InputOption('cache-file', '', InputArgument::OPTIONAL, 'The path to the cache file'),
-                    new InputOption('parallel', '', InputOption::VALUE_NONE, 'Runs the linter in parallel (Experimental)'),
+                    new InputOption('parallel', 'p', InputOption::VALUE_NONE, 'Runs the linter in parallel (Experimental)'),
                 ],
             );
     }


### PR DESCRIPTION
Totally understand if it's too early to add this for an experimental feature.

I use Laravel's parallel testing and am so used to the `-p` shortcut, so would be nice to have the consistency and save the keystrokes when running pint.

```sh
pint -p
artisan test -p
```