### PR TITLE
feat: add support for user-defined presets via composer

### DIFF
--- a/app/Commands/PresetListCommand.php
+++ b/app/Commands/PresetListCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Commands;
+
+use App\Services\PresetManifest;
+use LaravelZero\Framework\Commands\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand('preset:list', 'List all available presets')]
+class PresetListCommand extends Command
+{
+    public function handle(PresetManifest $presetManifest): int
+    {
+        $presets = $presetManifest->names();
+
+        if ($presets === []) {
+            $this->components->warn('No presets found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->newLine();
+        $this->components->twoColumnDetail(
+            '<fg=green;options=bold>Preset</>',
+            '<fg=yellow;options=bold>Path</>',
+        );
+
+        foreach ($presets as $preset) {
+            $path = $presetManifest->path($preset);
+            $presets[$preset] = $path;
+            $this->components->twoColumnDetail($preset, $path);
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Output/SummaryOutput.php
+++ b/app/Output/SummaryOutput.php
@@ -4,7 +4,9 @@ namespace App\Output;
 
 use App\Output\Concerns\InteractsWithSymbols;
 use App\Project;
+use App\Services\PresetManifest;
 use App\ValueObjects\Issue;
+use Illuminate\Support\Str;
 use PhpCsFixer\Runner\Event\FileProcessed;
 
 use function Termwind\render;
@@ -15,17 +17,21 @@ class SummaryOutput
     use InteractsWithSymbols;
 
     /**
-     * The list of presets, in a human-readable format.
+     * Get the list of presets in a human-readable format.
      *
-     * @var array<string, string>
+     * @return array<string, string>
      */
-    protected $presets = [
-        'per' => 'PER',
-        'psr12' => 'PSR 12',
-        'laravel' => 'Laravel',
-        'symfony' => 'Symfony',
-        'empty' => 'Empty',
-    ];
+    protected function getPresets(): array
+    {
+        $presetManifest = resolve(PresetManifest::class);
+        $presets = [];
+
+        foreach ($presetManifest->names() as $preset) {
+            $presets[$preset] = Str::headline($preset);
+        }
+
+        return [...$presets, 'per' => 'PER', 'psr12' => 'PSR 12'];
+    }
 
     /**
      * Creates a new Summary Output instance.
@@ -63,7 +69,7 @@ class SummaryOutput
                 'totalFiles' => $totalFiles,
                 'issues' => $issues,
                 'testing' => $summary->isDryRun(),
-                'preset' => $this->presets[$this->config->preset()],
+                'preset' => $this->getPresets()[$this->config->preset()] ?? $this->config->preset(),
             ]),
         );
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Services\PresetManifest;
 use Illuminate\Support\ServiceProvider;
 use PhpCsFixer\Error\ErrorsManager;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -31,6 +32,14 @@ class AppServiceProvider extends ServiceProvider
 
         $this->app->singleton(EventDispatcher::class, function () {
             return new EventDispatcher;
+        });
+
+        $this->app->singleton(PresetManifest::class, function ($app) {
+            return new PresetManifest(
+                $app->make('files'),
+                $app->basePath(),
+                $app->basePath('bootstrap/cache/pint_presets.php'),
+            );
         });
     }
 }

--- a/app/Services/PresetManifest.php
+++ b/app/Services/PresetManifest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+
+class PresetManifest
+{
+    /** @var ?array<string, string> */
+    protected ?array $manifest = null;
+
+    protected string $vendorPath;
+
+    public function __construct(
+        protected Filesystem $files,
+        protected string $basePath,
+        protected string $manifestPath,
+    ) {
+        $this->vendorPath = $this->basePath.'/vendor';
+    }
+
+    /**
+     * Get all available presets from packages.
+     *
+     * @return array<string, string> ['preset-name' => '/absolute/path/to/preset.php']
+     */
+    public function presets(): array
+    {
+        return $this->manifest ??= $this->getManifest();
+    }
+
+    /**
+     * Check if a preset exists.
+     */
+    public function has(string $preset): bool
+    {
+        return array_key_exists($preset, $this->presets());
+    }
+
+    /**
+     * Get the path for a specific preset.
+     */
+    public function path(string $preset): ?string
+    {
+        return $this->presets()[$preset] ?? null;
+    }
+
+    /**
+     * Get all preset names.
+     *
+     * @return list<string>
+     */
+    public function names(): array
+    {
+        return array_keys($this->presets());
+    }
+
+    /**
+     * Get the current preset manifest.
+     *
+     * @return array<string, string>
+     */
+    protected function getManifest(): array
+    {
+        $path = $this->vendorPath.'/composer/installed.json';
+
+        if (
+            ! $this->files->exists($this->manifestPath) ||
+            $this->files->lastModified($path) > $this->files->lastModified($this->manifestPath)
+        ) {
+            return $this->build();
+        }
+
+        return $this->files->getRequire($this->manifestPath);
+    }
+
+    /**
+     * Build the manifest and write it to disk.
+     *
+     * @return array<string, string>
+     */
+    protected function build(): array
+    {
+        $packages = [];
+        $installedPath = $this->vendorPath.'/composer/installed.json';
+        $composerPath = $this->basePath.'/composer.json';
+
+        if ($this->files->exists($installedPath)) {
+            $installed = json_decode($this->files->get($installedPath), true);
+            $packages = $installed['packages'] ?? $installed;
+        }
+
+        $presets = (new Collection($packages))
+            ->keyBy(fn ($package) => $this->vendorPath.'/'.$package['name'])
+            ->when($this->files->exists($composerPath), function ($presets) use ($composerPath) {
+                $composer = json_decode($this->files->get($composerPath), true);
+
+                return $presets->put($this->basePath, $composer);
+            })
+            ->map(fn ($package) => $package['extra']['laravel-pint']['presets'] ?? [])
+            ->flatMap(function (array $presets, string $basePath): array {
+                foreach ($presets as $name => $relativePath) {
+                    $absolutePath = $basePath.'/'.$relativePath;
+
+                    if ($this->files->exists($absolutePath)) {
+                        $presets[$name] = $absolutePath;
+                    } else {
+                        unset($presets[$name]);
+                    }
+                }
+
+                return $presets;
+            })
+            ->all();
+
+        $this->write($presets);
+
+        return $presets;
+    }
+
+    /**
+     * Write the given manifest array to disk.
+     *
+     * @param  array<string, string>  $manifest
+     */
+    protected function write(array $manifest): void
+    {
+        $this->files->ensureDirectoryExists(dirname($this->manifestPath), 0755, true);
+        $this->files->replace($this->manifestPath, '<?php return '.var_export($manifest, true).';');
+    }
+}

--- a/bootstrap/cache/.gitignore
+++ b/bootstrap/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,17 @@
             "pestphp/pest-plugin": true
         }
     },
+    "extra": {
+        "laravel-pint": {
+            "presets": {
+                "laravel": "resources/presets/laravel.php",
+                "per": "resources/presets/per.php",
+                "psr12": "resources/presets/psr12.php",
+                "symfony": "resources/presets/symfony.php",
+                "empty": "resources/presets/empty.php"
+            }
+        }
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "bin": ["builds/pint"]

--- a/tests/Feature/PresetDiscoveryTest.php
+++ b/tests/Feature/PresetDiscoveryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Services\PresetManifest;
+
+it('can resolve preset paths', function () {
+    $presetManifest = resolve(PresetManifest::class);
+
+    expect($presetManifest->has('laravel'))->toBeTrue();
+    expect($presetManifest->path('laravel'))->toContain('resources/presets/laravel.php');
+
+    expect($presetManifest->has('nonexistent'))->toBeFalse();
+    expect($presetManifest->path('nonexistent'))->toBeNull();
+});
+
+it('can list available presets', function () {
+    $this->artisan('preset:list')
+        ->expectsOutputToContain('laravel')
+        ->expectsOutputToContain('per')
+        ->expectsOutputToContain('psr12')
+        ->expectsOutputToContain('symfony')
+        ->expectsOutputToContain('empty')
+        ->assertSuccessful();
+});

--- a/tests/Unit/Services/PresetManifestTest.php
+++ b/tests/Unit/Services/PresetManifestTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Services\PresetManifest;
+use Illuminate\Filesystem\Filesystem;
+
+it('can discover presets from composer packages', function () {
+    $files = Mockery::mock(Filesystem::class);
+
+    $files->shouldReceive('exists')
+        ->with('/test/path/bootstrap/cache/pint_presets.php')
+        ->andReturn(false);
+
+    $files->shouldReceive('exists')
+        ->with('/test/path/vendor/composer/installed.json')
+        ->andReturn(true);
+
+    $files->shouldReceive('lastModified')
+        ->with('/test/path/vendor/composer/installed.json')
+        ->andReturn(time());
+
+    $files->shouldReceive('get')
+        ->with('/test/path/vendor/composer/installed.json')
+        ->andReturn(json_encode([
+            'packages' => [
+                [
+                    'name' => 'acme/pint-presets',
+                    'extra' => [
+                        'laravel-pint' => [
+                            'presets' => [
+                                'acme' => 'src/presets/acme.php',
+                                'acme-strict' => 'src/presets/strict.php',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+
+    $files->shouldReceive('exists')
+        ->with('/test/path/composer.json')
+        ->andReturn(false);
+
+    $files->shouldReceive('exists')
+        ->with('/test/path/vendor/acme/pint-presets/src/presets/acme.php')
+        ->andReturn(true);
+
+    $files->shouldReceive('exists')
+        ->with('/test/path/vendor/acme/pint-presets/src/presets/strict.php')
+        ->andReturn(true);
+
+    $files->shouldReceive('ensureDirectoryExists')
+        ->with('/test/path/bootstrap/cache', 0755, true);
+
+    $files->shouldReceive('replace')
+        ->with('/test/path/bootstrap/cache/pint_presets.php', Mockery::type('string'));
+
+    $manifest = new PresetManifest(
+        $files,
+        '/test/path',
+        '/test/path/bootstrap/cache/pint_presets.php',
+    );
+
+    expect($manifest->has('acme'))->toBeTrue();
+    expect($manifest->has('acme-strict'))->toBeTrue();
+    expect($manifest->path('acme'))->toBe('/test/path/vendor/acme/pint-presets/src/presets/acme.php');
+});
+
+it('handles missing composer installed.json gracefully', function () {
+    $files = Mockery::mock(Filesystem::class);
+
+    $files->shouldReceive('exists')
+        ->with('/test/path/bootstrap/cache/pint_presets.php')
+        ->andReturn(false);
+
+    $files->shouldReceive('exists')
+        ->with('/test/path/vendor/composer/installed.json')
+        ->andReturn(false);
+
+    $files->shouldReceive('exists')
+        ->with('/test/path/composer.json')
+        ->andReturn(false);
+
+    $files->shouldReceive('ensureDirectoryExists')
+        ->with('/test/path/bootstrap/cache', 0755, true);
+
+    $files->shouldReceive('replace')
+        ->with('/test/path/bootstrap/cache/pint_presets.php', "<?php return array (\n);");
+
+    $manifest = new PresetManifest(
+        $files,
+        '/test/path',
+        '/test/path/bootstrap/cache/pint_presets.php',
+    );
+
+    expect($manifest->names())->toBeEmpty();
+});


### PR DESCRIPTION
Hello!

This allows users to create and distribute custom presets through composer packages, enabling better code style sharing across projects. I also updated pint to use the new preset manifest system so there's a unified method of registering presets.

Presets are added in the composer `extra` section like so:
```json
    "extra": {
        "laravel-pint": {
            "presets": {
                "laravel": "resources/presets/laravel.php",
                "per": "resources/presets/per.php",
                "psr12": "resources/presets/psr12.php",
                "symfony": "resources/presets/symfony.php",
                "empty": "resources/presets/empty.php"
            }
        }
    },
```

> [!NOTE]
> I'm aware that it's possible to pass a custom config file like `./vendor/bin/pint --config vendor/my-company/coding-style/pint.json`, however, it's much nicer to be able to simple define a custom company preset which then is referenced in all pint configs





This also adds a new `preset:list` command to show all available presets:

<img width="3004" height="337" alt="image" src="https://github.com/user-attachments/assets/51469f62-ffb6-4fb2-8eb0-c5a046f3eb16" />

Thanks!