### PR TITLE
feat: add support for formatting code from stdin

### DIFF
--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -2,9 +2,11 @@
 
 namespace App\Commands;
 
+use App\Actions\FixCode;
 use LaravelZero\Framework\Commands\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
+use Throwable;
 
 class DefaultCommand extends Command
 {
@@ -61,8 +63,60 @@ class DefaultCommand extends Command
      */
     public function handle($fixCode, $elaborateSummary)
     {
+        if ($this->hasStdinInput()) {
+            return $this->handleStdin($fixCode);
+        }
+
         [$totalFiles, $changes] = $fixCode->execute();
 
         return $elaborateSummary->execute($totalFiles, $changes);
+    }
+
+    /**
+     * Check if there is input available on stdin.
+     */
+    protected function hasStdinInput(): bool
+    {
+        // If we are testing, bailing, or repairing, then there is no input available
+        if ($this->option('test') || $this->option('bail') || $this->option('repair')) {
+            return false;
+        }
+
+        // If stdin is a TTY, then there's no input available
+        if (! is_resource(STDIN) || stream_isatty(STDIN)) {
+            return false;
+        }
+
+        // If stdin is not a TTY, then check if there's data available
+        return ! stream_get_meta_data(STDIN)['eof'];
+    }
+
+    /**
+     * Handle stdin input and output to stdout.
+     */
+    protected function handleStdin(FixCode $fixCode): int
+    {
+        $paths = $this->argument('path');
+        $contextPath = ! empty($paths) ? $paths[0] : 'stdin.php';
+        $tempFile = sys_get_temp_dir().DIRECTORY_SEPARATOR.'pint_stdin_'.uniqid().'.php';
+
+        $this->input->setArgument('path', [$tempFile]);
+        $this->input->setOption('format', 'json');
+
+        try {
+            file_put_contents($tempFile, stream_get_contents(STDIN));
+            $fixCode->execute();
+            fwrite(STDOUT, file_get_contents($tempFile));
+
+            return self::SUCCESS;
+        } catch (Throwable $e) {
+            fwrite(STDERR, "pint: error processing {$contextPath}: {$e->getMessage()}\n");
+
+            return self::FAILURE;
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
     }
 }

--- a/tests/Feature/StdinTest.php
+++ b/tests/Feature/StdinTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Support\Facades\Process;
+
+it('formats code from stdin', function (string $input, ?string $expected) {
+    $result = Process::input($input)->run('php pint app/Test.php')->throw();
+
+    expect($result)
+        ->output()->toBe($expected ?? $input)
+        ->errorOutput()->toBe('');
+})->with([
+    'basic array and conditional' => [
+        <<<'PHP'
+            <?php
+            $array = array("a","b");
+            if($condition==true){
+                echo "test";
+            }
+            PHP,
+        <<<'PHP'
+            <?php
+
+            $array = ['a', 'b'];
+            if ($condition == true) {
+                echo 'test';
+            }
+
+            PHP,
+    ],
+    'class with method' => [
+        <<<'PHP'
+            <?php
+            class Test{
+            public function method(){
+            return array("key"=>"value");
+            }
+            }
+            PHP,
+        <<<'PHP'
+            <?php
+
+            class Test
+            {
+                public function method()
+                {
+                    return ['key' => 'value'];
+                }
+            }
+
+            PHP,
+    ],
+    'already formatted code' => [
+        <<<'PHP'
+            <?php
+
+            class AlreadyFormatted
+            {
+                public function method()
+                {
+                    return ['key' => 'value'];
+                }
+            }
+
+            PHP,
+        null,
+    ],
+]);


### PR DESCRIPTION
Hello!

Resolves https://github.com/laravel/pint/issues/262, resolves https://github.com/laravel/pint/issues/162

There's tools and editors (e.g., zed, https://jj-vcs.github.io/jj/latest/cli-reference/#jj-fix) that can integrate with formatters if the formatter accepts input on stdin and outputs the changes on stdout. This PR adds that functionality to pint

CC: @TheBlckbird, @bilogic, @serbanrobu, @gabrielbidula

Thanks!