### PR TITLE
Fix step numbering in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,6 @@
 ./pint app:build
 ```
 
-4. Commit all changes
-5. Push all commits to GitHub
-6. [Create a new GitHub release](https://github.com/laravel/pint/releases/new) with the release notes
+5. Commit all changes
+6. Push all commits to GitHub
+7. [Create a new GitHub release](https://github.com/laravel/pint/releases/new) with the release notes


### PR DESCRIPTION
Corrects duplicate step numbering in the release instructions. Steps 4 and 5 were both numbered "4", causing the remaining steps to be incorrectly numbered.

This is a documentation-only change with no impact on functionality.