### PR TITLE
Add conflict with php-cs-fixer v3.87.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
         "nunomaduro/termwind": "^2.3.1",
         "pestphp/pest": "^2.36.0"
     },
+    "conflict": {
+        "friendsofphp/php-cs-fixer": ">=3.87.0"
+    },
     "autoload": {
         "psr-4": {
             "App\\": "app/",


### PR DESCRIPTION
Overridden ProcessFactory changed it's definition, which breaks usage of php-cs-fixer directly when laravel/pint is installed.

https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/compare/v3.86.0...v3.87.0#diff-f946f92099e10961fb873c18a7f366301693d1c7d92cbbc8b4d9fdf8aa7862d6