### PR TITLE
Fix passing --parallel option alongside --config

### DIFF
--- a/app/Actions/FixCode.php
+++ b/app/Actions/FixCode.php
@@ -110,7 +110,7 @@ class FixCode
         $this->input->setOption('rules', json_encode($resolver->getRules()));
         $this->input->setOption('using-cache', $resolver->getUsingCache() ? 'yes' : 'no');
 
-        // remove config option so that it doesn't get passed to php-cs-fixer
+        // Remove config option so it doesn't get passed to php-cs-fixer...
         $this->input->setOption('config', null);
 
         return $this->input;


### PR DESCRIPTION
When using --config option alongside new --parallel option both gets passed to phpcsfixer and phpcsfixer doesn't allow that.

So this change removes config option, after pint has done passing it's own config file (that uses the same --config options as phpcsfixer).

The side effect of this change is that you no longer pass config option to phpcsfixer, but that is of no use anyway.
 
 fixes: https://github.com/laravel/pint/issues/377