### PR TITLE
Revert "feat: support boolean shorthand for 'cast_spaces' and add tests"

### DIFF
--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -83,10 +83,6 @@ class ConfigurationJsonRepository
                 $baseConfig = $this->resolveExtend($baseConfig);
             }
 
-            if (isset($baseConfig['rules'])) {
-                $baseConfig['rules'] = $this->normalizeRuleValues($baseConfig['rules']);
-            }
-
             return tap($baseConfig, function ($configuration) {
                 if (! is_array($configuration)) {
                     abort(1, sprintf('The configuration file [%s] is not valid JSON.', $this->path));
@@ -95,25 +91,6 @@ class ConfigurationJsonRepository
         }
 
         return [];
-    }
-
-    /**
-     * Normalize shorthand rule values into explicit configuration arrays as expected by PHP-CS-Fixer.
-     *
-     * @param  array<string, mixed>  $rules
-     * @return array<string, mixed>
-     */
-    protected function normalizeRuleValues(array $rules): array
-    {
-        if (array_key_exists('cast_spaces', $rules)) {
-            $rules['cast_spaces'] = match ($rules['cast_spaces']) {
-                false => ['space' => 'none'],
-                true => ['space' => 'single'],
-                default => $rules['cast_spaces'],
-            };
-        }
-
-        return $rules;
     }
 
     /**

--- a/tests/Fixtures/rules/pint_cast_spaces_array.json
+++ b/tests/Fixtures/rules/pint_cast_spaces_array.json
@@ -1,7 +1,0 @@
-{
-    "rules": {
-        "cast_spaces": {
-            "space": "single"
-        }
-    }
-}

--- a/tests/Fixtures/rules/pint_cast_spaces_false.json
+++ b/tests/Fixtures/rules/pint_cast_spaces_false.json
@@ -1,5 +1,0 @@
-{
-    "rules": {
-        "cast_spaces": false
-    }
-}

--- a/tests/Fixtures/rules/pint_cast_spaces_true.json
+++ b/tests/Fixtures/rules/pint_cast_spaces_true.json
@@ -1,5 +1,0 @@
-{
-    "rules": {
-        "cast_spaces": true
-    }
-}

--- a/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
+++ b/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
@@ -75,27 +75,3 @@ it('throw an error if the extended configuration also has an extend', function (
 
     $repository->finder();
 })->throws(LogicException::class);
-
-it('normalizes cast_spaces false to none', function () {
-    $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/rules/pint_cast_spaces_false.json', null);
-
-    expect($repository->rules())->toBe([
-        'cast_spaces' => ['space' => 'none'],
-    ]);
-});
-
-it('normalizes cast_spaces true to single', function () {
-    $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/rules/pint_cast_spaces_true.json', null);
-
-    expect($repository->rules())->toBe([
-        'cast_spaces' => ['space' => 'single'],
-    ]);
-});
-
-it('preserves explicit cast_spaces array', function () {
-    $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/rules/pint_cast_spaces_array.json', null);
-
-    expect($repository->rules())->toBe([
-        'cast_spaces' => ['space' => 'single'],
-    ]);
-});


### PR DESCRIPTION
This PR reverts a recent addition via PR #398 for two reasons:

1. It breaks the ability to disable the `cast_spaces` rule.
2. It was an attempt to address issue #397, but there actually isn't an issue there; it is a misunderstanding of how to configure the rules.

### Background

Setting a rule value to `true` enables a rule. For a rule with configuration options, this enables the rule with the default configuration options.

Setting a rule value to `false` is the way to disable a rule. This is not the same as enabling a rule with an "opposite" configuration. Disabling a rule will ensure the rule is not applied at all.

This is how you can disable a rule provided by a preset. For example, if you want to use everything provided by the `laravel` preset, with the exception of the `cast_spaces` rule, you would enable the `laravel` preset and add `"cast_spaces": false` to your `rules` to disable the rule.

### The Issue

With the addition of #398, setting the value of `cast_spaces` to `false` no longer disables the rule, but it enables it with a specific configuration. Instead of disabling the rule so that the rule isn't applied at all, it now enables the rule with the configuration of `['space' => 'none']` instead of the default `['space' => 'single']`.

### Resolution

This PR reverts the change so the `cast_spaces` rule can be disabled again. For issue #397, they just need to enable the rule with their desired configuration.