### PR TITLE
Allow setting the number of max processes for parallel mode

### DIFF
--- a/app/Actions/FixCode.php
+++ b/app/Actions/FixCode.php
@@ -71,7 +71,27 @@ class FixCode
     }
 
     /**
-     * Gets the input for the PHP CS Fixer Runner.
+     * Get the ParallelConfig for the number of cores.
+     */
+    private function getParallelConfig(ConfigurationResolver $resolver): ParallelConfig
+    {
+        $maxProcesses = intval($this->input->getOption('max-processes') ?? 0);
+
+        if (! $this->input->getOption('parallel') || $maxProcesses < 1) {
+            return $resolver->getParallelConfig();
+        }
+
+        $parallelConfig = $resolver->getParallelConfig();
+
+        return new ParallelConfig(
+            $maxProcesses,
+            $parallelConfig->getFilesPerProcess(),
+            $parallelConfig->getProcessTimeout()
+        );
+    }
+
+    /**
+     * Get the input for the PHP CS Fixer Runner.
      */
     private function getInput(ConfigurationResolver $resolver): InputInterface
     {
@@ -91,25 +111,5 @@ class FixCode
         $this->input->setOption('using-cache', $resolver->getUsingCache() ? 'yes' : 'no');
 
         return $this->input;
-    }
-
-    /**
-     * Get the ParallelConfig for the number of cores.
-     */
-    private function getParallelConfig(ConfigurationResolver $resolver): ParallelConfig
-    {
-        $maxProcesses = intval($this->input->getOption('max-processes') ?? 0);
-
-        if (! $this->input->getOption('parallel') || $maxProcesses < 1) {
-            return $resolver->getParallelConfig();
-        }
-
-        $parallelConfig = $resolver->getParallelConfig();
-
-        return new ParallelConfig(
-            $maxProcesses,
-            $parallelConfig->getFilesPerProcess(),
-            $parallelConfig->getProcessTimeout()
-        );
     }
 }

--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -50,7 +50,7 @@ class DefaultCommand extends Command
                     new InputOption('output-format', '', InputOption::VALUE_REQUIRED, 'The format that should be used when outputting the test results to a file'),
                     new InputOption('cache-file', '', InputArgument::OPTIONAL, 'The path to the cache file'),
                     new InputOption('parallel', 'p', InputOption::VALUE_NONE, 'Runs the linter in parallel (Experimental)'),
-                    new InputOption('max-processes', null, InputOption::VALUE_REQUIRED, 'Number of processes to spawn (for parallel execution)'),
+                    new InputOption('max-processes', null, InputOption::VALUE_REQUIRED, 'The number of processes to spawn when using parallel execution'),
                 ],
             );
     }


### PR DESCRIPTION
The parallel option is great!

However, the CpuCoreCounter has bitten our team in the past, as parallel processes attempt to work all of the cores on a Kubernetes cluster rather than just the cores assigned to the node.

Adding a new `max-processes` flag will let us run our pipelines with confidence that we'll always use a predefined number of cores.

Edit: Upon some deeper inspection, it looks like this can be set via `KUBERNETES_CPU_LIMIT=4 vendor/bin/pint` but this doesn't feel particularly eloquent.