### PR TITLE
Prompt users to use --dev flag for development-only packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "laravel/pint",
     "description": "An opinionated code formatter for PHP.",
-    "keywords": ["php", "format", "formatter", "lint", "linter"],
+    "keywords": ["php", "format", "formatter", "lint", "linter", "dev"],
     "homepage": "https://laravel.com",
     "type": "project",
     "license": "MIT",


### PR DESCRIPTION
This PR introduces a mechanism to significantly improve the developer experience by guiding users to correctly place development-only dependencies into the require-dev block. When a package is internally tagged with the new "dev" keyword, and a user attempts to install it using composer require without the --dev flag, Composer will now intelligently prompt them:
```
The package you required is recommended to be placed in require-dev (because it is tagged as "testing") but you did not use --dev.
Do you want to re-run the command with --dev? [yes]?
```