### PR TITLE
feat: add `ignore_single_line_comments` option to `phpdoc_type_annotations_only` rule

### DIFF
--- a/app/Fixers/TypeAnnotationsOnlyFixer.php
+++ b/app/Fixers/TypeAnnotationsOnlyFixer.php
@@ -3,6 +3,11 @@
 namespace App\Fixers;
 
 use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\Fixer\ConfigurableFixerTrait;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
@@ -10,8 +15,13 @@ use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 
-class TypeAnnotationsOnlyFixer extends AbstractFixer
+/**
+ * @implements ConfigurableFixerInterface<array{ignore_single_line_comments?: bool}, array{ignore_single_line_comments: bool}>
+ */
+class TypeAnnotationsOnlyFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
+    /** @use ConfigurableFixerTrait<array{ignore_single_line_comments?: bool}, array{ignore_single_line_comments: bool}> */
+    use ConfigurableFixerTrait;
     /**
      * Get the name of the fixer.
      */
@@ -97,7 +107,32 @@ class TypeAnnotationsOnlyFixer extends AbstractFixer
             return;
         }
 
+        if ($this->configuration['ignore_single_line_comments'] && $this->isSingleLineComment($content)) {
+            return;
+        }
+
         $this->clearAndCleanWhitespace($tokens, $index);
+    }
+
+    /**
+     * Determine whether the comment content is a single-line comment.
+     */
+    private function isSingleLineComment(string $content): bool
+    {
+        return str_starts_with(ltrim($content), '//') || str_starts_with(ltrim($content), '#');
+    }
+
+    /**
+     * Create the configuration definition.
+     */
+    protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('ignore_single_line_comments', 'Whether single-line comments (`//` and `#`) should be preserved.'))
+                ->setAllowedTypes(['bool'])
+                ->setDefault(false)
+                ->getOption(),
+        ]);
     }
 
     /**

--- a/app/Fixers/TypeAnnotationsOnlyFixer.php
+++ b/app/Fixers/TypeAnnotationsOnlyFixer.php
@@ -22,6 +22,7 @@ class TypeAnnotationsOnlyFixer extends AbstractFixer implements ConfigurableFixe
 {
     /** @use ConfigurableFixerTrait<array{ignore_single_line_comments?: bool}, array{ignore_single_line_comments: bool}> */
     use ConfigurableFixerTrait;
+
     /**
      * Get the name of the fixer.
      */

--- a/tests/Feature/Fixers/PhpdocTypeAnnotationsOnlyFixerTest.php
+++ b/tests/Feature/Fixers/PhpdocTypeAnnotationsOnlyFixerTest.php
@@ -2031,3 +2031,225 @@ it('does not skip files outside the config directory', function (string $filePat
     'app/Configurable.php' => ['/project/app/Configurable.php'],
     'src/config.php' => ['/project/src/config.php'],
 ]);
+
+it('preserves single-line comments when ignore_single_line_comments is true', function (string $input, string $expected) {
+    $this->fixer->configure(['ignore_single_line_comments' => true]);
+    expect(fixCode($this->fixer, $input))->toBe($expected);
+})->with([
+    'double-slash comment is preserved' => [
+        <<<'PHP'
+        <?php
+
+        // This is a comment
+        $x = 1;
+        PHP,
+        <<<'PHP'
+        <?php
+
+        // This is a comment
+        $x = 1;
+        PHP,
+    ],
+    'hash comment is preserved' => [
+        <<<'PHP'
+        <?php
+
+        # This is a hash comment
+        $x = 1;
+        PHP,
+        <<<'PHP'
+        <?php
+
+        # This is a hash comment
+        $x = 1;
+        PHP,
+    ],
+    'trailing comment is preserved' => [
+        <<<'PHP'
+        <?php
+
+        $x = 1; // trailing comment
+        PHP,
+        <<<'PHP'
+        <?php
+
+        $x = 1; // trailing comment
+        PHP,
+    ],
+    'multiple sequential comments are preserved' => [
+        <<<'PHP'
+        <?php
+
+        // First comment
+        // Second comment
+        // Third comment
+        $x = 1;
+        PHP,
+        <<<'PHP'
+        <?php
+
+        // First comment
+        // Second comment
+        // Third comment
+        $x = 1;
+        PHP,
+    ],
+    'TODO comment is preserved' => [
+        <<<'PHP'
+        <?php
+
+        // TODO: refactor this
+        $x = 1;
+        PHP,
+        <<<'PHP'
+        <?php
+
+        // TODO: refactor this
+        $x = 1;
+        PHP,
+    ],
+    'block comment is still removed' => [
+        <<<'PHP'
+        <?php
+
+        /* This is a block comment */
+        $x = 1;
+        PHP,
+        <<<'PHP'
+        <?php
+
+        $x = 1;
+        PHP,
+    ],
+    'docblock without annotations is still removed' => [
+        <<<'PHP'
+        <?php
+
+        /**
+         * Just a description.
+         */
+        $x = 1;
+        PHP,
+        <<<'PHP'
+        <?php
+
+        $x = 1;
+        PHP,
+    ],
+    'docblock prose is still stripped keeping annotations' => [
+        <<<'PHP'
+        <?php
+
+        /**
+         * A helper.
+         *
+         * @param  int  $a
+         * @return int
+         */
+        function add($a) {}
+        PHP,
+        <<<'PHP'
+        <?php
+
+        /**
+         * @param  int  $a
+         * @return int
+         */
+        function add($a) {}
+        PHP,
+    ],
+    'body placeholder comment still works' => [
+        <<<'PHP'
+        <?php
+
+        class Foo
+        {
+            public function bar()
+            {
+                // Moved to a seeder...
+            }
+        }
+        PHP,
+        <<<'PHP'
+        <?php
+
+        class Foo
+        {
+            public function bar()
+            {
+                //
+            }
+        }
+        PHP,
+    ],
+    'section divider comments are preserved' => [
+        <<<'PHP'
+        <?php
+
+        class UserController extends Controller
+        {
+            // ==================
+            // Authentication
+            // ==================
+
+            public function login() {}
+
+            // ==================
+            // Profile
+            // ==================
+
+            public function profile() {}
+        }
+        PHP,
+        <<<'PHP'
+        <?php
+
+        class UserController extends Controller
+        {
+            // ==================
+            // Authentication
+            // ==================
+
+            public function login() {}
+
+            // ==================
+            // Profile
+            // ==================
+
+            public function profile() {}
+        }
+        PHP,
+    ],
+]);
+
+it('still removes single-line comments when ignore_single_line_comments is false', function (string $input, string $expected) {
+    $this->fixer->configure(['ignore_single_line_comments' => false]);
+    expect(fixCode($this->fixer, $input))->toBe($expected);
+})->with([
+    'double-slash comment is removed' => [
+        <<<'PHP'
+        <?php
+
+        // This is a comment
+        $x = 1;
+        PHP,
+        <<<'PHP'
+        <?php
+
+        $x = 1;
+        PHP,
+    ],
+    'hash comment is removed' => [
+        <<<'PHP'
+        <?php
+
+        # This is a hash comment
+        $x = 1;
+        PHP,
+        <<<'PHP'
+        <?php
+
+        $x = 1;
+        PHP,
+    ],
+]);


### PR DESCRIPTION
This PR adds a configurable `ignore_single_line_comments` option to the `Pint/phpdoc_type_annotations_only` fixer.

When enabled, single-line comments (`//` and `#`) are preserved instead of being removed, while block comments (`/* */`) and docblocks without annotations are still processed as before.

This is useful for teams that want to keep inline documentation and section dividers in their code but still strip prose from docblocks.

### Usage

```json
{
    "rules": {
        "Pint/phpdoc_type_annotations_only": {
            "ignore_single_line_comments": true
        }
    }
}
```

### Before (with `ignore_single_line_comments: true`)

```php
// Authentication routes
Route::post('/login', [AuthController::class, 'login']);

/**
 * Display a listing of users.
 *
 * @return \Illuminate\Http\JsonResponse
 */
public function index() {}
```

### After

```php
// Authentication routes
Route::post('/login', [AuthController::class, 'login']);

/**
 * @return \Illuminate\Http\JsonResponse
 */
public function index() {}
```

> Single-line comments stay, docblock prose is still stripped.

## Changes

- **`app/Fixers/TypeAnnotationsOnlyFixer.php`** — Implements `ConfigurableFixerInterface` with `ConfigurableFixerTrait`, adds `ignore_single_line_comments` boolean option (default: `false`)
- **`tests/Feature/Fixers/PhpdocTypeAnnotationsOnlyFixerTest.php`** — Adds 12 new test cases covering the option in both `true` and `false` modes

## Notes

- Default behavior is **unchanged** — `ignore_single_line_comments` defaults to `false`
- Body placeholder comments (`//` inside empty `{}`) are still handled correctly regardless of the setting
- Comments containing `@` annotations are always preserved regardless of the setting
