### PR TITLE
[1.x] adds `schema.json`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,3949 @@
+{
+    "$schema": "https://json-schema.org/draft-04/schema#",
+    "title": "Laravel Pint",
+    "type": "object",
+    "properties": {
+        "preset": {
+            "type": "string",
+            "description": "Preset that applies a group of rules to the formatting.",
+            "default": "laravel",
+            "oneOf": [
+                {
+                    "enum": ["empty", "laravel", "per", "psr12", "symfony"]
+                }
+            ]
+        },
+        "exclude": {
+            "type": "array",
+            "description": "List of folders to exclude.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "notName": {
+            "type": "array",
+            "description": "List of file name patterns to exclude.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "notPath": {
+            "type": "array",
+            "description": "List of exact file paths to exclude.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "cache-file": {
+            "type": "string",
+            "description": "The path to the cache file to use (defaults to a file in the temp folder used by PHP)."
+        },
+        "rules": {
+            "type": "object",
+            "description": "Customise rules used for the formatting, this replaces the ones of the preset",
+            "properties": {
+                "align_multiline_comment": {
+                    "description": "Each line of multi-line DocComments must have an asterisk [PSR-5] and must be aligned with the first one.",
+                    "type": "object",
+                    "properties": {
+                        "comment_type": {
+                            "description": "Whether to fix PHPDoc comments only (`phpdocs_only`), any multi-line comment whose lines all start with an asterisk (`phpdocs_like`) or any multi-line comment (`all_multiline`).",
+                            "default": "phpdocs_only",
+                            "enum": [
+                                "phpdocs_only",
+                                "phpdocs_like",
+                                "all_multiline"
+                            ]
+                        }
+                    }
+                },
+                "array_indentation": {
+                    "description": "Each element of an array must be indented exactly once."
+                },
+                "array_push": {
+                    "description": "Converts simple usages of `array_push($x, $y);` to `$x[] = $y;`."
+                },
+                "array_syntax": {
+                    "description": "PHP arrays should be declared using the configured syntax.",
+                    "type": "object",
+                    "properties": {
+                        "syntax": {
+                            "description": "Whether to use the `long` or `short` array syntax.",
+                            "default": "short",
+                            "enum": ["long", "short"]
+                        }
+                    }
+                },
+                "assign_null_coalescing_to_coalesce_equal": {
+                    "description": "Use the null coalescing assignment operator `??=` where possible."
+                },
+                "attribute_block_no_spaces": {
+                    "description": "Remove spaces before and after the attributes block."
+                },
+                "attribute_empty_parentheses": {
+                    "description": "PHP attributes declared without arguments must (not) be followed by empty parentheses.",
+                    "type": "object",
+                    "properties": {
+                        "use_parentheses": {
+                            "description": "Whether attributes should be followed by parentheses or not.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "backtick_to_shell_exec": {
+                    "description": "Converts backtick operators to `shell_exec` calls."
+                },
+                "binary_operator_spaces": {
+                    "description": "Binary operators should be surrounded by space as configured.",
+                    "type": "object",
+                    "properties": {
+                        "default": {
+                            "description": "Default fix strategy.",
+                            "default": "single_space",
+                            "enum": [
+                                "align",
+                                "align_by_scope",
+                                "align_single_space",
+                                "align_single_space_minimal",
+                                "align_single_space_by_scope",
+                                "align_single_space_minimal_by_scope",
+                                "single_space",
+                                "no_space",
+                                "at_least_single_space",
+                                null
+                            ]
+                        },
+                        "operators": {
+                            "description": "Dictionary of `binary operator` => `fix strategy` values that differ from the default strategy. Supported are: `=`, `*`, `/`, `%`, `<`, `>`, `|`, `^`, `+`, `-`, `&`, `&=`, `&&`, `||`, `.=`, `/=`, `=>`, `==`, `>=`, `===`, `!=`, `<>`, `!==`, `<=`, `and`, `or`, `xor`, `-=`, `%=`, `*=`, `|=`, `+=`, `<<`, `<<=`, `>>`, `>>=`, `^=`, `**`, `**=`, `<=>`, `??` and `??=`.",
+                            "default": {},
+                            "type": "object",
+                            "additionalProperties": {
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "blank_line_after_namespace": {
+                    "description": "There MUST be one blank line after the namespace declaration."
+                },
+                "blank_line_after_opening_tag": {
+                    "description": "Ensure there is no code on the same line as the PHP open tag and it is followed by a blank line."
+                },
+                "blank_line_before_statement": {
+                    "description": "An empty line feed must precede any configured statement.",
+                    "type": "object",
+                    "properties": {
+                        "statements": {
+                            "description": "List of statements which must be preceded by an empty line.",
+                            "default": [
+                                "break",
+                                "continue",
+                                "declare",
+                                "return",
+                                "throw",
+                                "try"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [
+                                [
+                                    "break",
+                                    "case",
+                                    "continue",
+                                    "declare",
+                                    "default",
+                                    "do",
+                                    "exit",
+                                    "for",
+                                    "foreach",
+                                    "goto",
+                                    "if",
+                                    "include",
+                                    "include_once",
+                                    "phpdoc",
+                                    "require",
+                                    "require_once",
+                                    "return",
+                                    "switch",
+                                    "throw",
+                                    "try",
+                                    "while",
+                                    "yield",
+                                    "yield_from"
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "blank_line_between_import_groups": {
+                    "description": "Putting blank lines between `use` statement groups."
+                },
+                "blank_lines_before_namespace": {
+                    "description": "Controls blank lines before a namespace declaration.",
+                    "type": "object",
+                    "properties": {
+                        "max_line_breaks": {
+                            "description": "Maximum line breaks that should exist before namespace declaration.",
+                            "default": 2,
+                            "type": "integer"
+                        },
+                        "min_line_breaks": {
+                            "description": "Minimum line breaks that should exist before namespace declaration.",
+                            "default": 2,
+                            "type": "integer"
+                        }
+                    }
+                },
+                "braces": {
+                    "description": "The body of each structure MUST be enclosed by braces. Braces should be properly placed. Body of braces should be properly indented.",
+                    "type": "object",
+                    "properties": {
+                        "allow_single_line_anonymous_class_with_empty_body": {
+                            "description": "Whether single line anonymous class with empty body notation should be allowed.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "allow_single_line_closure": {
+                            "description": "Whether single line lambda notation should be allowed.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "position_after_anonymous_constructs": {
+                            "description": "Whether the opening brace should be placed on \"next\" or \"same\" line after anonymous constructs (anonymous classes and lambda functions).",
+                            "default": "same",
+                            "enum": ["next", "same"]
+                        },
+                        "position_after_control_structures": {
+                            "description": "Whether the opening brace should be placed on \"next\" or \"same\" line after control structures.",
+                            "default": "same",
+                            "enum": ["next", "same"]
+                        },
+                        "position_after_functions_and_oop_constructs": {
+                            "description": "Whether the opening brace should be placed on \"next\" or \"same\" line after classy constructs (non-anonymous classes, interfaces, traits, methods and non-lambda functions).",
+                            "default": "next",
+                            "enum": ["next", "same"]
+                        }
+                    }
+                },
+                "braces_position": {
+                    "description": "Braces must be placed as configured.",
+                    "type": "object",
+                    "properties": {
+                        "allow_single_line_anonymous_functions": {
+                            "description": "Allow anonymous functions to have opening and closing braces on the same line.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "allow_single_line_empty_anonymous_classes": {
+                            "description": "Allow anonymous classes to have opening and closing braces on the same line.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "anonymous_classes_opening_brace": {
+                            "description": "The position of the opening brace of anonymous classes‘ body.",
+                            "default": "same_line",
+                            "enum": [
+                                "next_line_unless_newline_at_signature_end",
+                                "same_line"
+                            ]
+                        },
+                        "anonymous_functions_opening_brace": {
+                            "description": "The position of the opening brace of anonymous functions‘ body.",
+                            "default": "same_line",
+                            "enum": [
+                                "next_line_unless_newline_at_signature_end",
+                                "same_line"
+                            ]
+                        },
+                        "classes_opening_brace": {
+                            "description": "The position of the opening brace of classes‘ body.",
+                            "default": "next_line_unless_newline_at_signature_end",
+                            "enum": [
+                                "next_line_unless_newline_at_signature_end",
+                                "same_line"
+                            ]
+                        },
+                        "control_structures_opening_brace": {
+                            "description": "The position of the opening brace of control structures‘ body.",
+                            "default": "same_line",
+                            "enum": [
+                                "next_line_unless_newline_at_signature_end",
+                                "same_line"
+                            ]
+                        },
+                        "functions_opening_brace": {
+                            "description": "The position of the opening brace of functions‘ body.",
+                            "default": "next_line_unless_newline_at_signature_end",
+                            "enum": [
+                                "next_line_unless_newline_at_signature_end",
+                                "same_line"
+                            ]
+                        }
+                    }
+                },
+                "cast_spaces": {
+                    "description": "A single space or none should be between cast and variable.",
+                    "type": "object",
+                    "properties": {
+                        "space": {
+                            "description": "Spacing to apply between cast and variable.",
+                            "default": "single",
+                            "enum": ["none", "single"]
+                        }
+                    }
+                },
+                "class_attributes_separation": {
+                    "description": "Class, trait and interface elements must be separated with one or none blank line.",
+                    "type": "object",
+                    "properties": {
+                        "elements": {
+                            "description": "Dictionary of `const|method|property|trait_import|case` => `none|one|only_if_meta` values.",
+                            "default": {
+                                "const": "one",
+                                "method": "one",
+                                "property": "one",
+                                "trait_import": "none",
+                                "case": "none"
+                            },
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "class_definition": {
+                    "description": "Whitespace around the keywords of a class, trait, enum or interfaces definition should be one space.",
+                    "type": "object",
+                    "properties": {
+                        "inline_constructor_arguments": {
+                            "description": "Whether constructor argument list in anonymous classes should be single line.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "multi_line_extends_each_single_line": {
+                            "description": "Whether definitions should be multiline.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "single_item_single_line": {
+                            "description": "Whether definitions should be single line when including a single item.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "single_line": {
+                            "description": "Whether definitions should be single line.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "space_before_parenthesis": {
+                            "description": "Whether there should be a single space after the parenthesis of anonymous class (PSR12) or not.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "class_keyword": {
+                    "description": "Converts FQCN strings to `*::class` keywords."
+                },
+                "class_keyword_remove": {
+                    "description": "Converts `::class` keywords to FQCN strings."
+                },
+                "class_reference_name_casing": {
+                    "description": "When referencing an internal class it must be written using the correct casing."
+                },
+                "clean_namespace": {
+                    "description": "Namespace must not contain spacing, comments or PHPDoc."
+                },
+                "combine_consecutive_issets": {
+                    "description": "Using `isset($var) &&` multiple times should be done in one call."
+                },
+                "combine_consecutive_unsets": {
+                    "description": "Calling `unset` on multiple items should be done in one call."
+                },
+                "combine_nested_dirname": {
+                    "description": "Replace multiple nested calls of `dirname` by only one call with second `$level` parameter."
+                },
+                "comment_to_phpdoc": {
+                    "description": "Comments with annotation should be docblock when used on structural elements.",
+                    "type": "object",
+                    "properties": {
+                        "ignored_tags": {
+                            "description": "List of ignored tags.",
+                            "default": [],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "compact_nullable_type_declaration": {
+                    "description": "Remove extra spaces in a nullable type declaration."
+                },
+                "compact_nullable_typehint": {
+                    "description": "Remove extra spaces in a nullable typehint."
+                },
+                "concat_space": {
+                    "description": "Concatenation should be spaced according to configuration.",
+                    "type": "object",
+                    "properties": {
+                        "spacing": {
+                            "description": "Spacing to apply around concatenation operator.",
+                            "default": "none",
+                            "enum": ["one", "none"]
+                        }
+                    }
+                },
+                "constant_case": {
+                    "description": "The PHP constants `true`, `false`, and `null` MUST be written using the correct casing.",
+                    "type": "object",
+                    "properties": {
+                        "case": {
+                            "description": "Whether to use the `upper` or `lower` case syntax.",
+                            "default": "lower",
+                            "enum": ["upper", "lower"]
+                        }
+                    }
+                },
+                "control_structure_braces": {
+                    "description": "The body of each control structure MUST be enclosed within braces."
+                },
+                "control_structure_continuation_position": {
+                    "description": "Control structure continuation keyword must be on the configured line.",
+                    "type": "object",
+                    "properties": {
+                        "position": {
+                            "description": "The position of the keyword that continues the control structure.",
+                            "default": "same_line",
+                            "enum": ["next_line", "same_line"]
+                        }
+                    }
+                },
+                "curly_braces_position": {
+                    "description": "Curly braces must be placed as configured.",
+                    "type": "object",
+                    "properties": {
+                        "allow_single_line_anonymous_functions": {
+                            "description": "Allow anonymous functions to have opening and closing braces on the same line.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "allow_single_line_empty_anonymous_classes": {
+                            "description": "Allow anonymous classes to have opening and closing braces on the same line.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "anonymous_classes_opening_brace": {
+                            "description": "The position of the opening brace of anonymous classes‘ body.",
+                            "default": "same_line",
+                            "enum": [
+                                "next_line_unless_newline_at_signature_end",
+                                "same_line"
+                            ]
+                        },
+                        "anonymous_functions_opening_brace": {
+                            "description": "The position of the opening brace of anonymous functions‘ body.",
+                            "default": "same_line",
+                            "enum": [
+                                "next_line_unless_newline_at_signature_end",
+                                "same_line"
+                            ]
+                        },
+                        "classes_opening_brace": {
+                            "description": "The position of the opening brace of classes‘ body.",
+                            "default": "next_line_unless_newline_at_signature_end",
+                            "enum": [
+                                "next_line_unless_newline_at_signature_end",
+                                "same_line"
+                            ]
+                        },
+                        "control_structures_opening_brace": {
+                            "description": "The position of the opening brace of control structures‘ body.",
+                            "default": "same_line",
+                            "enum": [
+                                "next_line_unless_newline_at_signature_end",
+                                "same_line"
+                            ]
+                        },
+                        "functions_opening_brace": {
+                            "description": "The position of the opening brace of functions‘ body.",
+                            "default": "next_line_unless_newline_at_signature_end",
+                            "enum": [
+                                "next_line_unless_newline_at_signature_end",
+                                "same_line"
+                            ]
+                        }
+                    }
+                },
+                "date_time_create_from_format_call": {
+                    "description": "The first argument of `DateTime::createFromFormat` method must start with `!`."
+                },
+                "date_time_immutable": {
+                    "description": "Class `DateTimeImmutable` should be used instead of `DateTime`."
+                },
+                "declare_equal_normalize": {
+                    "description": "Equal sign in declare statement should be surrounded by spaces or not following configuration.",
+                    "type": "object",
+                    "properties": {
+                        "space": {
+                            "description": "Spacing to apply around the equal sign.",
+                            "default": "none",
+                            "enum": ["single", "none"]
+                        }
+                    }
+                },
+                "declare_parentheses": {
+                    "description": "There must not be spaces around `declare` statement parentheses."
+                },
+                "declare_strict_types": {
+                    "description": "Force strict types declaration in all files.",
+                    "type": "object",
+                    "properties": {
+                        "preserve_existing_declaration": {
+                            "description": "Whether existing strict_types=? should be preserved and not overridden.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "dir_constant": {
+                    "description": "Replaces `dirname(__FILE__)` expression with equivalent `__DIR__` constant."
+                },
+                "doctrine_annotation_array_assignment": {
+                    "description": "Doctrine annotations must use configured operator for assignment in arrays.",
+                    "type": "object",
+                    "properties": {
+                        "ignored_tags": {
+                            "description": "List of tags that must not be treated as Doctrine Annotations.",
+                            "default": [
+                                "abstract",
+                                "access",
+                                "code",
+                                "deprec",
+                                "encode",
+                                "exception",
+                                "final",
+                                "ingroup",
+                                "inheritdoc",
+                                "inheritDoc",
+                                "magic",
+                                "name",
+                                "toc",
+                                "tutorial",
+                                "private",
+                                "static",
+                                "staticvar",
+                                "staticVar",
+                                "throw",
+                                "api",
+                                "author",
+                                "category",
+                                "copyright",
+                                "deprecated",
+                                "example",
+                                "filesource",
+                                "global",
+                                "ignore",
+                                "internal",
+                                "license",
+                                "link",
+                                "method",
+                                "package",
+                                "param",
+                                "property",
+                                "property-read",
+                                "property-write",
+                                "return",
+                                "see",
+                                "since",
+                                "source",
+                                "subpackage",
+                                "throws",
+                                "todo",
+                                "TODO",
+                                "usedBy",
+                                "uses",
+                                "var",
+                                "version",
+                                "after",
+                                "afterClass",
+                                "backupGlobals",
+                                "backupStaticAttributes",
+                                "before",
+                                "beforeClass",
+                                "codeCoverageIgnore",
+                                "codeCoverageIgnoreStart",
+                                "codeCoverageIgnoreEnd",
+                                "covers",
+                                "coversDefaultClass",
+                                "coversNothing",
+                                "dataProvider",
+                                "depends",
+                                "expectedException",
+                                "expectedExceptionCode",
+                                "expectedExceptionMessage",
+                                "expectedExceptionMessageRegExp",
+                                "group",
+                                "large",
+                                "medium",
+                                "preserveGlobalState",
+                                "requires",
+                                "runTestsInSeparateProcesses",
+                                "runInSeparateProcess",
+                                "small",
+                                "test",
+                                "testdox",
+                                "ticket",
+                                "uses",
+                                "SuppressWarnings",
+                                "noinspection",
+                                "package_version",
+                                "enduml",
+                                "startuml",
+                                "psalm",
+                                "phpstan",
+                                "template",
+                                "fix",
+                                "FIXME",
+                                "fixme",
+                                "override"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "operator": {
+                            "description": "The operator to use.",
+                            "default": "=",
+                            "enum": ["=", ":"]
+                        }
+                    }
+                },
+                "doctrine_annotation_braces": {
+                    "description": "Doctrine annotations without arguments must use the configured syntax.",
+                    "type": "object",
+                    "properties": {
+                        "ignored_tags": {
+                            "description": "List of tags that must not be treated as Doctrine Annotations.",
+                            "default": [
+                                "abstract",
+                                "access",
+                                "code",
+                                "deprec",
+                                "encode",
+                                "exception",
+                                "final",
+                                "ingroup",
+                                "inheritdoc",
+                                "inheritDoc",
+                                "magic",
+                                "name",
+                                "toc",
+                                "tutorial",
+                                "private",
+                                "static",
+                                "staticvar",
+                                "staticVar",
+                                "throw",
+                                "api",
+                                "author",
+                                "category",
+                                "copyright",
+                                "deprecated",
+                                "example",
+                                "filesource",
+                                "global",
+                                "ignore",
+                                "internal",
+                                "license",
+                                "link",
+                                "method",
+                                "package",
+                                "param",
+                                "property",
+                                "property-read",
+                                "property-write",
+                                "return",
+                                "see",
+                                "since",
+                                "source",
+                                "subpackage",
+                                "throws",
+                                "todo",
+                                "TODO",
+                                "usedBy",
+                                "uses",
+                                "var",
+                                "version",
+                                "after",
+                                "afterClass",
+                                "backupGlobals",
+                                "backupStaticAttributes",
+                                "before",
+                                "beforeClass",
+                                "codeCoverageIgnore",
+                                "codeCoverageIgnoreStart",
+                                "codeCoverageIgnoreEnd",
+                                "covers",
+                                "coversDefaultClass",
+                                "coversNothing",
+                                "dataProvider",
+                                "depends",
+                                "expectedException",
+                                "expectedExceptionCode",
+                                "expectedExceptionMessage",
+                                "expectedExceptionMessageRegExp",
+                                "group",
+                                "large",
+                                "medium",
+                                "preserveGlobalState",
+                                "requires",
+                                "runTestsInSeparateProcesses",
+                                "runInSeparateProcess",
+                                "small",
+                                "test",
+                                "testdox",
+                                "ticket",
+                                "uses",
+                                "SuppressWarnings",
+                                "noinspection",
+                                "package_version",
+                                "enduml",
+                                "startuml",
+                                "psalm",
+                                "phpstan",
+                                "template",
+                                "fix",
+                                "FIXME",
+                                "fixme",
+                                "override"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "syntax": {
+                            "description": "Whether to add or remove braces.",
+                            "default": "without_braces",
+                            "enum": ["with_braces", "without_braces"]
+                        }
+                    }
+                },
+                "doctrine_annotation_indentation": {
+                    "description": "Doctrine annotations must be indented with four spaces.",
+                    "type": "object",
+                    "properties": {
+                        "ignored_tags": {
+                            "description": "List of tags that must not be treated as Doctrine Annotations.",
+                            "default": [
+                                "abstract",
+                                "access",
+                                "code",
+                                "deprec",
+                                "encode",
+                                "exception",
+                                "final",
+                                "ingroup",
+                                "inheritdoc",
+                                "inheritDoc",
+                                "magic",
+                                "name",
+                                "toc",
+                                "tutorial",
+                                "private",
+                                "static",
+                                "staticvar",
+                                "staticVar",
+                                "throw",
+                                "api",
+                                "author",
+                                "category",
+                                "copyright",
+                                "deprecated",
+                                "example",
+                                "filesource",
+                                "global",
+                                "ignore",
+                                "internal",
+                                "license",
+                                "link",
+                                "method",
+                                "package",
+                                "param",
+                                "property",
+                                "property-read",
+                                "property-write",
+                                "return",
+                                "see",
+                                "since",
+                                "source",
+                                "subpackage",
+                                "throws",
+                                "todo",
+                                "TODO",
+                                "usedBy",
+                                "uses",
+                                "var",
+                                "version",
+                                "after",
+                                "afterClass",
+                                "backupGlobals",
+                                "backupStaticAttributes",
+                                "before",
+                                "beforeClass",
+                                "codeCoverageIgnore",
+                                "codeCoverageIgnoreStart",
+                                "codeCoverageIgnoreEnd",
+                                "covers",
+                                "coversDefaultClass",
+                                "coversNothing",
+                                "dataProvider",
+                                "depends",
+                                "expectedException",
+                                "expectedExceptionCode",
+                                "expectedExceptionMessage",
+                                "expectedExceptionMessageRegExp",
+                                "group",
+                                "large",
+                                "medium",
+                                "preserveGlobalState",
+                                "requires",
+                                "runTestsInSeparateProcesses",
+                                "runInSeparateProcess",
+                                "small",
+                                "test",
+                                "testdox",
+                                "ticket",
+                                "uses",
+                                "SuppressWarnings",
+                                "noinspection",
+                                "package_version",
+                                "enduml",
+                                "startuml",
+                                "psalm",
+                                "phpstan",
+                                "template",
+                                "fix",
+                                "FIXME",
+                                "fixme",
+                                "override"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "indent_mixed_lines": {
+                            "description": "Whether to indent lines that have content before closing parenthesis.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "doctrine_annotation_spaces": {
+                    "description": "Fixes spaces in Doctrine annotations.",
+                    "type": "object",
+                    "properties": {
+                        "after_argument_assignments": {
+                            "description": "Whether to add, remove or ignore spaces after argument assignment operator.",
+                            "default": false,
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        },
+                        "after_array_assignments_colon": {
+                            "description": "Whether to add, remove or ignore spaces after array assignment `:` operator.",
+                            "default": true,
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        },
+                        "after_array_assignments_equals": {
+                            "description": "Whether to add, remove or ignore spaces after array assignment `=` operator.",
+                            "default": true,
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        },
+                        "around_commas": {
+                            "description": "Whether to fix spaces around commas.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "around_parentheses": {
+                            "description": "Whether to fix spaces around parentheses.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "before_argument_assignments": {
+                            "description": "Whether to add, remove or ignore spaces before argument assignment operator.",
+                            "default": false,
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        },
+                        "before_array_assignments_colon": {
+                            "description": "Whether to add, remove or ignore spaces before array `:` assignment operator.",
+                            "default": true,
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        },
+                        "before_array_assignments_equals": {
+                            "description": "Whether to add, remove or ignore spaces before array `=` assignment operator.",
+                            "default": true,
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        },
+                        "ignored_tags": {
+                            "description": "List of tags that must not be treated as Doctrine Annotations.",
+                            "default": [
+                                "abstract",
+                                "access",
+                                "code",
+                                "deprec",
+                                "encode",
+                                "exception",
+                                "final",
+                                "ingroup",
+                                "inheritdoc",
+                                "inheritDoc",
+                                "magic",
+                                "name",
+                                "toc",
+                                "tutorial",
+                                "private",
+                                "static",
+                                "staticvar",
+                                "staticVar",
+                                "throw",
+                                "api",
+                                "author",
+                                "category",
+                                "copyright",
+                                "deprecated",
+                                "example",
+                                "filesource",
+                                "global",
+                                "ignore",
+                                "internal",
+                                "license",
+                                "link",
+                                "method",
+                                "package",
+                                "param",
+                                "property",
+                                "property-read",
+                                "property-write",
+                                "return",
+                                "see",
+                                "since",
+                                "source",
+                                "subpackage",
+                                "throws",
+                                "todo",
+                                "TODO",
+                                "usedBy",
+                                "uses",
+                                "var",
+                                "version",
+                                "after",
+                                "afterClass",
+                                "backupGlobals",
+                                "backupStaticAttributes",
+                                "before",
+                                "beforeClass",
+                                "codeCoverageIgnore",
+                                "codeCoverageIgnoreStart",
+                                "codeCoverageIgnoreEnd",
+                                "covers",
+                                "coversDefaultClass",
+                                "coversNothing",
+                                "dataProvider",
+                                "depends",
+                                "expectedException",
+                                "expectedExceptionCode",
+                                "expectedExceptionMessage",
+                                "expectedExceptionMessageRegExp",
+                                "group",
+                                "large",
+                                "medium",
+                                "preserveGlobalState",
+                                "requires",
+                                "runTestsInSeparateProcesses",
+                                "runInSeparateProcess",
+                                "small",
+                                "test",
+                                "testdox",
+                                "ticket",
+                                "uses",
+                                "SuppressWarnings",
+                                "noinspection",
+                                "package_version",
+                                "enduml",
+                                "startuml",
+                                "psalm",
+                                "phpstan",
+                                "template",
+                                "fix",
+                                "FIXME",
+                                "fixme",
+                                "override"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "echo_tag_syntax": {
+                    "description": "Replaces short-echo `<?=` with long format `<?php echo`/`<?php print` syntax, or vice-versa.",
+                    "type": "object",
+                    "properties": {
+                        "format": {
+                            "description": "The desired language construct.",
+                            "default": "long",
+                            "enum": ["long", "short"]
+                        },
+                        "long_function": {
+                            "description": "The function to be used to expand the short echo tags.",
+                            "default": "echo",
+                            "enum": ["echo", "print"]
+                        },
+                        "shorten_simple_statements_only": {
+                            "description": "Render short-echo tags only in case of simple code.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "elseif": {
+                    "description": "The keyword `elseif` should be used instead of `else if` so that all control keywords look like single words."
+                },
+                "empty_loop_body": {
+                    "description": "Empty loop-body must be in configured style.",
+                    "type": "object",
+                    "properties": {
+                        "style": {
+                            "description": "Style of empty loop-bodies.",
+                            "default": "semicolon",
+                            "type": "string",
+                            "enum": ["braces", "semicolon"]
+                        }
+                    }
+                },
+                "empty_loop_condition": {
+                    "description": "Empty loop-condition must be in configured style.",
+                    "type": "object",
+                    "properties": {
+                        "style": {
+                            "description": "Style of empty loop-condition.",
+                            "default": "while",
+                            "type": "string",
+                            "enum": ["while", "for"]
+                        }
+                    }
+                },
+                "encoding": {
+                    "description": "PHP code MUST use only UTF-8 without BOM (remove BOM)."
+                },
+                "ereg_to_preg": {
+                    "description": "Replace deprecated `ereg` regular expression functions with `preg`."
+                },
+                "error_suppression": {
+                    "description": "Error control operator should be added to deprecation notices and/or removed from other cases.",
+                    "type": "object",
+                    "properties": {
+                        "mute_deprecation_error": {
+                            "description": "Whether to add `@` in deprecation notices.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "noise_remaining_usages": {
+                            "description": "Whether to remove `@` in remaining usages.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "noise_remaining_usages_exclude": {
+                            "description": "List of global functions to exclude from removing `@`.",
+                            "default": [],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "escape_implicit_backslashes": {
+                    "description": "Escape implicit backslashes in strings and heredocs to ease the understanding of which are special chars interpreted by PHP and which not.",
+                    "type": "object",
+                    "properties": {
+                        "double_quoted": {
+                            "description": "Whether to fix double-quoted strings.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "heredoc_syntax": {
+                            "description": "Whether to fix heredoc syntax.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "single_quoted": {
+                            "description": "Whether to fix single-quoted strings.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "explicit_indirect_variable": {
+                    "description": "Add curly braces to indirect variables to make them clear to understand."
+                },
+                "explicit_string_variable": {
+                    "description": "Converts implicit variables into explicit ones in double-quoted strings or heredoc syntax."
+                },
+                "final_class": {
+                    "description": "All classes must be final, except abstract ones and Doctrine entities."
+                },
+                "final_internal_class": {
+                    "description": "Internal classes should be `final`.",
+                    "type": "object",
+                    "properties": {
+                        "annotation_exclude": {
+                            "description": "Class level attribute or annotation tags that must be omitted to fix the class, even if all of the white list ones are used as well (case insensitive).",
+                            "default": [
+                                "@final",
+                                "@Entity",
+                                "@ORM\\Entity",
+                                "@ORM\\Mapping\\Entity",
+                                "@Mapping\\Entity",
+                                "@Document",
+                                "@ODM\\Document"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "annotation_include": {
+                            "description": "Class level attribute or annotation tags that must be set in order to fix the class (case insensitive).",
+                            "default": ["@internal"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "consider_absent_docblock_as_internal_class": {
+                            "description": "Whether classes without any DocBlock should be fixed to final.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "exclude": {
+                            "description": "Class level attribute or annotation tags that must be omitted to fix the class, even if all of the white list ones are used as well (case insensitive).",
+                            "default": [
+                                "final",
+                                "Entity",
+                                "ORM\\Entity",
+                                "ORM\\Mapping\\Entity",
+                                "Mapping\\Entity",
+                                "Document",
+                                "ODM\\Document"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "include": {
+                            "description": "Class level attribute or annotation tags that must be set in order to fix the class (case insensitive).",
+                            "default": ["internal"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "final_public_method_for_abstract_class": {
+                    "description": "All `public` methods of `abstract` classes should be `final`."
+                },
+                "fopen_flag_order": {
+                    "description": "Order the flags in `fopen` calls, `b` and `t` must be last."
+                },
+                "fopen_flags": {
+                    "description": "The flags in `fopen` calls must omit `t`, and `b` must be omitted or included consistently.",
+                    "type": "object",
+                    "properties": {
+                        "b_mode": {
+                            "description": "The `b` flag must be used (`true`) or omitted (`false`).",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "full_opening_tag": {
+                    "description": "PHP code must use the long `<?php` tags or short-echo `<?=` tags and not other tag variations."
+                },
+                "fully_qualified_strict_types": {
+                    "description": "Removes the leading part of fully qualified symbol references if a given symbol is imported or belongs to the current namespace.",
+                    "type": "object",
+                    "properties": {
+                        "import_symbols": {
+                            "description": "Whether FQCNs should be automatically imported.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "leading_backslash_in_global_namespace": {
+                            "description": "Whether FQCN is prefixed with backslash when that FQCN is used in global namespace context.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "phpdoc_tags": {
+                            "description": "Collection of PHPDoc annotation tags where FQCNs should be processed. As of now only simple tags with `@tag \\F\\Q\\C\\N` format are supported (no complex types).",
+                            "default": [
+                                "param",
+                                "phpstan-param",
+                                "phpstan-property",
+                                "phpstan-property-read",
+                                "phpstan-property-write",
+                                "phpstan-return",
+                                "phpstan-var",
+                                "property",
+                                "property-read",
+                                "property-write",
+                                "psalm-param",
+                                "psalm-property",
+                                "psalm-property-read",
+                                "psalm-property-write",
+                                "psalm-return",
+                                "psalm-var",
+                                "return",
+                                "see",
+                                "throws",
+                                "var"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "function_declaration": {
+                    "description": "Spaces should be properly placed in a function declaration.",
+                    "type": "object",
+                    "properties": {
+                        "closure_fn_spacing": {
+                            "description": "Spacing to use before open parenthesis for short arrow functions.",
+                            "default": "one",
+                            "enum": ["none", "one"]
+                        },
+                        "closure_function_spacing": {
+                            "description": "Spacing to use before open parenthesis for closures.",
+                            "default": "one",
+                            "enum": ["none", "one"]
+                        },
+                        "trailing_comma_single_line": {
+                            "description": "Whether trailing commas are allowed in single line signatures.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "function_to_constant": {
+                    "description": "Replace core functions calls returning constants with the constants.",
+                    "type": "object",
+                    "properties": {
+                        "functions": {
+                            "description": "List of function names to fix.",
+                            "default": [
+                                "get_called_class",
+                                "get_class",
+                                "get_class_this",
+                                "php_sapi_name",
+                                "phpversion",
+                                "pi"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [
+                                [
+                                    "get_called_class",
+                                    "get_class",
+                                    "get_class_this",
+                                    "php_sapi_name",
+                                    "phpversion",
+                                    "pi"
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "function_typehint_space": {
+                    "description": "Ensure single space between function's argument and its typehint."
+                },
+                "general_attribute_remove": {
+                    "description": "Removes configured attributes by their respective FQN.",
+                    "type": "object",
+                    "properties": {
+                        "attributes": {
+                            "description": "List of FQNs of attributes for removal.",
+                            "default": [],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "general_phpdoc_annotation_remove": {
+                    "description": "Removes configured annotations from PHPDoc.",
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "description": "List of annotations to remove, e.g. `[\"author\"]`.",
+                            "default": [],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "case_sensitive": {
+                            "description": "Should annotations be case sensitive.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "general_phpdoc_tag_rename": {
+                    "description": "Renames PHPDoc tags.",
+                    "type": "object",
+                    "properties": {
+                        "case_sensitive": {
+                            "description": "Whether tags should be replaced only if they have exact same casing.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "fix_annotation": {
+                            "description": "Whether annotation tags should be fixed.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "fix_inline": {
+                            "description": "Whether inline tags should be fixed.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "replacements": {
+                            "description": "A map of tags to replace.",
+                            "default": {},
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "get_class_to_class_keyword": {
+                    "description": "Replace `get_class` calls on object variables with class keyword syntax."
+                },
+                "global_namespace_import": {
+                    "description": "Imports or fully qualifies global classes/functions/constants.",
+                    "type": "object",
+                    "properties": {
+                        "import_classes": {
+                            "description": "Whether to import, not import or ignore global classes.",
+                            "default": true,
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        },
+                        "import_constants": {
+                            "description": "Whether to import, not import or ignore global constants.",
+                            "default": null,
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        },
+                        "import_functions": {
+                            "description": "Whether to import, not import or ignore global functions.",
+                            "default": null,
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "boolean"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "group_import": {
+                    "description": "There MUST be group use for the same namespaces.",
+                    "type": "object",
+                    "properties": {
+                        "group_types": {
+                            "description": "Defines the order of import types.",
+                            "default": ["classy", "functions", "constants"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "header_comment": {
+                    "description": "Add, replace or remove header comment.",
+                    "type": "object",
+                    "properties": {
+                        "comment_type": {
+                            "description": "Comment syntax type.",
+                            "default": "comment",
+                            "enum": ["PHPDoc", "comment"]
+                        },
+                        "header": {
+                            "description": "Proper header content.",
+                            "type": "string"
+                        },
+                        "location": {
+                            "description": "The location of the inserted header.",
+                            "default": "after_declare_strict",
+                            "enum": ["after_open", "after_declare_strict"]
+                        },
+                        "separate": {
+                            "description": "Whether the header should be separated from the file content with a new line.",
+                            "default": "both",
+                            "enum": ["both", "top", "bottom", "none"]
+                        },
+                        "validator": {
+                            "description": "RegEx validator for header content.",
+                            "default": null,
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "heredoc_closing_marker": {
+                    "description": "Unify `heredoc` or `nowdoc` closing marker.",
+                    "type": "object",
+                    "properties": {
+                        "closing_marker": {
+                            "description": "Preferred closing marker.",
+                            "default": "EOD",
+                            "type": "string"
+                        },
+                        "explicit_heredoc_style": {
+                            "description": "Whether the closing marker should be wrapped in double quotes.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "reserved_closing_markers": {
+                            "description": "Reserved closing markers to be kept unchanged.",
+                            "default": [
+                                "CSS",
+                                "DIFF",
+                                "HTML",
+                                "JS",
+                                "JSON",
+                                "MD",
+                                "PHP",
+                                "PYTHON",
+                                "RST",
+                                "TS",
+                                "SQL",
+                                "XML",
+                                "YAML"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "heredoc_indentation": {
+                    "description": "Heredoc/nowdoc content must be properly indented.",
+                    "type": "object",
+                    "properties": {
+                        "indentation": {
+                            "description": "Whether the indentation should be the same as in the start token line or one level more.",
+                            "default": "start_plus_one",
+                            "enum": ["start_plus_one", "same_as_start"]
+                        }
+                    }
+                },
+                "heredoc_to_nowdoc": {
+                    "description": "Convert `heredoc` to `nowdoc` where possible."
+                },
+                "implode_call": {
+                    "description": "Function `implode` must be called with 2 arguments in the documented order."
+                },
+                "include": {
+                    "description": "Include/Require and file path should be divided with a single space. File path should not be placed within parentheses."
+                },
+                "increment_style": {
+                    "description": "Pre- or post-increment and decrement operators should be used if possible.",
+                    "type": "object",
+                    "properties": {
+                        "style": {
+                            "description": "Whether to use pre- or post-increment and decrement operators.",
+                            "default": "pre",
+                            "enum": ["pre", "post"]
+                        }
+                    }
+                },
+                "indentation_type": {
+                    "description": "Code MUST use configured indentation type."
+                },
+                "integer_literal_case": {
+                    "description": "Integer literals must be in correct case."
+                },
+                "is_null": {
+                    "description": "Replaces `is_null($var)` expression with `null === $var`."
+                },
+                "lambda_not_used_import": {
+                    "description": "Lambda must not import variables it doesn't use."
+                },
+                "line_ending": {
+                    "description": "All PHP files must use same line ending."
+                },
+                "linebreak_after_opening_tag": {
+                    "description": "Ensure there is no code on the same line as the PHP open tag."
+                },
+                "list_syntax": {
+                    "description": "List (`array` destructuring) assignment should be declared using the configured syntax.",
+                    "type": "object",
+                    "properties": {
+                        "syntax": {
+                            "description": "Whether to use the `long` or `short` syntax for array destructuring.",
+                            "default": "short",
+                            "enum": ["long", "short"]
+                        }
+                    }
+                },
+                "logical_operators": {
+                    "description": "Use `&&` and `||` logical operators instead of `and` and `or`."
+                },
+                "long_to_shorthand_operator": {
+                    "description": "Shorthand notation for operators should be used if possible."
+                },
+                "lowercase_cast": {
+                    "description": "Cast should be written in lower case."
+                },
+                "lowercase_keywords": {
+                    "description": "PHP keywords MUST be in lower case."
+                },
+                "lowercase_static_reference": {
+                    "description": "Class static references `self`, `static` and `parent` MUST be in lower case."
+                },
+                "magic_constant_casing": {
+                    "description": "Magic constants should be referred to using the correct casing."
+                },
+                "magic_method_casing": {
+                    "description": "Magic method definitions and calls must be using the correct casing."
+                },
+                "mb_str_functions": {
+                    "description": "Replace non multibyte-safe functions with corresponding mb function."
+                },
+                "method_argument_space": {
+                    "description": "In method arguments and method call, there MUST NOT be a space before each comma and there MUST be one space after each comma. Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line.",
+                    "type": "object",
+                    "properties": {
+                        "after_heredoc": {
+                            "description": "Whether the whitespace between heredoc end and comma should be removed.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "attribute_placement": {
+                            "description": "Defines how to handle argument attributes when function definition is multiline.",
+                            "default": "standalone",
+                            "enum": ["ignore", "same_line", "standalone"]
+                        },
+                        "keep_multiple_spaces_after_comma": {
+                            "description": "Whether keep multiple spaces after comma.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "on_multiline": {
+                            "description": "Defines how to handle function arguments lists that contain newlines.",
+                            "default": "ensure_fully_multiline",
+                            "enum": [
+                                "ignore",
+                                "ensure_single_line",
+                                "ensure_fully_multiline"
+                            ]
+                        }
+                    }
+                },
+                "method_chaining_indentation": {
+                    "description": "Method chaining MUST be properly indented. Method chaining with different levels of indentation is not supported."
+                },
+                "modern_serialization_methods": {
+                    "description": "Use new serialization methods `__serialize` and `__unserialize` instead of deprecated ones `__sleep` and `__wakeup`."
+                },
+                "modernize_strpos": {
+                    "description": "Replace `strpos()` and `stripos()` calls with `str_starts_with()` or `str_contains()` if possible.",
+                    "type": "object",
+                    "properties": {
+                        "modernize_stripos": {
+                            "description": "Whether to modernize `stripos` calls as well.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "modernize_types_casting": {
+                    "description": "Replaces `intval`, `floatval`, `doubleval`, `strval` and `boolval` function calls with according type casting operator."
+                },
+                "modifier_keywords": {
+                    "description": "Classes, constants, properties, and methods MUST have visibility declared, and keyword modifiers MUST be in the following order: inheritance modifier (`abstract` or `final`), visibility modifier (`public`, `protected`, or `private`), set-visibility modifier (`public(set)`, `protected(set)`, or `private(set)`), scope modifier (`static`), mutation modifier (`readonly`), type declaration, name.",
+                    "type": "object",
+                    "properties": {
+                        "elements": {
+                            "description": "The structural elements to fix.",
+                            "default": ["const", "method", "property"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [["const", "method", "property"]]
+                        }
+                    }
+                },
+                "multiline_comment_opening_closing": {
+                    "description": "DocBlocks must start with two asterisks, multiline comments must start with a single asterisk, after the opening slash. Both must end with a single asterisk before the closing slash."
+                },
+                "multiline_promoted_properties": {
+                    "description": "Promoted properties must be on separate lines.",
+                    "type": "object",
+                    "properties": {
+                        "keep_blank_lines": {
+                            "description": "Whether to keep blank lines between properties.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "minimum_number_of_parameters": {
+                            "description": "Minimum number of parameters in the constructor to fix.",
+                            "default": 1,
+                            "type": "integer"
+                        }
+                    }
+                },
+                "multiline_string_to_heredoc": {
+                    "description": "Convert multiline string to `heredoc` or `nowdoc`."
+                },
+                "multiline_whitespace_before_semicolons": {
+                    "description": "Forbid multi-line whitespace before the closing semicolon or move the semicolon to the new line for chained calls.",
+                    "type": "object",
+                    "properties": {
+                        "strategy": {
+                            "description": "Forbid multi-line whitespace or move the semicolon to the new line for chained calls.",
+                            "default": "no_multi_line",
+                            "enum": [
+                                "no_multi_line",
+                                "new_line_for_chained_calls"
+                            ]
+                        }
+                    }
+                },
+                "native_constant_invocation": {
+                    "description": "Add leading `\\` before constant invocation of internal constant to speed up resolving. Constant name match is case-sensitive, except for `null`, `false` and `true`.",
+                    "type": "object",
+                    "properties": {
+                        "exclude": {
+                            "description": "List of constants to ignore.",
+                            "default": ["null", "false", "true"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "fix_built_in": {
+                            "description": "Whether to fix constants returned by `get_defined_constants`. User constants are not accounted in this list and must be specified in the include one.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "include": {
+                            "description": "List of additional constants to fix.",
+                            "default": [],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "scope": {
+                            "description": "Only fix constant invocations that are made within a namespace or fix all.",
+                            "default": "all",
+                            "enum": ["all", "namespaced"]
+                        },
+                        "strict": {
+                            "description": "Whether leading `\\` of constant invocation not meant to have it should be removed.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "native_function_casing": {
+                    "description": "Function defined by PHP should be called using the correct casing."
+                },
+                "native_function_invocation": {
+                    "description": "Add leading `\\` before function invocation to speed up resolving.",
+                    "type": "object",
+                    "properties": {
+                        "exclude": {
+                            "description": "List of functions to ignore.",
+                            "default": [],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "include": {
+                            "description": "List of function names or sets to fix. Defined sets are `@internal` (all native functions), `@all` (all global functions) and `@compiler_optimized` (functions that are specially optimized by Zend).",
+                            "default": ["@compiler_optimized"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "scope": {
+                            "description": "Only fix function calls that are made within a namespace or fix all.",
+                            "default": "all",
+                            "enum": ["all", "namespaced"]
+                        },
+                        "strict": {
+                            "description": "Whether leading `\\` of function call not meant to have it should be removed.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "native_function_type_declaration_casing": {
+                    "description": "Native type declarations for functions should use the correct case."
+                },
+                "native_type_declaration_casing": {
+                    "description": "Native type declarations should be used in the correct case."
+                },
+                "new_expression_parentheses": {
+                    "description": "All `new` expressions with a further call must (not) be wrapped in parentheses.",
+                    "type": "object",
+                    "properties": {
+                        "use_parentheses": {
+                            "description": "Whether `new` expressions with a further call should be wrapped in parentheses or not.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "new_with_braces": {
+                    "description": "All instances created with `new` keyword must (not) be followed by braces.",
+                    "type": "object",
+                    "properties": {
+                        "anonymous_class": {
+                            "description": "Whether anonymous classes should be followed by parentheses.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "named_class": {
+                            "description": "Whether named classes should be followed by parentheses.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "new_with_parentheses": {
+                    "description": "All instances created with `new` keyword must (not) be followed by parentheses.",
+                    "type": "object",
+                    "properties": {
+                        "anonymous_class": {
+                            "description": "Whether anonymous classes should be followed by parentheses.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "named_class": {
+                            "description": "Whether named classes should be followed by parentheses.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "no_alias_functions": {
+                    "description": "Master functions shall be used instead of aliases.",
+                    "type": "object",
+                    "properties": {
+                        "sets": {
+                            "description": "List of sets to fix. Defined sets are:\n\n* `@all` (all listed sets);\n* `@internal` (native functions);\n* `@exif` (EXIF functions);\n* `@ftp` (FTP functions);\n* `@IMAP` (IMAP functions);\n* `@ldap` (LDAP functions);\n* `@mbreg` (from `ext-mbstring`);\n* `@mysqli` (mysqli functions);\n* `@oci` (oci functions);\n* `@odbc` (odbc functions);\n* `@openssl` (openssl functions);\n* `@pcntl` (PCNTL functions);\n* `@pg` (pg functions);\n* `@posix` (POSIX functions);\n* `@snmp` (SNMP functions);\n* `@sodium` (libsodium functions);\n* `@time` (time functions).",
+                            "default": ["@internal", "@IMAP", "@pg"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [
+                                [
+                                    "@all",
+                                    "@exif",
+                                    "@ftp",
+                                    "@IMAP",
+                                    "@internal",
+                                    "@ldap",
+                                    "@mbreg",
+                                    "@mysqli",
+                                    "@oci",
+                                    "@odbc",
+                                    "@openssl",
+                                    "@pcntl",
+                                    "@pg",
+                                    "@posix",
+                                    "@snmp",
+                                    "@sodium",
+                                    "@time"
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "no_alias_language_construct_call": {
+                    "description": "Master language constructs shall be used instead of aliases."
+                },
+                "no_alternative_syntax": {
+                    "description": "Replace control structure alternative syntax to use braces.",
+                    "type": "object",
+                    "properties": {
+                        "fix_non_monolithic_code": {
+                            "description": "Whether to also fix code with inline HTML.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "no_binary_string": {
+                    "description": "There should not be a binary flag before strings."
+                },
+                "no_blank_lines_after_class_opening": {
+                    "description": "There should be no empty lines after class opening brace."
+                },
+                "no_blank_lines_after_phpdoc": {
+                    "description": "There should not be blank lines between docblock and the documented element."
+                },
+                "no_blank_lines_before_namespace": {
+                    "description": "There should be no blank lines before a namespace declaration."
+                },
+                "no_break_comment": {
+                    "description": "There must be a comment when fall-through is intentional in a non-empty case body.",
+                    "type": "object",
+                    "properties": {
+                        "comment_text": {
+                            "description": "The text to use in the added comment and to detect it.",
+                            "default": "no break",
+                            "type": "string"
+                        }
+                    }
+                },
+                "no_closing_tag": {
+                    "description": "The closing `?>` tag MUST be omitted from files containing only PHP."
+                },
+                "no_empty_comment": {
+                    "description": "There should not be any empty comments."
+                },
+                "no_empty_phpdoc": {
+                    "description": "There should not be empty PHPDoc blocks."
+                },
+                "no_empty_statement": {
+                    "description": "Remove useless (semicolon) statements."
+                },
+                "no_extra_blank_lines": {
+                    "description": "Removes extra blank lines and/or blank lines following configuration.",
+                    "type": "object",
+                    "properties": {
+                        "tokens": {
+                            "description": "List of tokens to fix.",
+                            "default": ["extra"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [
+                                [
+                                    "attribute",
+                                    "break",
+                                    "case",
+                                    "comma",
+                                    "continue",
+                                    "curly_brace_block",
+                                    "default",
+                                    "extra",
+                                    "parenthesis_brace_block",
+                                    "return",
+                                    "square_brace_block",
+                                    "switch",
+                                    "throw",
+                                    "use",
+                                    "use_trait"
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "no_homoglyph_names": {
+                    "description": "Replace accidental usage of homoglyphs (non ascii characters) in names."
+                },
+                "no_leading_import_slash": {
+                    "description": "Remove leading slashes in `use` clauses."
+                },
+                "no_leading_namespace_whitespace": {
+                    "description": "The namespace declaration line shouldn't contain leading whitespace."
+                },
+                "no_mixed_echo_print": {
+                    "description": "Either language construct `print` or `echo` should be used.",
+                    "type": "object",
+                    "properties": {
+                        "use": {
+                            "description": "The desired language construct.",
+                            "default": "echo",
+                            "enum": ["print", "echo"]
+                        }
+                    }
+                },
+                "no_multiline_whitespace_around_double_arrow": {
+                    "description": "Operator `=>` should not be surrounded by multi-line whitespaces."
+                },
+                "no_multiple_statements_per_line": {
+                    "description": "There must not be more than one statement per line."
+                },
+                "no_null_property_initialization": {
+                    "description": "Properties MUST not be explicitly initialised with `null` except when they have a type declaration (PHP 7.4)."
+                },
+                "no_php4_constructor": {
+                    "description": "Convert PHP4-style constructors to `__construct`."
+                },
+                "no_redundant_readonly_property": {
+                    "description": "Removes redundant readonly from properties in readonly classes."
+                },
+                "no_short_bool_cast": {
+                    "description": "Short cast `bool` using double exclamation mark should not be used."
+                },
+                "no_singleline_whitespace_before_semicolons": {
+                    "description": "Single-line whitespace before closing semicolon are prohibited."
+                },
+                "no_space_around_double_colon": {
+                    "description": "There must be no space around double colons (also called Scope Resolution Operator or Paamayim Nekudotayim)."
+                },
+                "no_spaces_after_function_name": {
+                    "description": "When making a method or function call, there MUST NOT be a space between the method or function name and the opening parenthesis."
+                },
+                "no_spaces_around_offset": {
+                    "description": "There MUST NOT be spaces around offset braces.",
+                    "type": "object",
+                    "properties": {
+                        "positions": {
+                            "description": "Whether spacing should be fixed inside and/or outside the offset braces.",
+                            "default": ["inside", "outside"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [["inside", "outside"]]
+                        }
+                    }
+                },
+                "no_spaces_inside_parenthesis": {
+                    "description": "There MUST NOT be a space after the opening parenthesis. There MUST NOT be a space before the closing parenthesis."
+                },
+                "no_superfluous_elseif": {
+                    "description": "Replaces superfluous `elseif` with `if`."
+                },
+                "no_superfluous_phpdoc_tags": {
+                    "description": "Removes `@param`, `@return` and `@var` tags that don't provide any useful information.",
+                    "type": "object",
+                    "properties": {
+                        "allow_hidden_params": {
+                            "description": "Whether `param` annotation for hidden params in method signature are allowed.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "allow_mixed": {
+                            "description": "Whether type `mixed` without description is allowed (`true`) or considered superfluous (`false`).",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "allow_unused_params": {
+                            "description": "Whether `param` annotation without actual signature is allowed (`true`) or considered superfluous (`false`).",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "remove_inheritdoc": {
+                            "description": "Remove `@inheritDoc` tags.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "no_trailing_comma_in_list_call": {
+                    "description": "Remove trailing commas in list function calls."
+                },
+                "no_trailing_comma_in_singleline": {
+                    "description": "If a list of values separated by a comma is contained on a single line, then the last item MUST NOT have a trailing comma.",
+                    "type": "object",
+                    "properties": {
+                        "elements": {
+                            "description": "Which elements to fix.",
+                            "default": [
+                                "arguments",
+                                "array",
+                                "array_destructuring",
+                                "group_import"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [
+                                [
+                                    "arguments",
+                                    "array",
+                                    "array_destructuring",
+                                    "group_import"
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "no_trailing_comma_in_singleline_array": {
+                    "description": "PHP single-line arrays should not have trailing comma."
+                },
+                "no_trailing_comma_in_singleline_function_call": {
+                    "description": "When making a method or function call on a single line there MUST NOT be a trailing comma after the last argument."
+                },
+                "no_trailing_whitespace": {
+                    "description": "There must be no trailing whitespace at the end of non-blank lines."
+                },
+                "no_trailing_whitespace_in_comment": {
+                    "description": "There must be no trailing whitespace at the end of lines in comments and PHPDocs."
+                },
+                "no_trailing_whitespace_in_string": {
+                    "description": "There must be no trailing whitespace at the end of lines in strings."
+                },
+                "no_unneeded_braces": {
+                    "description": "Removes unneeded braces that are superfluous and aren't part of a control structure's body.",
+                    "type": "object",
+                    "properties": {
+                        "namespaces": {
+                            "description": "Remove unneeded braces from bracketed namespaces.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "no_unneeded_control_parentheses": {
+                    "description": "Removes unneeded parentheses around control statements.",
+                    "type": "object",
+                    "properties": {
+                        "statements": {
+                            "description": "List of control statements to fix.",
+                            "default": [
+                                "break",
+                                "clone",
+                                "continue",
+                                "echo_print",
+                                "return",
+                                "switch_case",
+                                "yield"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [
+                                [
+                                    "break",
+                                    "clone",
+                                    "continue",
+                                    "echo_print",
+                                    "negative_instanceof",
+                                    "others",
+                                    "return",
+                                    "switch_case",
+                                    "yield",
+                                    "yield_from"
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "no_unneeded_curly_braces": {
+                    "description": "Removes unneeded curly braces that are superfluous and aren't part of a control structure's body.",
+                    "type": "object",
+                    "properties": {
+                        "namespaces": {
+                            "description": "Remove unneeded curly braces from bracketed namespaces.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "no_unneeded_final_method": {
+                    "description": "Removes `final` from methods where possible.",
+                    "type": "object",
+                    "properties": {
+                        "private_methods": {
+                            "description": "Private methods of non-`final` classes must not be declared `final`.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "no_unneeded_import_alias": {
+                    "description": "Imports should not be aliased as the same name."
+                },
+                "no_unreachable_default_argument_value": {
+                    "description": "In function arguments there must not be arguments with default values before non-default ones."
+                },
+                "no_unset_cast": {
+                    "description": "Variables must be set `null` instead of using `(unset)` casting."
+                },
+                "no_unset_on_property": {
+                    "description": "Properties should be set to `null` instead of using `unset`."
+                },
+                "no_unused_imports": {
+                    "description": "Unused `use` statements must be removed."
+                },
+                "no_useless_concat_operator": {
+                    "description": "There should not be useless concat operations.",
+                    "type": "object",
+                    "properties": {
+                        "juggle_simple_strings": {
+                            "description": "Allow for simple string quote juggling if it results in more concat-operations merges.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "no_useless_else": {
+                    "description": "There should not be useless `else` cases."
+                },
+                "no_useless_nullsafe_operator": {
+                    "description": "There should not be useless Null-safe operator `?->` used."
+                },
+                "no_useless_printf": {
+                    "description": "There must be no `printf` calls with only the first argument."
+                },
+                "no_useless_return": {
+                    "description": "There should not be an empty `return` statement at the end of a function."
+                },
+                "no_useless_sprintf": {
+                    "description": "There must be no `sprintf` calls with only the first argument."
+                },
+                "no_whitespace_before_comma_in_array": {
+                    "description": "In array declaration, there MUST NOT be a whitespace before each comma.",
+                    "type": "object",
+                    "properties": {
+                        "after_heredoc": {
+                            "description": "Whether the whitespace between heredoc end and comma should be removed.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "no_whitespace_in_blank_line": {
+                    "description": "Remove trailing whitespace at the end of blank lines."
+                },
+                "non_printable_character": {
+                    "description": "Remove Zero-width space (ZWSP), Non-breaking space (NBSP) and other invisible unicode symbols.",
+                    "type": "object",
+                    "properties": {
+                        "use_escape_sequences_in_strings": {
+                            "description": "Whether characters should be replaced with escape sequences in strings.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "normalize_index_brace": {
+                    "description": "Array index should always be written by using square braces."
+                },
+                "not_operator_with_space": {
+                    "description": "Logical NOT operators (`!`) should have leading and trailing whitespaces."
+                },
+                "not_operator_with_successor_space": {
+                    "description": "Logical NOT operators (`!`) should have one trailing whitespace."
+                },
+                "nullable_type_declaration": {
+                    "description": "Nullable single type declaration should be standardised using configured syntax.",
+                    "type": "object",
+                    "properties": {
+                        "syntax": {
+                            "description": "Whether to use question mark (`?`) or explicit `null` union for nullable type.",
+                            "default": "question_mark",
+                            "enum": ["union", "question_mark"]
+                        }
+                    }
+                },
+                "nullable_type_declaration_for_default_null_value": {
+                    "description": "Adds or removes `?` before single type declarations or `|null` at the end of union types when parameters have a default `null` value.",
+                    "type": "object",
+                    "properties": {
+                        "use_nullable_type_declaration": {
+                            "description": "Whether to add or remove `?` or `|null` to parameters with a default `null` value.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "numeric_literal_separator": {
+                    "description": "Adds separators to numeric literals of any kind.",
+                    "type": "object",
+                    "properties": {
+                        "override_existing": {
+                            "description": "Whether literals already containing underscores should be reformatted.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "strategy": {
+                            "description": "Whether numeric literal should be separated by underscores or not.",
+                            "default": "use_separator",
+                            "enum": ["use_separator", "no_separator"]
+                        }
+                    }
+                },
+                "object_operator_without_whitespace": {
+                    "description": "There should not be space before or after object operators `->` and `?->`."
+                },
+                "octal_notation": {
+                    "description": "Literal octal must be in `0o` notation."
+                },
+                "operator_linebreak": {
+                    "description": "Operators - when multiline - must always be at the beginning or at the end of the line.",
+                    "type": "object",
+                    "properties": {
+                        "only_booleans": {
+                            "description": "Whether to limit operators to only boolean ones.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "position": {
+                            "description": "Whether to place operators at the beginning or at the end of the line.",
+                            "default": "beginning",
+                            "enum": ["beginning", "end"]
+                        }
+                    }
+                },
+                "ordered_attributes": {
+                    "description": "Sorts attributes using the configured sort algorithm.",
+                    "type": "object",
+                    "properties": {
+                        "order": {
+                            "description": "A list of FQCNs of attributes defining the desired order used when custom sorting algorithm is configured.",
+                            "default": [],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "sort_algorithm": {
+                            "description": "How the attributes should be sorted.",
+                            "default": "alpha",
+                            "enum": ["alpha", "custom"]
+                        }
+                    }
+                },
+                "ordered_class_elements": {
+                    "description": "Orders the elements of classes/interfaces/traits/enums.",
+                    "type": "object",
+                    "properties": {
+                        "case_sensitive": {
+                            "description": "Whether the sorting should be case sensitive.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "order": {
+                            "description": "List of strings defining order of elements.",
+                            "default": [
+                                "use_trait",
+                                "case",
+                                "constant_public",
+                                "constant_protected",
+                                "constant_private",
+                                "property_public",
+                                "property_protected",
+                                "property_private",
+                                "construct",
+                                "destruct",
+                                "magic",
+                                "phpunit",
+                                "method_public",
+                                "method_protected",
+                                "method_private"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "sort_algorithm": {
+                            "description": "How multiple occurrences of same type statements should be sorted.",
+                            "default": "none",
+                            "enum": ["none", "alpha"]
+                        }
+                    }
+                },
+                "ordered_imports": {
+                    "description": "Ordering `use` statements.",
+                    "type": "object",
+                    "properties": {
+                        "case_sensitive": {
+                            "description": "Whether the sorting should be case sensitive.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "imports_order": {
+                            "description": "Defines the order of import types.",
+                            "default": null,
+                            "oneOf": [
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "sort_algorithm": {
+                            "description": "Whether the statements should be sorted alphabetically or by length (*deprecated*), or not sorted.",
+                            "default": "alpha",
+                            "enum": ["alpha", "length", "none"]
+                        }
+                    }
+                },
+                "ordered_interfaces": {
+                    "description": "Orders the interfaces in an `implements` or `interface extends` clause.",
+                    "type": "object",
+                    "properties": {
+                        "case_sensitive": {
+                            "description": "Whether the sorting should be case sensitive.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "direction": {
+                            "description": "Which direction the interfaces should be ordered.",
+                            "default": "ascend",
+                            "enum": ["ascend", "descend"]
+                        },
+                        "order": {
+                            "description": "How the interfaces should be ordered.",
+                            "default": "alpha",
+                            "enum": ["alpha", "length"]
+                        }
+                    }
+                },
+                "ordered_traits": {
+                    "description": "Trait `use` statements must be sorted alphabetically.",
+                    "type": "object",
+                    "properties": {
+                        "case_sensitive": {
+                            "description": "Whether the sorting should be case sensitive.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "ordered_types": {
+                    "description": "Sort union types and intersection types using configured order.",
+                    "type": "object",
+                    "properties": {
+                        "case_sensitive": {
+                            "description": "Whether the sorting should be case sensitive.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "null_adjustment": {
+                            "description": "Forces the position of `null` (overrides `sort_algorithm`).",
+                            "default": "always_first",
+                            "enum": ["always_first", "always_last", "none"]
+                        },
+                        "sort_algorithm": {
+                            "description": "Whether the types should be sorted alphabetically, or not sorted.",
+                            "default": "alpha",
+                            "enum": ["alpha", "none"]
+                        }
+                    }
+                },
+                "php_unit_assert_new_names": {
+                    "description": "Rename deprecated PHPUnit assertions like `assertFileNotExists` to new methods like `assertFileDoesNotExist`."
+                },
+                "php_unit_attributes": {
+                    "description": "PHPUnit attributes must be used over their respective PHPDoc-based annotations.",
+                    "type": "object",
+                    "properties": {
+                        "keep_annotations": {
+                            "description": "Whether to keep annotations or not. This may be helpful for projects that support PHP before version 8 or PHPUnit before version 10.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "php_unit_construct": {
+                    "description": "PHPUnit assertion method calls like `->assertSame(true, $foo)` should be written with dedicated method like `->assertTrue($foo)`.",
+                    "type": "object",
+                    "properties": {
+                        "assertions": {
+                            "description": "List of assertion methods to fix.",
+                            "default": [
+                                "assertEquals",
+                                "assertNotEquals",
+                                "assertNotSame",
+                                "assertSame"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [
+                                [
+                                    "assertEquals",
+                                    "assertNotEquals",
+                                    "assertNotSame",
+                                    "assertSame"
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "php_unit_data_provider_method_order": {
+                    "description": "Data provider method must be placed after/before the last/first test where used.",
+                    "type": "object",
+                    "properties": {
+                        "placement": {
+                            "description": "Where to place the data provider relative to the test where used.",
+                            "default": "after",
+                            "enum": ["after", "before"]
+                        }
+                    }
+                },
+                "php_unit_data_provider_name": {
+                    "description": "Data provider names must match the name of the test.",
+                    "type": "object",
+                    "properties": {
+                        "prefix": {
+                            "description": "Prefix that replaces \"test\".",
+                            "default": "provide",
+                            "type": "string"
+                        },
+                        "suffix": {
+                            "description": "Suffix to be present at the end.",
+                            "default": "Cases",
+                            "type": "string"
+                        }
+                    }
+                },
+                "php_unit_data_provider_return_type": {
+                    "description": "The return type of PHPUnit data provider must be `iterable`."
+                },
+                "php_unit_data_provider_static": {
+                    "description": "Data providers must be static.",
+                    "type": "object",
+                    "properties": {
+                        "force": {
+                            "description": "Whether to make the data providers static even if they have a dynamic class call (may introduce fatal error \"using $this when not in object context\", and you may have to adjust the code manually by converting dynamic calls to static ones).",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "php_unit_dedicate_assert": {
+                    "description": "PHPUnit assertions like `assertInternalType`, `assertFileExists`, should be used over `assertTrue`.",
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "description": "Target version of PHPUnit.",
+                            "default": "newest",
+                            "type": "string",
+                            "enum": ["3.0", "3.5", "5.0", "5.6", "newest"]
+                        }
+                    }
+                },
+                "php_unit_dedicate_assert_internal_type": {
+                    "description": "PHPUnit assertions like `assertIsArray` should be used over `assertInternalType`.",
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "description": "Target version of PHPUnit.",
+                            "default": "newest",
+                            "type": "string",
+                            "enum": ["7.5", "newest"]
+                        }
+                    }
+                },
+                "php_unit_expectation": {
+                    "description": "Usages of `->setExpectedException*` methods MUST be replaced by `->expectException*` methods.",
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "description": "Target version of PHPUnit.",
+                            "default": "newest",
+                            "type": "string",
+                            "enum": ["5.2", "5.6", "8.4", "newest"]
+                        }
+                    }
+                },
+                "php_unit_fqcn_annotation": {
+                    "description": "PHPUnit annotations should be a FQCNs including a root namespace."
+                },
+                "php_unit_internal_class": {
+                    "description": "All PHPUnit test classes should be marked as internal.",
+                    "type": "object",
+                    "properties": {
+                        "types": {
+                            "description": "What types of classes to mark as internal.",
+                            "default": ["normal", "final"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [["abstract", "final", "normal"]]
+                        }
+                    }
+                },
+                "php_unit_method_casing": {
+                    "description": "Enforce camel (or snake) case for PHPUnit test methods, following configuration.",
+                    "type": "object",
+                    "properties": {
+                        "case": {
+                            "description": "Apply camel or snake case to test methods.",
+                            "default": "camel_case",
+                            "enum": ["camel_case", "snake_case"]
+                        }
+                    }
+                },
+                "php_unit_mock": {
+                    "description": "Usages of `->getMock` and `->getMockWithoutInvokingTheOriginalConstructor` methods MUST be replaced by `->createMock` or `->createPartialMock` methods.",
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "description": "Target version of PHPUnit.",
+                            "default": "newest",
+                            "type": "string",
+                            "enum": ["5.4", "5.5", "newest"]
+                        }
+                    }
+                },
+                "php_unit_mock_short_will_return": {
+                    "description": "Usage of PHPUnit's mock e.g. `->will($this->returnValue(..))` must be replaced by its shorter equivalent such as `->willReturn(...)`."
+                },
+                "php_unit_namespaced": {
+                    "description": "PHPUnit classes MUST be used in namespaced version, e.g. `\\PHPUnit\\Framework\\TestCase` instead of `\\PHPUnit_Framework_TestCase`.",
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "description": "Target version of PHPUnit.",
+                            "default": "newest",
+                            "type": "string",
+                            "enum": ["4.8", "5.7", "6.0", "newest"]
+                        }
+                    }
+                },
+                "php_unit_no_expectation_annotation": {
+                    "description": "Usages of `@expectedException*` annotations MUST be replaced by `->setExpectedException*` methods.",
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "description": "Target version of PHPUnit.",
+                            "default": "newest",
+                            "type": "string",
+                            "enum": ["3.2", "4.3", "newest"]
+                        },
+                        "use_class_const": {
+                            "description": "Use ::class notation.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "php_unit_set_up_tear_down_visibility": {
+                    "description": "Changes the visibility of the `setUp()` and `tearDown()` functions of PHPUnit to `protected`, to match the PHPUnit TestCase."
+                },
+                "php_unit_size_class": {
+                    "description": "All PHPUnit test cases should have `@small`, `@medium` or `@large` annotation to enable run time limits.",
+                    "type": "object",
+                    "properties": {
+                        "group": {
+                            "description": "Define a specific group to be used in case no group is already in use.",
+                            "default": "small",
+                            "enum": ["small", "medium", "large"]
+                        }
+                    }
+                },
+                "php_unit_strict": {
+                    "description": "PHPUnit methods like `assertSame` should be used instead of `assertEquals`.",
+                    "type": "object",
+                    "properties": {
+                        "assertions": {
+                            "description": "List of assertion methods to fix.",
+                            "default": [
+                                "assertAttributeEquals",
+                                "assertAttributeNotEquals",
+                                "assertEquals",
+                                "assertNotEquals"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [
+                                [
+                                    "assertAttributeEquals",
+                                    "assertAttributeNotEquals",
+                                    "assertEquals",
+                                    "assertNotEquals"
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "php_unit_test_annotation": {
+                    "description": "Adds or removes @test annotations from tests, following configuration.",
+                    "type": "object",
+                    "properties": {
+                        "style": {
+                            "description": "Whether to use the @test annotation or not.",
+                            "default": "prefix",
+                            "enum": ["prefix", "annotation"]
+                        }
+                    }
+                },
+                "php_unit_test_case_static_method_calls": {
+                    "description": "Calls to `PHPUnit\\Framework\\TestCase` static methods (like assertions) must all be of the same type, either `$this->`, `self::` or `static::`.",
+                    "type": "object",
+                    "properties": {
+                        "call_type": {
+                            "description": "The call type to use for referring to PHPUnit methods.",
+                            "default": "static",
+                            "type": "string",
+                            "enum": ["this", "self", "static"]
+                        },
+                        "methods": {
+                            "description": "Dictionary of `method` => `call_type` values that differ from the default strategy.",
+                            "default": {},
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "target": {
+                            "description": "Target version of PHPUnit.",
+                            "default": "10.0",
+                            "type": "string",
+                            "enum": ["10.0", "11.0", "newest"]
+                        }
+                    }
+                },
+                "php_unit_test_class_requires_covers": {
+                    "description": "Adds a default `@coversNothing` annotation to PHPUnit test classes that have no `@covers*` annotation."
+                },
+                "phpdoc_add_missing_param_annotation": {
+                    "description": "PHPDoc should contain `@param` for all params.",
+                    "type": "object",
+                    "properties": {
+                        "only_untyped": {
+                            "description": "Whether to add missing `@param` annotations for untyped parameters only.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "phpdoc_align": {
+                    "description": "All items of the given PHPDoc tags must be either left-aligned or (by default) aligned vertically.",
+                    "type": "object",
+                    "properties": {
+                        "align": {
+                            "description": "How comments should be aligned.",
+                            "default": "vertical",
+                            "type": "string",
+                            "enum": ["left", "vertical"]
+                        },
+                        "spacing": {
+                            "description": "Spacing between tag, hint, comment, signature, etc. You can set same spacing for all tags using a positive integer or different spacings for different tags using an associative array of positive integers `['tagA' => spacingForA, 'tagB' => spacingForB]`. If you want to define default spacing to more than 1 space use `_default` key in config array, e.g.: `['tagA' => spacingForA, 'tagB' => spacingForB, '_default' => spacingForAllOthers]`.",
+                            "default": 1,
+                            "oneOf": [
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "integer"
+                                    }
+                                }
+                            ]
+                        },
+                        "tags": {
+                            "description": "The tags that should be aligned. Allowed values are tags with name (`'param', 'property', 'property-read', 'property-write', 'phpstan-param', 'phpstan-property', 'phpstan-property-read', 'phpstan-property-write', 'phpstan-assert', 'phpstan-assert-if-true', 'phpstan-assert-if-false', 'psalm-param', 'psalm-param-out', 'psalm-property', 'psalm-property-read', 'psalm-property-write', 'psalm-assert', 'psalm-assert-if-true', 'psalm-assert-if-false'`), tags with method signature (`'method', 'phpstan-method', 'psalm-method'`) and any custom tag with description (e.g. `@tag <desc>`).",
+                            "default": [
+                                "method",
+                                "param",
+                                "property",
+                                "return",
+                                "throws",
+                                "type",
+                                "var"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "phpdoc_annotation_without_dot": {
+                    "description": "PHPDoc annotation descriptions should not be a sentence."
+                },
+                "phpdoc_array_type": {
+                    "description": "PHPDoc `array<T>` type must be used instead of `T[]`."
+                },
+                "phpdoc_indent": {
+                    "description": "Docblocks should have the same indentation as the documented subject."
+                },
+                "phpdoc_inline_tag_normalizer": {
+                    "description": "Fixes PHPDoc inline tags.",
+                    "type": "object",
+                    "properties": {
+                        "tags": {
+                            "description": "The list of tags to normalize.",
+                            "default": [
+                                "example",
+                                "id",
+                                "internal",
+                                "inheritdoc",
+                                "inheritdocs",
+                                "link",
+                                "source",
+                                "toc",
+                                "tutorial"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "phpdoc_line_span": {
+                    "description": "Changes doc blocks from single to multi line, or reversed.",
+                    "type": "object",
+                    "properties": {
+                        "case": {
+                            "description": "Whether enum case doc blocks should be single or multi line.",
+                            "default": "multi",
+                            "enum": ["single", "multi", null]
+                        },
+                        "class": {
+                            "description": "Whether class/interface/enum/trait blocks should be single or multi line.",
+                            "default": "multi",
+                            "enum": ["single", "multi", null]
+                        },
+                        "const": {
+                            "description": "Whether const blocks should be single or multi line.",
+                            "default": "multi",
+                            "enum": ["single", "multi", null]
+                        },
+                        "method": {
+                            "description": "Whether method doc blocks should be single or multi line.",
+                            "default": "multi",
+                            "enum": ["single", "multi", null]
+                        },
+                        "other": {
+                            "description": "Whether blocks for other code lines should be single or multi line.",
+                            "default": null,
+                            "enum": ["single", "multi", null]
+                        },
+                        "property": {
+                            "description": "Whether property doc blocks should be single or multi line.",
+                            "default": "multi",
+                            "enum": ["single", "multi", null]
+                        },
+                        "trait_import": {
+                            "description": "Whether trait usage blocks should be single or multi line.",
+                            "default": null,
+                            "enum": ["single", "multi", null]
+                        }
+                    }
+                },
+                "phpdoc_list_type": {
+                    "description": "PHPDoc `list` type must be used instead of `array` without a key."
+                },
+                "phpdoc_no_access": {
+                    "description": "`@access` annotations must be removed from PHPDoc."
+                },
+                "phpdoc_no_alias_tag": {
+                    "description": "No alias PHPDoc tags should be used.",
+                    "type": "object",
+                    "properties": {
+                        "replacements": {
+                            "description": "Mapping between replaced annotations with new ones.",
+                            "default": {
+                                "property-read": "property",
+                                "property-write": "property",
+                                "type": "var",
+                                "link": "see"
+                            },
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "phpdoc_no_empty_return": {
+                    "description": "`@return void` and `@return null` annotations must be removed from PHPDoc."
+                },
+                "phpdoc_no_package": {
+                    "description": "`@package` and `@subpackage` annotations must be removed from PHPDoc."
+                },
+                "phpdoc_no_useless_inheritdoc": {
+                    "description": "Classy that does not inherit must not have `@inheritdoc` tags."
+                },
+                "phpdoc_order": {
+                    "description": "Annotations in PHPDoc should be ordered in defined sequence.",
+                    "type": "object",
+                    "properties": {
+                        "order": {
+                            "description": "Sequence in which annotations in PHPDoc should be ordered.",
+                            "default": ["param", "throws", "return"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "phpdoc_order_by_value": {
+                    "description": "Order PHPDoc tags by value.",
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "description": "List of annotations to order, e.g. `[\"covers\"]`.",
+                            "default": ["covers"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [
+                                [
+                                    "author",
+                                    "covers",
+                                    "coversNothing",
+                                    "dataProvider",
+                                    "depends",
+                                    "group",
+                                    "internal",
+                                    "method",
+                                    "mixin",
+                                    "property",
+                                    "property-read",
+                                    "property-write",
+                                    "requires",
+                                    "throws",
+                                    "uses"
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "phpdoc_param_order": {
+                    "description": "Orders all `@param` annotations in DocBlocks according to method signature."
+                },
+                "phpdoc_readonly_class_comment_to_keyword": {
+                    "description": "Converts readonly comment on classes to the readonly keyword."
+                },
+                "phpdoc_return_self_reference": {
+                    "description": "The type of `@return` annotations of methods returning a reference to itself must the configured one.",
+                    "type": "object",
+                    "properties": {
+                        "replacements": {
+                            "description": "Mapping between replaced return types with new ones.",
+                            "default": {
+                                "this": "$this",
+                                "@this": "$this",
+                                "$self": "self",
+                                "@self": "self",
+                                "$static": "static",
+                                "@static": "static"
+                            },
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "phpdoc_scalar": {
+                    "description": "Scalar types should always be written in the same form. `int` not `integer`, `bool` not `boolean`, `float` not `real` or `double`.",
+                    "type": "object",
+                    "properties": {
+                        "types": {
+                            "description": "A list of types to fix.",
+                            "default": [
+                                "boolean",
+                                "callback",
+                                "double",
+                                "integer",
+                                "real",
+                                "str"
+                            ],
+                            "enum": [
+                                [
+                                    "boolean",
+                                    "callback",
+                                    "double",
+                                    "integer",
+                                    "never-return",
+                                    "never-returns",
+                                    "no-return",
+                                    "real",
+                                    "str"
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "phpdoc_separation": {
+                    "description": "Annotations in PHPDoc should be grouped together so that annotations of the same type immediately follow each other. Annotations of a different type are separated by a single blank line.",
+                    "type": "object",
+                    "properties": {
+                        "groups": {
+                            "description": "Sets of annotation types to be grouped together. Use `*` to match any tag character.",
+                            "default": [
+                                ["author", "copyright", "license"],
+                                ["category", "package", "subpackage"],
+                                ["property", "property-read", "property-write"],
+                                ["deprecated", "link", "see", "since"]
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "skip_unlisted_annotations": {
+                            "description": "Whether to skip annotations that are not listed in any group.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "phpdoc_single_line_var_spacing": {
+                    "description": "Single line `@var` PHPDoc should have proper spacing."
+                },
+                "phpdoc_summary": {
+                    "description": "PHPDoc summary should end in either a full stop, exclamation mark, or question mark."
+                },
+                "phpdoc_tag_casing": {
+                    "description": "Fixes casing of PHPDoc tags.",
+                    "type": "object",
+                    "properties": {
+                        "tags": {
+                            "description": "List of tags to fix with their expected casing.",
+                            "default": ["inheritDoc"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "phpdoc_tag_no_named_arguments": {
+                    "description": "There must be `@no-named-arguments` tag in PHPDoc of a class/enum/interface/trait.",
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "description": "Description of the tag.",
+                            "default": "",
+                            "type": "string"
+                        },
+                        "fix_attribute": {
+                            "description": "Whether to fix attribute classes.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "fix_internal": {
+                            "description": "Whether to fix internal elements (marked with `@internal`).",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "phpdoc_tag_type": {
+                    "description": "Forces PHPDoc tags to be either regular annotations or inline.",
+                    "type": "object",
+                    "properties": {
+                        "tags": {
+                            "description": "The list of tags to fix.",
+                            "default": {
+                                "api": "annotation",
+                                "author": "annotation",
+                                "copyright": "annotation",
+                                "deprecated": "annotation",
+                                "example": "annotation",
+                                "global": "annotation",
+                                "inheritDoc": "annotation",
+                                "internal": "annotation",
+                                "license": "annotation",
+                                "method": "annotation",
+                                "package": "annotation",
+                                "param": "annotation",
+                                "property": "annotation",
+                                "return": "annotation",
+                                "see": "annotation",
+                                "since": "annotation",
+                                "throws": "annotation",
+                                "todo": "annotation",
+                                "uses": "annotation",
+                                "var": "annotation",
+                                "version": "annotation"
+                            },
+                            "type": "object",
+                            "additionalProperties": {
+                                "enum": ["annotation", "inline"]
+                            }
+                        }
+                    }
+                },
+                "phpdoc_to_comment": {
+                    "description": "Docblocks should only be used on structural elements.",
+                    "type": "object",
+                    "properties": {
+                        "allow_before_return_statement": {
+                            "description": "Whether to allow PHPDoc before return statement.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "ignored_tags": {
+                            "description": "List of ignored tags (matched case insensitively).",
+                            "default": [],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "phpdoc_to_param_type": {
+                    "description": "Takes `@param` annotations of non-mixed types and adjusts accordingly the function signature.",
+                    "type": "object",
+                    "properties": {
+                        "scalar_types": {
+                            "description": "Fix also scalar types; may have unexpected behaviour due to PHP bad type coercion system.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "types_map": {
+                            "description": "Map of custom types, e.g. template types from PHPStan.",
+                            "default": {},
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "union_types": {
+                            "description": "Fix also union types; turned on by default on PHP >= 8.0.0.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "phpdoc_to_property_type": {
+                    "description": "Takes `@var` annotation of non-mixed types and adjusts accordingly the property signature..",
+                    "type": "object",
+                    "properties": {
+                        "scalar_types": {
+                            "description": "Fix also scalar types; may have unexpected behaviour due to PHP bad type coercion system.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "types_map": {
+                            "description": "Map of custom types, e.g. template types from PHPStan.",
+                            "default": {},
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "union_types": {
+                            "description": "Fix also union types; turned on by default on PHP >= 8.0.0.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "phpdoc_to_return_type": {
+                    "description": "Takes `@return` annotation of non-mixed types and adjusts accordingly the function signature.",
+                    "type": "object",
+                    "properties": {
+                        "scalar_types": {
+                            "description": "Fix also scalar types; may have unexpected behaviour due to PHP bad type coercion system.",
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "types_map": {
+                            "description": "Map of custom types, e.g. template types from PHPStan.",
+                            "default": {},
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "union_types": {
+                            "description": "Fix also union types; turned on by default on PHP >= 8.0.0.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "phpdoc_trim": {
+                    "description": "PHPDoc should start and end with content, excluding the very first and last line of the docblocks."
+                },
+                "phpdoc_trim_consecutive_blank_line_separation": {
+                    "description": "Removes extra blank lines after summary and after description in PHPDoc."
+                },
+                "phpdoc_types": {
+                    "description": "The correct case must be used for standard PHP types in PHPDoc.",
+                    "type": "object",
+                    "properties": {
+                        "groups": {
+                            "description": "Type groups to fix.",
+                            "default": ["alias", "meta", "simple"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [["alias", "meta", "simple"]]
+                        }
+                    }
+                },
+                "phpdoc_types_no_duplicates": {
+                    "description": "Removes duplicate PHPDoc types."
+                },
+                "phpdoc_types_order": {
+                    "description": "Sorts PHPDoc types.",
+                    "type": "object",
+                    "properties": {
+                        "case_sensitive": {
+                            "description": "Whether the sorting should be case sensitive.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "null_adjustment": {
+                            "description": "Forces the position of `null` (overrides `sort_algorithm`).",
+                            "default": "always_first",
+                            "enum": ["always_first", "always_last", "none"]
+                        },
+                        "sort_algorithm": {
+                            "description": "The sorting algorithm to apply.",
+                            "default": "alpha",
+                            "enum": ["alpha", "none"]
+                        }
+                    }
+                },
+                "phpdoc_var_annotation_correct_order": {
+                    "description": "`@var` and `@type` annotations must have type and name in the correct order."
+                },
+                "phpdoc_var_without_name": {
+                    "description": "`@var` and `@type` annotations of classy properties should not contain the name."
+                },
+                "pow_to_exponentiation": {
+                    "description": "Converts `pow` to the `**` operator."
+                },
+                "protected_to_private": {
+                    "description": "Converts `protected` variables and methods to `private` where possible."
+                },
+                "psr_autoloading": {
+                    "description": "Classes must be in a path that matches their namespace, be at least one namespace deep and the class name should match the file name.",
+                    "type": "object",
+                    "properties": {
+                        "dir": {
+                            "description": "If provided, the directory where the project code is placed.",
+                            "default": null,
+                            "oneOf": [
+                                {
+                                    "type": "null"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "random_api_migration": {
+                    "description": "Replaces `rand`, `srand`, `getrandmax` functions calls with their `mt_*` analogs or `random_int`.",
+                    "type": "object",
+                    "properties": {
+                        "replacements": {
+                            "description": "Mapping between replaced functions with the new ones.",
+                            "default": {
+                                "getrandmax": "mt_getrandmax",
+                                "rand": "mt_rand",
+                                "srand": "mt_srand"
+                            },
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "regular_callable_call": {
+                    "description": "Callables must be called without using `call_user_func*` when possible."
+                },
+                "return_assignment": {
+                    "description": "Local, dynamic and directly referenced variables should not be assigned and directly returned by a function or method."
+                },
+                "return_to_yield_from": {
+                    "description": "If the function explicitly returns an array, and has the return type `iterable`, then `yield from` must be used instead of `return`."
+                },
+                "return_type_declaration": {
+                    "description": "Adjust spacing around colon in return type declarations and backed enum types.",
+                    "type": "object",
+                    "properties": {
+                        "space_before": {
+                            "description": "Spacing to apply before colon.",
+                            "default": "none",
+                            "enum": ["one", "none"]
+                        }
+                    }
+                },
+                "self_accessor": {
+                    "description": "Inside class or interface element `self` should be preferred to the class name itself."
+                },
+                "self_static_accessor": {
+                    "description": "Inside an enum or `final`/anonymous class, `self` should be preferred over `static`."
+                },
+                "semicolon_after_instruction": {
+                    "description": "Instructions must be terminated with a semicolon."
+                },
+                "set_type_to_cast": {
+                    "description": "Cast shall be used, not `settype`."
+                },
+                "short_scalar_cast": {
+                    "description": "Cast `(boolean)` and `(integer)` should be written as `(bool)` and `(int)`, `(double)` and `(real)` as `(float)`, `(binary)` as `(string)`."
+                },
+                "simple_to_complex_string_variable": {
+                    "description": "Converts explicit variables in double-quoted strings and heredoc syntax from simple to complex format (`${` to `{$`)."
+                },
+                "simplified_if_return": {
+                    "description": "Simplify `if` control structures that return the boolean result of their condition."
+                },
+                "simplified_null_return": {
+                    "description": "A return statement wishing to return `void` should not return `null`."
+                },
+                "single_blank_line_at_eof": {
+                    "description": "A PHP file without end tag must always end with a single empty line feed."
+                },
+                "single_blank_line_before_namespace": {
+                    "description": "There should be exactly one blank line before a namespace declaration."
+                },
+                "single_class_element_per_statement": {
+                    "description": "There MUST NOT be more than one property or constant declared per statement.",
+                    "type": "object",
+                    "properties": {
+                        "elements": {
+                            "description": "List of strings which element should be modified.",
+                            "default": ["const", "property"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [["const", "property"]]
+                        }
+                    }
+                },
+                "single_import_per_statement": {
+                    "description": "There MUST be one use keyword per declaration.",
+                    "type": "object",
+                    "properties": {
+                        "group_to_single_imports": {
+                            "description": "Whether to change group imports into single imports.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "single_line_after_imports": {
+                    "description": "Each namespace use MUST go on its own line and there MUST be one blank line after the use statements block."
+                },
+                "single_line_comment_spacing": {
+                    "description": "Single-line comments must have proper spacing."
+                },
+                "single_line_comment_style": {
+                    "description": "Single-line comments and multi-line comments with only one line of actual content should use the `//` syntax.",
+                    "type": "object",
+                    "properties": {
+                        "comment_types": {
+                            "description": "List of comment types to fix.",
+                            "default": ["asterisk", "hash"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [["asterisk", "hash"]]
+                        }
+                    }
+                },
+                "single_line_empty_body": {
+                    "description": "Empty body of class, interface, trait, enum or function must be abbreviated as `{}` and placed on the same line as the previous symbol, separated by a single space."
+                },
+                "single_line_throw": {
+                    "description": "Throwing exception must be done in single line."
+                },
+                "single_quote": {
+                    "description": "Convert double quotes to single quotes for simple strings.",
+                    "type": "object",
+                    "properties": {
+                        "strings_containing_single_quote_chars": {
+                            "description": "Whether to fix double-quoted strings that contains single-quotes.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "single_space_after_construct": {
+                    "description": "Ensures a single space after language constructs.",
+                    "type": "object",
+                    "properties": {
+                        "constructs": {
+                            "description": "List of constructs which must be followed by a single space.",
+                            "default": [
+                                "abstract",
+                                "as",
+                                "attribute",
+                                "break",
+                                "case",
+                                "catch",
+                                "class",
+                                "clone",
+                                "comment",
+                                "const",
+                                "const_import",
+                                "continue",
+                                "do",
+                                "echo",
+                                "else",
+                                "elseif",
+                                "enum",
+                                "extends",
+                                "final",
+                                "finally",
+                                "for",
+                                "foreach",
+                                "function",
+                                "function_import",
+                                "global",
+                                "goto",
+                                "if",
+                                "implements",
+                                "include",
+                                "include_once",
+                                "instanceof",
+                                "insteadof",
+                                "interface",
+                                "match",
+                                "named_argument",
+                                "namespace",
+                                "new",
+                                "open_tag_with_echo",
+                                "php_doc",
+                                "php_open",
+                                "print",
+                                "private",
+                                "protected",
+                                "public",
+                                "readonly",
+                                "require",
+                                "require_once",
+                                "return",
+                                "static",
+                                "switch",
+                                "throw",
+                                "trait",
+                                "try",
+                                "use",
+                                "use_lambda",
+                                "use_trait",
+                                "var",
+                                "while",
+                                "yield",
+                                "yield_from"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [
+                                [
+                                    "abstract",
+                                    "as",
+                                    "attribute",
+                                    "break",
+                                    "case",
+                                    "catch",
+                                    "class",
+                                    "clone",
+                                    "comment",
+                                    "const",
+                                    "const_import",
+                                    "continue",
+                                    "do",
+                                    "echo",
+                                    "else",
+                                    "elseif",
+                                    "enum",
+                                    "extends",
+                                    "final",
+                                    "finally",
+                                    "for",
+                                    "foreach",
+                                    "function",
+                                    "function_import",
+                                    "global",
+                                    "goto",
+                                    "if",
+                                    "implements",
+                                    "include",
+                                    "include_once",
+                                    "instanceof",
+                                    "insteadof",
+                                    "interface",
+                                    "match",
+                                    "named_argument",
+                                    "namespace",
+                                    "new",
+                                    "open_tag_with_echo",
+                                    "php_doc",
+                                    "php_open",
+                                    "print",
+                                    "private",
+                                    "protected",
+                                    "public",
+                                    "readonly",
+                                    "require",
+                                    "require_once",
+                                    "return",
+                                    "static",
+                                    "switch",
+                                    "throw",
+                                    "trait",
+                                    "try",
+                                    "type_colon",
+                                    "use",
+                                    "use_lambda",
+                                    "use_trait",
+                                    "var",
+                                    "while",
+                                    "yield",
+                                    "yield_from"
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "single_space_around_construct": {
+                    "description": "Ensures a single space after language constructs.",
+                    "type": "object",
+                    "properties": {
+                        "constructs_contain_a_single_space": {
+                            "description": "List of constructs which must contain a single space.",
+                            "default": ["yield_from"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [["yield_from"]]
+                        },
+                        "constructs_followed_by_a_single_space": {
+                            "description": "List of constructs which must be followed by a single space.",
+                            "default": [
+                                "abstract",
+                                "as",
+                                "attribute",
+                                "break",
+                                "case",
+                                "catch",
+                                "class",
+                                "clone",
+                                "comment",
+                                "const",
+                                "const_import",
+                                "continue",
+                                "do",
+                                "echo",
+                                "else",
+                                "elseif",
+                                "enum",
+                                "extends",
+                                "final",
+                                "finally",
+                                "for",
+                                "foreach",
+                                "function",
+                                "function_import",
+                                "global",
+                                "goto",
+                                "if",
+                                "implements",
+                                "include",
+                                "include_once",
+                                "instanceof",
+                                "insteadof",
+                                "interface",
+                                "match",
+                                "named_argument",
+                                "namespace",
+                                "new",
+                                "open_tag_with_echo",
+                                "php_doc",
+                                "php_open",
+                                "print",
+                                "private",
+                                "private_set",
+                                "protected",
+                                "protected_set",
+                                "public",
+                                "public_set",
+                                "readonly",
+                                "require",
+                                "require_once",
+                                "return",
+                                "static",
+                                "switch",
+                                "throw",
+                                "trait",
+                                "try",
+                                "type_colon",
+                                "use",
+                                "use_lambda",
+                                "use_trait",
+                                "var",
+                                "while",
+                                "yield",
+                                "yield_from"
+                            ],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [
+                                [
+                                    "abstract",
+                                    "as",
+                                    "attribute",
+                                    "break",
+                                    "case",
+                                    "catch",
+                                    "class",
+                                    "clone",
+                                    "comment",
+                                    "const",
+                                    "const_import",
+                                    "continue",
+                                    "do",
+                                    "echo",
+                                    "else",
+                                    "elseif",
+                                    "enum",
+                                    "extends",
+                                    "final",
+                                    "finally",
+                                    "for",
+                                    "foreach",
+                                    "function",
+                                    "function_import",
+                                    "global",
+                                    "goto",
+                                    "if",
+                                    "implements",
+                                    "include",
+                                    "include_once",
+                                    "instanceof",
+                                    "insteadof",
+                                    "interface",
+                                    "match",
+                                    "named_argument",
+                                    "namespace",
+                                    "new",
+                                    "open_tag_with_echo",
+                                    "php_doc",
+                                    "php_open",
+                                    "print",
+                                    "private",
+                                    "private_set",
+                                    "protected",
+                                    "protected_set",
+                                    "public",
+                                    "public_set",
+                                    "readonly",
+                                    "require",
+                                    "require_once",
+                                    "return",
+                                    "static",
+                                    "switch",
+                                    "throw",
+                                    "trait",
+                                    "try",
+                                    "type_colon",
+                                    "use",
+                                    "use_lambda",
+                                    "use_trait",
+                                    "var",
+                                    "while",
+                                    "yield",
+                                    "yield_from"
+                                ]
+                            ]
+                        },
+                        "constructs_preceded_by_a_single_space": {
+                            "description": "List of constructs which must be preceded by a single space.",
+                            "default": ["as", "use_lambda"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [["as", "else", "elseif", "use_lambda"]]
+                        }
+                    }
+                },
+                "single_trait_insert_per_statement": {
+                    "description": "Each trait `use` must be done as single statement."
+                },
+                "space_after_semicolon": {
+                    "description": "Fix whitespace after a semicolon.",
+                    "type": "object",
+                    "properties": {
+                        "remove_in_empty_for_expressions": {
+                            "description": "Whether spaces should be removed for empty `for` expressions.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "spaces_inside_parentheses": {
+                    "description": "Parentheses must be declared using the configured whitespace.",
+                    "type": "object",
+                    "properties": {
+                        "space": {
+                            "description": "Whether to have `single` or `none` space inside parentheses.",
+                            "default": "none",
+                            "enum": ["none", "single"]
+                        }
+                    }
+                },
+                "standardize_increment": {
+                    "description": "Increment and decrement operators should be used if possible."
+                },
+                "standardize_not_equals": {
+                    "description": "Replace all `<>` with `!=`."
+                },
+                "statement_indentation": {
+                    "description": "Each statement must be indented.",
+                    "type": "object",
+                    "properties": {
+                        "stick_comment_to_next_continuous_control_statement": {
+                            "description": "Last comment of code block counts as comment for next block.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "static_lambda": {
+                    "description": "Lambdas not (indirectly) referencing `$this` must be declared `static`."
+                },
+                "static_private_method": {
+                    "description": "Converts private methods to `static` where possible."
+                },
+                "strict_comparison": {
+                    "description": "Comparisons should be strict."
+                },
+                "strict_param": {
+                    "description": "Functions should be used with `$strict` param set to `true`."
+                },
+                "string_implicit_backslashes": {
+                    "description": "Handles implicit backslashes in strings and heredocs. Depending on the chosen strategy, it can escape implicit backslashes to ease the understanding of which are special chars interpreted by PHP and which not (`escape`), or it can remove these additional backslashes if you find them superfluous (`unescape`). You can also leave them as-is using `ignore` strategy.",
+                    "type": "object",
+                    "properties": {
+                        "double_quoted": {
+                            "description": "Whether to escape backslashes in double-quoted strings.",
+                            "default": "escape",
+                            "enum": ["escape", "unescape", "ignore"]
+                        },
+                        "heredoc": {
+                            "description": "Whether to escape backslashes in heredoc syntax.",
+                            "default": "escape",
+                            "enum": ["escape", "unescape", "ignore"]
+                        },
+                        "single_quoted": {
+                            "description": "Whether to escape backslashes in single-quoted strings.",
+                            "default": "unescape",
+                            "enum": ["escape", "unescape", "ignore"]
+                        }
+                    }
+                },
+                "string_length_to_empty": {
+                    "description": "String tests for empty must be done against `''`, not with `strlen`."
+                },
+                "string_line_ending": {
+                    "description": "All multi-line strings must use correct line ending."
+                },
+                "stringable_for_to_string": {
+                    "description": "A class that implements the `__toString()` method must explicitly implement the `Stringable` interface."
+                },
+                "switch_case_semicolon_to_colon": {
+                    "description": "A case should be followed by a colon and not a semicolon."
+                },
+                "switch_case_space": {
+                    "description": "Removes extra spaces between colon and case value."
+                },
+                "switch_continue_to_break": {
+                    "description": "Switch case must not be ended with `continue` but with `break`."
+                },
+                "ternary_operator_spaces": {
+                    "description": "Standardize spaces around ternary operator."
+                },
+                "ternary_to_elvis_operator": {
+                    "description": "Use the Elvis operator `?:` where possible."
+                },
+                "ternary_to_null_coalescing": {
+                    "description": "Use `null` coalescing operator `??` where possible."
+                },
+                "trailing_comma_in_multiline": {
+                    "description": "Arguments lists, array destructuring lists, arrays that are multi-line, `match`-lines and parameters lists must have a trailing comma.",
+                    "type": "object",
+                    "properties": {
+                        "after_heredoc": {
+                            "description": "Whether a trailing comma should also be placed after heredoc end.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "elements": {
+                            "description": "Where to fix multiline trailing comma (PHP >= 8.0 for `parameters` and `match`).",
+                            "default": ["arrays"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [
+                                [
+                                    "arguments",
+                                    "array_destructuring",
+                                    "arrays",
+                                    "match",
+                                    "parameters"
+                                ]
+                            ]
+                        }
+                    }
+                },
+                "trim_array_spaces": {
+                    "description": "Arrays should be formatted like function/method arguments, without leading or trailing single line space."
+                },
+                "type_declaration_spaces": {
+                    "description": "Ensure single space between a variable and its type declaration in function arguments and properties.",
+                    "type": "object",
+                    "properties": {
+                        "elements": {
+                            "description": "Structural elements where the spacing after the type declaration should be fixed.",
+                            "default": ["function", "property"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [["constant", "function", "property"]]
+                        }
+                    }
+                },
+                "types_spaces": {
+                    "description": "A single space or none should be around union type and intersection type operators.",
+                    "type": "object",
+                    "properties": {
+                        "space": {
+                            "description": "Spacing to apply around union type and intersection type operators.",
+                            "default": "none",
+                            "enum": ["none", "single"]
+                        },
+                        "space_multiple_catch": {
+                            "description": "Spacing to apply around type operator when catching exceptions of multiple types, use `null` to follow the value configured for `space`.",
+                            "default": null,
+                            "enum": ["none", "single", null]
+                        }
+                    }
+                },
+                "unary_operator_spaces": {
+                    "description": "Unary operators should be placed adjacent to their operands.",
+                    "type": "object",
+                    "properties": {
+                        "only_dec_inc": {
+                            "description": "Limit to increment and decrement operators.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "use_arrow_functions": {
+                    "description": "Anonymous functions with return as the only statement must use arrow functions."
+                },
+                "visibility_required": {
+                    "description": "Classes, constants, properties, and methods MUST have visibility declared, and keyword modifiers MUST be in the following order: inheritance modifier (`abstract` or `final`), visibility modifier (`public`, `protected`, or `private`), set-visibility modifier (`public(set)`, `protected(set)`, or `private(set)`), scope modifier (`static`), mutation modifier (`readonly`), type declaration, name.",
+                    "type": "object",
+                    "properties": {
+                        "elements": {
+                            "description": "The structural elements to fix.",
+                            "default": ["const", "method", "property"],
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "enum": [["const", "method", "property"]]
+                        }
+                    }
+                },
+                "void_return": {
+                    "description": "Add `void` return type to functions with missing or empty return statements, but priority is given to `@return` annotations.",
+                    "type": "object",
+                    "properties": {
+                        "fix_lambda": {
+                            "description": "Whether to fix lambda functions as well.",
+                            "default": true,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "whitespace_after_comma_in_array": {
+                    "description": "In array declaration, there MUST be a whitespace after each comma.",
+                    "type": "object",
+                    "properties": {
+                        "ensure_single_space": {
+                            "description": "If there are only horizontal whitespaces after the comma then ensure it is a single space.",
+                            "default": false,
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "yield_from_array_to_yields": {
+                    "description": "Yield from array must be unpacked to series of yields."
+                },
+                "yoda_style": {
+                    "description": "Write conditions in Yoda style (`true`), non-Yoda style (`['equal' => false, 'identical' => false, 'less_and_greater' => false]`) or ignore those conditions (`null`) based on configuration.",
+                    "type": "object",
+                    "properties": {
+                        "always_move_variable": {
+                            "description": "Whether variables should always be on non assignable side when applying Yoda style.",
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "equal": {
+                            "description": "Style for equal (`==`, `!=`) statements.",
+                            "default": true,
+                            "oneOf": [
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "identical": {
+                            "description": "Style for identical (`===`, `!==`) statements.",
+                            "default": true,
+                            "oneOf": [
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "less_and_greater": {
+                            "description": "Style for less and greater than (`<`, `<=`, `>`, `>=`) statements.",
+                            "default": null,
+                            "oneOf": [
+                                {
+                                    "type": "boolean"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/schema.json
+++ b/schema.json
@@ -58,10 +58,12 @@
                     }
                 },
                 "array_indentation": {
-                    "description": "Each element of an array must be indented exactly once."
+                    "description": "Each element of an array must be indented exactly once.",
+                    "type": "boolean"
                 },
                 "array_push": {
-                    "description": "Converts simple usages of `array_push($x, $y);` to `$x[] = $y;`."
+                    "description": "Converts simple usages of `array_push($x, $y);` to `$x[] = $y;`.",
+                    "type": "boolean"
                 },
                 "array_syntax": {
                     "description": "PHP arrays should be declared using the configured syntax.",
@@ -75,10 +77,12 @@
                     }
                 },
                 "assign_null_coalescing_to_coalesce_equal": {
-                    "description": "Use the null coalescing assignment operator `??=` where possible."
+                    "description": "Use the null coalescing assignment operator `??=` where possible.",
+                    "type": "boolean"
                 },
                 "attribute_block_no_spaces": {
-                    "description": "Remove spaces before and after the attributes block."
+                    "description": "Remove spaces before and after the attributes block.",
+                    "type": "boolean"
                 },
                 "attribute_empty_parentheses": {
                     "description": "PHP attributes declared without arguments must (not) be followed by empty parentheses.",
@@ -92,7 +96,8 @@
                     }
                 },
                 "backtick_to_shell_exec": {
-                    "description": "Converts backtick operators to `shell_exec` calls."
+                    "description": "Converts backtick operators to `shell_exec` calls.",
+                    "type": "boolean"
                 },
                 "binary_operator_spaces": {
                     "description": "Binary operators should be surrounded by space as configured.",
@@ -132,10 +137,12 @@
                     }
                 },
                 "blank_line_after_namespace": {
-                    "description": "There MUST be one blank line after the namespace declaration."
+                    "description": "There MUST be one blank line after the namespace declaration.",
+                    "type": "boolean"
                 },
                 "blank_line_after_opening_tag": {
-                    "description": "Ensure there is no code on the same line as the PHP open tag and it is followed by a blank line."
+                    "description": "Ensure there is no code on the same line as the PHP open tag and it is followed by a blank line.",
+                    "type": "boolean"
                 },
                 "blank_line_before_statement": {
                     "description": "An empty line feed must precede any configured statement.",
@@ -186,7 +193,8 @@
                     }
                 },
                 "blank_line_between_import_groups": {
-                    "description": "Putting blank lines between `use` statement groups."
+                    "description": "Putting blank lines between `use` statement groups.",
+                    "type": "boolean"
                 },
                 "blank_lines_before_namespace": {
                     "description": "Controls blank lines before a namespace declaration.",
@@ -354,25 +362,32 @@
                     }
                 },
                 "class_keyword": {
-                    "description": "Converts FQCN strings to `*::class` keywords."
+                    "description": "Converts FQCN strings to `*::class` keywords.",
+                    "type": "boolean"
                 },
                 "class_keyword_remove": {
-                    "description": "Converts `::class` keywords to FQCN strings."
+                    "description": "Converts `::class` keywords to FQCN strings.",
+                    "type": "boolean"
                 },
                 "class_reference_name_casing": {
-                    "description": "When referencing an internal class it must be written using the correct casing."
+                    "description": "When referencing an internal class it must be written using the correct casing.",
+                    "type": "boolean"
                 },
                 "clean_namespace": {
-                    "description": "Namespace must not contain spacing, comments or PHPDoc."
+                    "description": "Namespace must not contain spacing, comments or PHPDoc.",
+                    "type": "boolean"
                 },
                 "combine_consecutive_issets": {
-                    "description": "Using `isset($var) &&` multiple times should be done in one call."
+                    "description": "Using `isset($var) &&` multiple times should be done in one call.",
+                    "type": "boolean"
                 },
                 "combine_consecutive_unsets": {
-                    "description": "Calling `unset` on multiple items should be done in one call."
+                    "description": "Calling `unset` on multiple items should be done in one call.",
+                    "type": "boolean"
                 },
                 "combine_nested_dirname": {
-                    "description": "Replace multiple nested calls of `dirname` by only one call with second `$level` parameter."
+                    "description": "Replace multiple nested calls of `dirname` by only one call with second `$level` parameter.",
+                    "type": "boolean"
                 },
                 "comment_to_phpdoc": {
                     "description": "Comments with annotation should be docblock when used on structural elements.",
@@ -389,10 +404,12 @@
                     }
                 },
                 "compact_nullable_type_declaration": {
-                    "description": "Remove extra spaces in a nullable type declaration."
+                    "description": "Remove extra spaces in a nullable type declaration.",
+                    "type": "boolean"
                 },
                 "compact_nullable_typehint": {
-                    "description": "Remove extra spaces in a nullable typehint."
+                    "description": "Remove extra spaces in a nullable typehint.",
+                    "type": "boolean"
                 },
                 "concat_space": {
                     "description": "Concatenation should be spaced according to configuration.",
@@ -417,7 +434,8 @@
                     }
                 },
                 "control_structure_braces": {
-                    "description": "The body of each control structure MUST be enclosed within braces."
+                    "description": "The body of each control structure MUST be enclosed within braces.",
+                    "type": "boolean"
                 },
                 "control_structure_continuation_position": {
                     "description": "Control structure continuation keyword must be on the configured line.",
@@ -487,10 +505,12 @@
                     }
                 },
                 "date_time_create_from_format_call": {
-                    "description": "The first argument of `DateTime::createFromFormat` method must start with `!`."
+                    "description": "The first argument of `DateTime::createFromFormat` method must start with `!`.",
+                    "type": "boolean"
                 },
                 "date_time_immutable": {
-                    "description": "Class `DateTimeImmutable` should be used instead of `DateTime`."
+                    "description": "Class `DateTimeImmutable` should be used instead of `DateTime`.",
+                    "type": "boolean"
                 },
                 "declare_equal_normalize": {
                     "description": "Equal sign in declare statement should be surrounded by spaces or not following configuration.",
@@ -504,7 +524,8 @@
                     }
                 },
                 "declare_parentheses": {
-                    "description": "There must not be spaces around `declare` statement parentheses."
+                    "description": "There must not be spaces around `declare` statement parentheses.",
+                    "type": "boolean"
                 },
                 "declare_strict_types": {
                     "description": "Force strict types declaration in all files.",
@@ -518,7 +539,8 @@
                     }
                 },
                 "dir_constant": {
-                    "description": "Replaces `dirname(__FILE__)` expression with equivalent `__DIR__` constant."
+                    "description": "Replaces `dirname(__FILE__)` expression with equivalent `__DIR__` constant.",
+                    "type": "boolean"
                 },
                 "doctrine_annotation_array_assignment": {
                     "description": "Doctrine annotations must use configured operator for assignment in arrays.",
@@ -1063,7 +1085,8 @@
                     }
                 },
                 "elseif": {
-                    "description": "The keyword `elseif` should be used instead of `else if` so that all control keywords look like single words."
+                    "description": "The keyword `elseif` should be used instead of `else if` so that all control keywords look like single words.",
+                    "type": "boolean"
                 },
                 "empty_loop_body": {
                     "description": "Empty loop-body must be in configured style.",
@@ -1090,10 +1113,12 @@
                     }
                 },
                 "encoding": {
-                    "description": "PHP code MUST use only UTF-8 without BOM (remove BOM)."
+                    "description": "PHP code MUST use only UTF-8 without BOM (remove BOM).",
+                    "type": "boolean"
                 },
                 "ereg_to_preg": {
-                    "description": "Replace deprecated `ereg` regular expression functions with `preg`."
+                    "description": "Replace deprecated `ereg` regular expression functions with `preg`.",
+                    "type": "boolean"
                 },
                 "error_suppression": {
                     "description": "Error control operator should be added to deprecation notices and/or removed from other cases.",
@@ -1141,13 +1166,16 @@
                     }
                 },
                 "explicit_indirect_variable": {
-                    "description": "Add curly braces to indirect variables to make them clear to understand."
+                    "description": "Add curly braces to indirect variables to make them clear to understand.",
+                    "type": "boolean"
                 },
                 "explicit_string_variable": {
-                    "description": "Converts implicit variables into explicit ones in double-quoted strings or heredoc syntax."
+                    "description": "Converts implicit variables into explicit ones in double-quoted strings or heredoc syntax.",
+                    "type": "boolean"
                 },
                 "final_class": {
-                    "description": "All classes must be final, except abstract ones and Doctrine entities."
+                    "description": "All classes must be final, except abstract ones and Doctrine entities.",
+                    "type": "boolean"
                 },
                 "final_internal_class": {
                     "description": "Internal classes should be `final`.",
@@ -1209,10 +1237,12 @@
                     }
                 },
                 "final_public_method_for_abstract_class": {
-                    "description": "All `public` methods of `abstract` classes should be `final`."
+                    "description": "All `public` methods of `abstract` classes should be `final`.",
+                    "type": "boolean"
                 },
                 "fopen_flag_order": {
-                    "description": "Order the flags in `fopen` calls, `b` and `t` must be last."
+                    "description": "Order the flags in `fopen` calls, `b` and `t` must be last.",
+                    "type": "boolean"
                 },
                 "fopen_flags": {
                     "description": "The flags in `fopen` calls must omit `t`, and `b` must be omitted or included consistently.",
@@ -1226,7 +1256,8 @@
                     }
                 },
                 "full_opening_tag": {
-                    "description": "PHP code must use the long `<?php` tags or short-echo `<?=` tags and not other tag variations."
+                    "description": "PHP code must use the long `<?php` tags or short-echo `<?=` tags and not other tag variations.",
+                    "type": "boolean"
                 },
                 "fully_qualified_strict_types": {
                     "description": "Removes the leading part of fully qualified symbol references if a given symbol is imported or belongs to the current namespace.",
@@ -1326,7 +1357,8 @@
                     }
                 },
                 "function_typehint_space": {
-                    "description": "Ensure single space between function's argument and its typehint."
+                    "description": "Ensure single space between function's argument and its typehint.",
+                    "type": "boolean"
                 },
                 "general_attribute_remove": {
                     "description": "Removes configured attributes by their respective FQN.",
@@ -1391,7 +1423,8 @@
                     }
                 },
                 "get_class_to_class_keyword": {
-                    "description": "Replace `get_class` calls on object variables with class keyword syntax."
+                    "description": "Replace `get_class` calls on object variables with class keyword syntax.",
+                    "type": "boolean"
                 },
                 "global_namespace_import": {
                     "description": "Imports or fully qualifies global classes/functions/constants.",
@@ -1536,13 +1569,16 @@
                     }
                 },
                 "heredoc_to_nowdoc": {
-                    "description": "Convert `heredoc` to `nowdoc` where possible."
+                    "description": "Convert `heredoc` to `nowdoc` where possible.",
+                    "type": "boolean"
                 },
                 "implode_call": {
-                    "description": "Function `implode` must be called with 2 arguments in the documented order."
+                    "description": "Function `implode` must be called with 2 arguments in the documented order.",
+                    "type": "boolean"
                 },
                 "include": {
-                    "description": "Include/Require and file path should be divided with a single space. File path should not be placed within parentheses."
+                    "description": "Include/Require and file path should be divided with a single space. File path should not be placed within parentheses.",
+                    "type": "boolean"
                 },
                 "increment_style": {
                     "description": "Pre- or post-increment and decrement operators should be used if possible.",
@@ -1556,22 +1592,28 @@
                     }
                 },
                 "indentation_type": {
-                    "description": "Code MUST use configured indentation type."
+                    "description": "Code MUST use configured indentation type.",
+                    "type": "boolean"
                 },
                 "integer_literal_case": {
-                    "description": "Integer literals must be in correct case."
+                    "description": "Integer literals must be in correct case.",
+                    "type": "boolean"
                 },
                 "is_null": {
-                    "description": "Replaces `is_null($var)` expression with `null === $var`."
+                    "description": "Replaces `is_null($var)` expression with `null === $var`.",
+                    "type": "boolean"
                 },
                 "lambda_not_used_import": {
-                    "description": "Lambda must not import variables it doesn't use."
+                    "description": "Lambda must not import variables it doesn't use.",
+                    "type": "boolean"
                 },
                 "line_ending": {
-                    "description": "All PHP files must use same line ending."
+                    "description": "All PHP files must use same line ending.",
+                    "type": "boolean"
                 },
                 "linebreak_after_opening_tag": {
-                    "description": "Ensure there is no code on the same line as the PHP open tag."
+                    "description": "Ensure there is no code on the same line as the PHP open tag.",
+                    "type": "boolean"
                 },
                 "list_syntax": {
                     "description": "List (`array` destructuring) assignment should be declared using the configured syntax.",
@@ -1585,28 +1627,36 @@
                     }
                 },
                 "logical_operators": {
-                    "description": "Use `&&` and `||` logical operators instead of `and` and `or`."
+                    "description": "Use `&&` and `||` logical operators instead of `and` and `or`.",
+                    "type": "boolean"
                 },
                 "long_to_shorthand_operator": {
-                    "description": "Shorthand notation for operators should be used if possible."
+                    "description": "Shorthand notation for operators should be used if possible.",
+                    "type": "boolean"
                 },
                 "lowercase_cast": {
-                    "description": "Cast should be written in lower case."
+                    "description": "Cast should be written in lower case.",
+                    "type": "boolean"
                 },
                 "lowercase_keywords": {
-                    "description": "PHP keywords MUST be in lower case."
+                    "description": "PHP keywords MUST be in lower case.",
+                    "type": "boolean"
                 },
                 "lowercase_static_reference": {
-                    "description": "Class static references `self`, `static` and `parent` MUST be in lower case."
+                    "description": "Class static references `self`, `static` and `parent` MUST be in lower case.",
+                    "type": "boolean"
                 },
                 "magic_constant_casing": {
-                    "description": "Magic constants should be referred to using the correct casing."
+                    "description": "Magic constants should be referred to using the correct casing.",
+                    "type": "boolean"
                 },
                 "magic_method_casing": {
-                    "description": "Magic method definitions and calls must be using the correct casing."
+                    "description": "Magic method definitions and calls must be using the correct casing.",
+                    "type": "boolean"
                 },
                 "mb_str_functions": {
-                    "description": "Replace non multibyte-safe functions with corresponding mb function."
+                    "description": "Replace non multibyte-safe functions with corresponding mb function.",
+                    "type": "boolean"
                 },
                 "method_argument_space": {
                     "description": "In method arguments and method call, there MUST NOT be a space before each comma and there MUST be one space after each comma. Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line.",
@@ -1639,10 +1689,12 @@
                     }
                 },
                 "method_chaining_indentation": {
-                    "description": "Method chaining MUST be properly indented. Method chaining with different levels of indentation is not supported."
+                    "description": "Method chaining MUST be properly indented. Method chaining with different levels of indentation is not supported.",
+                    "type": "boolean"
                 },
                 "modern_serialization_methods": {
-                    "description": "Use new serialization methods `__serialize` and `__unserialize` instead of deprecated ones `__sleep` and `__wakeup`."
+                    "description": "Use new serialization methods `__serialize` and `__unserialize` instead of deprecated ones `__sleep` and `__wakeup`.",
+                    "type": "boolean"
                 },
                 "modernize_strpos": {
                     "description": "Replace `strpos()` and `stripos()` calls with `str_starts_with()` or `str_contains()` if possible.",
@@ -1656,7 +1708,8 @@
                     }
                 },
                 "modernize_types_casting": {
-                    "description": "Replaces `intval`, `floatval`, `doubleval`, `strval` and `boolval` function calls with according type casting operator."
+                    "description": "Replaces `intval`, `floatval`, `doubleval`, `strval` and `boolval` function calls with according type casting operator.",
+                    "type": "boolean"
                 },
                 "modifier_keywords": {
                     "description": "Classes, constants, properties, and methods MUST have visibility declared, and keyword modifiers MUST be in the following order: inheritance modifier (`abstract` or `final`), visibility modifier (`public`, `protected`, or `private`), set-visibility modifier (`public(set)`, `protected(set)`, or `private(set)`), scope modifier (`static`), mutation modifier (`readonly`), type declaration, name.",
@@ -1674,7 +1727,8 @@
                     }
                 },
                 "multiline_comment_opening_closing": {
-                    "description": "DocBlocks must start with two asterisks, multiline comments must start with a single asterisk, after the opening slash. Both must end with a single asterisk before the closing slash."
+                    "description": "DocBlocks must start with two asterisks, multiline comments must start with a single asterisk, after the opening slash. Both must end with a single asterisk before the closing slash.",
+                    "type": "boolean"
                 },
                 "multiline_promoted_properties": {
                     "description": "Promoted properties must be on separate lines.",
@@ -1693,7 +1747,8 @@
                     }
                 },
                 "multiline_string_to_heredoc": {
-                    "description": "Convert multiline string to `heredoc` or `nowdoc`."
+                    "description": "Convert multiline string to `heredoc` or `nowdoc`.",
+                    "type": "boolean"
                 },
                 "multiline_whitespace_before_semicolons": {
                     "description": "Forbid multi-line whitespace before the closing semicolon or move the semicolon to the new line for chained calls.",
@@ -1747,7 +1802,8 @@
                     }
                 },
                 "native_function_casing": {
-                    "description": "Function defined by PHP should be called using the correct casing."
+                    "description": "Function defined by PHP should be called using the correct casing.",
+                    "type": "boolean"
                 },
                 "native_function_invocation": {
                     "description": "Add leading `\\` before function invocation to speed up resolving.",
@@ -1782,10 +1838,12 @@
                     }
                 },
                 "native_function_type_declaration_casing": {
-                    "description": "Native type declarations for functions should use the correct case."
+                    "description": "Native type declarations for functions should use the correct case.",
+                    "type": "boolean"
                 },
                 "native_type_declaration_casing": {
-                    "description": "Native type declarations should be used in the correct case."
+                    "description": "Native type declarations should be used in the correct case.",
+                    "type": "boolean"
                 },
                 "new_expression_parentheses": {
                     "description": "All `new` expressions with a further call must (not) be wrapped in parentheses.",
@@ -1866,7 +1924,8 @@
                     }
                 },
                 "no_alias_language_construct_call": {
-                    "description": "Master language constructs shall be used instead of aliases."
+                    "description": "Master language constructs shall be used instead of aliases.",
+                    "type": "boolean"
                 },
                 "no_alternative_syntax": {
                     "description": "Replace control structure alternative syntax to use braces.",
@@ -1880,16 +1939,20 @@
                     }
                 },
                 "no_binary_string": {
-                    "description": "There should not be a binary flag before strings."
+                    "description": "There should not be a binary flag before strings.",
+                    "type": "boolean"
                 },
                 "no_blank_lines_after_class_opening": {
-                    "description": "There should be no empty lines after class opening brace."
+                    "description": "There should be no empty lines after class opening brace.",
+                    "type": "boolean"
                 },
                 "no_blank_lines_after_phpdoc": {
-                    "description": "There should not be blank lines between docblock and the documented element."
+                    "description": "There should not be blank lines between docblock and the documented element.",
+                    "type": "boolean"
                 },
                 "no_blank_lines_before_namespace": {
-                    "description": "There should be no blank lines before a namespace declaration."
+                    "description": "There should be no blank lines before a namespace declaration.",
+                    "type": "boolean"
                 },
                 "no_break_comment": {
                     "description": "There must be a comment when fall-through is intentional in a non-empty case body.",
@@ -1903,16 +1966,20 @@
                     }
                 },
                 "no_closing_tag": {
-                    "description": "The closing `?>` tag MUST be omitted from files containing only PHP."
+                    "description": "The closing `?>` tag MUST be omitted from files containing only PHP.",
+                    "type": "boolean"
                 },
                 "no_empty_comment": {
-                    "description": "There should not be any empty comments."
+                    "description": "There should not be any empty comments.",
+                    "type": "boolean"
                 },
                 "no_empty_phpdoc": {
-                    "description": "There should not be empty PHPDoc blocks."
+                    "description": "There should not be empty PHPDoc blocks.",
+                    "type": "boolean"
                 },
                 "no_empty_statement": {
-                    "description": "Remove useless (semicolon) statements."
+                    "description": "Remove useless (semicolon) statements.",
+                    "type": "boolean"
                 },
                 "no_extra_blank_lines": {
                     "description": "Removes extra blank lines and/or blank lines following configuration.",
@@ -1948,13 +2015,16 @@
                     }
                 },
                 "no_homoglyph_names": {
-                    "description": "Replace accidental usage of homoglyphs (non ascii characters) in names."
+                    "description": "Replace accidental usage of homoglyphs (non ascii characters) in names.",
+                    "type": "boolean"
                 },
                 "no_leading_import_slash": {
-                    "description": "Remove leading slashes in `use` clauses."
+                    "description": "Remove leading slashes in `use` clauses.",
+                    "type": "boolean"
                 },
                 "no_leading_namespace_whitespace": {
-                    "description": "The namespace declaration line shouldn't contain leading whitespace."
+                    "description": "The namespace declaration line shouldn't contain leading whitespace.",
+                    "type": "boolean"
                 },
                 "no_mixed_echo_print": {
                     "description": "Either language construct `print` or `echo` should be used.",
@@ -1968,31 +2038,40 @@
                     }
                 },
                 "no_multiline_whitespace_around_double_arrow": {
-                    "description": "Operator `=>` should not be surrounded by multi-line whitespaces."
+                    "description": "Operator `=>` should not be surrounded by multi-line whitespaces.",
+                    "type": "boolean"
                 },
                 "no_multiple_statements_per_line": {
-                    "description": "There must not be more than one statement per line."
+                    "description": "There must not be more than one statement per line.",
+                    "type": "boolean"
                 },
                 "no_null_property_initialization": {
-                    "description": "Properties MUST not be explicitly initialised with `null` except when they have a type declaration (PHP 7.4)."
+                    "description": "Properties MUST not be explicitly initialised with `null` except when they have a type declaration (PHP 7.4).",
+                    "type": "boolean"
                 },
                 "no_php4_constructor": {
-                    "description": "Convert PHP4-style constructors to `__construct`."
+                    "description": "Convert PHP4-style constructors to `__construct`.",
+                    "type": "boolean"
                 },
                 "no_redundant_readonly_property": {
-                    "description": "Removes redundant readonly from properties in readonly classes."
+                    "description": "Removes redundant readonly from properties in readonly classes.",
+                    "type": "boolean"
                 },
                 "no_short_bool_cast": {
-                    "description": "Short cast `bool` using double exclamation mark should not be used."
+                    "description": "Short cast `bool` using double exclamation mark should not be used.",
+                    "type": "boolean"
                 },
                 "no_singleline_whitespace_before_semicolons": {
-                    "description": "Single-line whitespace before closing semicolon are prohibited."
+                    "description": "Single-line whitespace before closing semicolon are prohibited.",
+                    "type": "boolean"
                 },
                 "no_space_around_double_colon": {
-                    "description": "There must be no space around double colons (also called Scope Resolution Operator or Paamayim Nekudotayim)."
+                    "description": "There must be no space around double colons (also called Scope Resolution Operator or Paamayim Nekudotayim).",
+                    "type": "boolean"
                 },
                 "no_spaces_after_function_name": {
-                    "description": "When making a method or function call, there MUST NOT be a space between the method or function name and the opening parenthesis."
+                    "description": "When making a method or function call, there MUST NOT be a space between the method or function name and the opening parenthesis.",
+                    "type": "boolean"
                 },
                 "no_spaces_around_offset": {
                     "description": "There MUST NOT be spaces around offset braces.",
@@ -2010,10 +2089,12 @@
                     }
                 },
                 "no_spaces_inside_parenthesis": {
-                    "description": "There MUST NOT be a space after the opening parenthesis. There MUST NOT be a space before the closing parenthesis."
+                    "description": "There MUST NOT be a space after the opening parenthesis. There MUST NOT be a space before the closing parenthesis.",
+                    "type": "boolean"
                 },
                 "no_superfluous_elseif": {
-                    "description": "Replaces superfluous `elseif` with `if`."
+                    "description": "Replaces superfluous `elseif` with `if`.",
+                    "type": "boolean"
                 },
                 "no_superfluous_phpdoc_tags": {
                     "description": "Removes `@param`, `@return` and `@var` tags that don't provide any useful information.",
@@ -2042,7 +2123,8 @@
                     }
                 },
                 "no_trailing_comma_in_list_call": {
-                    "description": "Remove trailing commas in list function calls."
+                    "description": "Remove trailing commas in list function calls.",
+                    "type": "boolean"
                 },
                 "no_trailing_comma_in_singleline": {
                     "description": "If a list of values separated by a comma is contained on a single line, then the last item MUST NOT have a trailing comma.",
@@ -2072,19 +2154,24 @@
                     }
                 },
                 "no_trailing_comma_in_singleline_array": {
-                    "description": "PHP single-line arrays should not have trailing comma."
+                    "description": "PHP single-line arrays should not have trailing comma.",
+                    "type": "boolean"
                 },
                 "no_trailing_comma_in_singleline_function_call": {
-                    "description": "When making a method or function call on a single line there MUST NOT be a trailing comma after the last argument."
+                    "description": "When making a method or function call on a single line there MUST NOT be a trailing comma after the last argument.",
+                    "type": "boolean"
                 },
                 "no_trailing_whitespace": {
-                    "description": "There must be no trailing whitespace at the end of non-blank lines."
+                    "description": "There must be no trailing whitespace at the end of non-blank lines.",
+                    "type": "boolean"
                 },
                 "no_trailing_whitespace_in_comment": {
-                    "description": "There must be no trailing whitespace at the end of lines in comments and PHPDocs."
+                    "description": "There must be no trailing whitespace at the end of lines in comments and PHPDocs.",
+                    "type": "boolean"
                 },
                 "no_trailing_whitespace_in_string": {
-                    "description": "There must be no trailing whitespace at the end of lines in strings."
+                    "description": "There must be no trailing whitespace at the end of lines in strings.",
+                    "type": "boolean"
                 },
                 "no_unneeded_braces": {
                     "description": "Removes unneeded braces that are superfluous and aren't part of a control structure's body.",
@@ -2156,19 +2243,24 @@
                     }
                 },
                 "no_unneeded_import_alias": {
-                    "description": "Imports should not be aliased as the same name."
+                    "description": "Imports should not be aliased as the same name.",
+                    "type": "boolean"
                 },
                 "no_unreachable_default_argument_value": {
-                    "description": "In function arguments there must not be arguments with default values before non-default ones."
+                    "description": "In function arguments there must not be arguments with default values before non-default ones.",
+                    "type": "boolean"
                 },
                 "no_unset_cast": {
-                    "description": "Variables must be set `null` instead of using `(unset)` casting."
+                    "description": "Variables must be set `null` instead of using `(unset)` casting.",
+                    "type": "boolean"
                 },
                 "no_unset_on_property": {
-                    "description": "Properties should be set to `null` instead of using `unset`."
+                    "description": "Properties should be set to `null` instead of using `unset`.",
+                    "type": "boolean"
                 },
                 "no_unused_imports": {
-                    "description": "Unused `use` statements must be removed."
+                    "description": "Unused `use` statements must be removed.",
+                    "type": "boolean"
                 },
                 "no_useless_concat_operator": {
                     "description": "There should not be useless concat operations.",
@@ -2182,19 +2274,24 @@
                     }
                 },
                 "no_useless_else": {
-                    "description": "There should not be useless `else` cases."
+                    "description": "There should not be useless `else` cases.",
+                    "type": "boolean"
                 },
                 "no_useless_nullsafe_operator": {
-                    "description": "There should not be useless Null-safe operator `?->` used."
+                    "description": "There should not be useless Null-safe operator `?->` used.",
+                    "type": "boolean"
                 },
                 "no_useless_printf": {
-                    "description": "There must be no `printf` calls with only the first argument."
+                    "description": "There must be no `printf` calls with only the first argument.",
+                    "type": "boolean"
                 },
                 "no_useless_return": {
-                    "description": "There should not be an empty `return` statement at the end of a function."
+                    "description": "There should not be an empty `return` statement at the end of a function.",
+                    "type": "boolean"
                 },
                 "no_useless_sprintf": {
-                    "description": "There must be no `sprintf` calls with only the first argument."
+                    "description": "There must be no `sprintf` calls with only the first argument.",
+                    "type": "boolean"
                 },
                 "no_whitespace_before_comma_in_array": {
                     "description": "In array declaration, there MUST NOT be a whitespace before each comma.",
@@ -2208,7 +2305,8 @@
                     }
                 },
                 "no_whitespace_in_blank_line": {
-                    "description": "Remove trailing whitespace at the end of blank lines."
+                    "description": "Remove trailing whitespace at the end of blank lines.",
+                    "type": "boolean"
                 },
                 "non_printable_character": {
                     "description": "Remove Zero-width space (ZWSP), Non-breaking space (NBSP) and other invisible unicode symbols.",
@@ -2222,13 +2320,16 @@
                     }
                 },
                 "normalize_index_brace": {
-                    "description": "Array index should always be written by using square braces."
+                    "description": "Array index should always be written by using square braces.",
+                    "type": "boolean"
                 },
                 "not_operator_with_space": {
-                    "description": "Logical NOT operators (`!`) should have leading and trailing whitespaces."
+                    "description": "Logical NOT operators (`!`) should have leading and trailing whitespaces.",
+                    "type": "boolean"
                 },
                 "not_operator_with_successor_space": {
-                    "description": "Logical NOT operators (`!`) should have one trailing whitespace."
+                    "description": "Logical NOT operators (`!`) should have one trailing whitespace.",
+                    "type": "boolean"
                 },
                 "nullable_type_declaration": {
                     "description": "Nullable single type declaration should be standardised using configured syntax.",
@@ -2269,10 +2370,12 @@
                     }
                 },
                 "object_operator_without_whitespace": {
-                    "description": "There should not be space before or after object operators `->` and `?->`."
+                    "description": "There should not be space before or after object operators `->` and `?->`.",
+                    "type": "boolean"
                 },
                 "octal_notation": {
-                    "description": "Literal octal must be in `0o` notation."
+                    "description": "Literal octal must be in `0o` notation.",
+                    "type": "boolean"
                 },
                 "operator_linebreak": {
                     "description": "Operators - when multiline - must always be at the beginning or at the end of the line.",
@@ -2434,7 +2537,8 @@
                     }
                 },
                 "php_unit_assert_new_names": {
-                    "description": "Rename deprecated PHPUnit assertions like `assertFileNotExists` to new methods like `assertFileDoesNotExist`."
+                    "description": "Rename deprecated PHPUnit assertions like `assertFileNotExists` to new methods like `assertFileDoesNotExist`.",
+                    "type": "boolean"
                 },
                 "php_unit_attributes": {
                     "description": "PHPUnit attributes must be used over their respective PHPDoc-based annotations.",
@@ -2502,7 +2606,8 @@
                     }
                 },
                 "php_unit_data_provider_return_type": {
-                    "description": "The return type of PHPUnit data provider must be `iterable`."
+                    "description": "The return type of PHPUnit data provider must be `iterable`.",
+                    "type": "boolean"
                 },
                 "php_unit_data_provider_static": {
                     "description": "Data providers must be static.",
@@ -2552,7 +2657,8 @@
                     }
                 },
                 "php_unit_fqcn_annotation": {
-                    "description": "PHPUnit annotations should be a FQCNs including a root namespace."
+                    "description": "PHPUnit annotations should be a FQCNs including a root namespace.",
+                    "type": "boolean"
                 },
                 "php_unit_internal_class": {
                     "description": "All PHPUnit test classes should be marked as internal.",
@@ -2593,7 +2699,8 @@
                     }
                 },
                 "php_unit_mock_short_will_return": {
-                    "description": "Usage of PHPUnit's mock e.g. `->will($this->returnValue(..))` must be replaced by its shorter equivalent such as `->willReturn(...)`."
+                    "description": "Usage of PHPUnit's mock e.g. `->will($this->returnValue(..))` must be replaced by its shorter equivalent such as `->willReturn(...)`.",
+                    "type": "boolean"
                 },
                 "php_unit_namespaced": {
                     "description": "PHPUnit classes MUST be used in namespaced version, e.g. `\\PHPUnit\\Framework\\TestCase` instead of `\\PHPUnit_Framework_TestCase`.",
@@ -2625,7 +2732,8 @@
                     }
                 },
                 "php_unit_set_up_tear_down_visibility": {
-                    "description": "Changes the visibility of the `setUp()` and `tearDown()` functions of PHPUnit to `protected`, to match the PHPUnit TestCase."
+                    "description": "Changes the visibility of the `setUp()` and `tearDown()` functions of PHPUnit to `protected`, to match the PHPUnit TestCase.",
+                    "type": "boolean"
                 },
                 "php_unit_size_class": {
                     "description": "All PHPUnit test cases should have `@small`, `@medium` or `@large` annotation to enable run time limits.",
@@ -2703,7 +2811,8 @@
                     }
                 },
                 "php_unit_test_class_requires_covers": {
-                    "description": "Adds a default `@coversNothing` annotation to PHPUnit test classes that have no `@covers*` annotation."
+                    "description": "Adds a default `@coversNothing` annotation to PHPUnit test classes that have no `@covers*` annotation.",
+                    "type": "boolean"
                 },
                 "phpdoc_add_missing_param_annotation": {
                     "description": "PHPDoc should contain `@param` for all params.",
@@ -2760,13 +2869,16 @@
                     }
                 },
                 "phpdoc_annotation_without_dot": {
-                    "description": "PHPDoc annotation descriptions should not be a sentence."
+                    "description": "PHPDoc annotation descriptions should not be a sentence.",
+                    "type": "boolean"
                 },
                 "phpdoc_array_type": {
-                    "description": "PHPDoc `array<T>` type must be used instead of `T[]`."
+                    "description": "PHPDoc `array<T>` type must be used instead of `T[]`.",
+                    "type": "boolean"
                 },
                 "phpdoc_indent": {
-                    "description": "Docblocks should have the same indentation as the documented subject."
+                    "description": "Docblocks should have the same indentation as the documented subject.",
+                    "type": "boolean"
                 },
                 "phpdoc_inline_tag_normalizer": {
                     "description": "Fixes PHPDoc inline tags.",
@@ -2834,10 +2946,12 @@
                     }
                 },
                 "phpdoc_list_type": {
-                    "description": "PHPDoc `list` type must be used instead of `array` without a key."
+                    "description": "PHPDoc `list` type must be used instead of `array` without a key.",
+                    "type": "boolean"
                 },
                 "phpdoc_no_access": {
-                    "description": "`@access` annotations must be removed from PHPDoc."
+                    "description": "`@access` annotations must be removed from PHPDoc.",
+                    "type": "boolean"
                 },
                 "phpdoc_no_alias_tag": {
                     "description": "No alias PHPDoc tags should be used.",
@@ -2859,13 +2973,16 @@
                     }
                 },
                 "phpdoc_no_empty_return": {
-                    "description": "`@return void` and `@return null` annotations must be removed from PHPDoc."
+                    "description": "`@return void` and `@return null` annotations must be removed from PHPDoc.",
+                    "type": "boolean"
                 },
                 "phpdoc_no_package": {
-                    "description": "`@package` and `@subpackage` annotations must be removed from PHPDoc."
+                    "description": "`@package` and `@subpackage` annotations must be removed from PHPDoc.",
+                    "type": "boolean"
                 },
                 "phpdoc_no_useless_inheritdoc": {
-                    "description": "Classy that does not inherit must not have `@inheritdoc` tags."
+                    "description": "Classy that does not inherit must not have `@inheritdoc` tags.",
+                    "type": "boolean"
                 },
                 "phpdoc_order": {
                     "description": "Annotations in PHPDoc should be ordered in defined sequence.",
@@ -2915,10 +3032,12 @@
                     }
                 },
                 "phpdoc_param_order": {
-                    "description": "Orders all `@param` annotations in DocBlocks according to method signature."
+                    "description": "Orders all `@param` annotations in DocBlocks according to method signature.",
+                    "type": "boolean"
                 },
                 "phpdoc_readonly_class_comment_to_keyword": {
-                    "description": "Converts readonly comment on classes to the readonly keyword."
+                    "description": "Converts readonly comment on classes to the readonly keyword.",
+                    "type": "boolean"
                 },
                 "phpdoc_return_self_reference": {
                     "description": "The type of `@return` annotations of methods returning a reference to itself must the configured one.",
@@ -2999,10 +3118,12 @@
                     }
                 },
                 "phpdoc_single_line_var_spacing": {
-                    "description": "Single line `@var` PHPDoc should have proper spacing."
+                    "description": "Single line `@var` PHPDoc should have proper spacing.",
+                    "type": "boolean"
                 },
                 "phpdoc_summary": {
-                    "description": "PHPDoc summary should end in either a full stop, exclamation mark, or question mark."
+                    "description": "PHPDoc summary should end in either a full stop, exclamation mark, or question mark.",
+                    "type": "boolean"
                 },
                 "phpdoc_tag_casing": {
                     "description": "Fixes casing of PHPDoc tags.",
@@ -3167,10 +3288,12 @@
                     }
                 },
                 "phpdoc_trim": {
-                    "description": "PHPDoc should start and end with content, excluding the very first and last line of the docblocks."
+                    "description": "PHPDoc should start and end with content, excluding the very first and last line of the docblocks.",
+                    "type": "boolean"
                 },
                 "phpdoc_trim_consecutive_blank_line_separation": {
-                    "description": "Removes extra blank lines after summary and after description in PHPDoc."
+                    "description": "Removes extra blank lines after summary and after description in PHPDoc.",
+                    "type": "boolean"
                 },
                 "phpdoc_types": {
                     "description": "The correct case must be used for standard PHP types in PHPDoc.",
@@ -3188,7 +3311,8 @@
                     }
                 },
                 "phpdoc_types_no_duplicates": {
-                    "description": "Removes duplicate PHPDoc types."
+                    "description": "Removes duplicate PHPDoc types.",
+                    "type": "boolean"
                 },
                 "phpdoc_types_order": {
                     "description": "Sorts PHPDoc types.",
@@ -3212,20 +3336,24 @@
                     }
                 },
                 "phpdoc_var_annotation_correct_order": {
-                    "description": "`@var` and `@type` annotations must have type and name in the correct order."
+                    "description": "`@var` and `@type` annotations must have type and name in the correct order.",
+                    "type": "boolean"
                 },
                 "phpdoc_var_without_name": {
-                    "description": "`@var` and `@type` annotations of classy properties should not contain the name."
+                    "description": "`@var` and `@type` annotations of classy properties should not contain the name.",
+                    "type": "boolean"
                 },
                 "Pint/phpdoc_type_annotations_only": {
                     "description": "Removes all prose from comments, keeping only `@` annotations (e.g. `@param`, `@return`, `@var`, `@phpstan-type`). Use `@note`, `@warning`, or `@todo` to preserve comments.",
                     "type": "boolean"
                 },
                 "pow_to_exponentiation": {
-                    "description": "Converts `pow` to the `**` operator."
+                    "description": "Converts `pow` to the `**` operator.",
+                    "type": "boolean"
                 },
                 "protected_to_private": {
-                    "description": "Converts `protected` variables and methods to `private` where possible."
+                    "description": "Converts `protected` variables and methods to `private` where possible.",
+                    "type": "boolean"
                 },
                 "psr_autoloading": {
                     "description": "Classes must be in a path that matches their namespace, be at least one namespace deep and the class name should match the file name.",
@@ -3264,13 +3392,16 @@
                     }
                 },
                 "regular_callable_call": {
-                    "description": "Callables must be called without using `call_user_func*` when possible."
+                    "description": "Callables must be called without using `call_user_func*` when possible.",
+                    "type": "boolean"
                 },
                 "return_assignment": {
-                    "description": "Local, dynamic and directly referenced variables should not be assigned and directly returned by a function or method."
+                    "description": "Local, dynamic and directly referenced variables should not be assigned and directly returned by a function or method.",
+                    "type": "boolean"
                 },
                 "return_to_yield_from": {
-                    "description": "If the function explicitly returns an array, and has the return type `iterable`, then `yield from` must be used instead of `return`."
+                    "description": "If the function explicitly returns an array, and has the return type `iterable`, then `yield from` must be used instead of `return`.",
+                    "type": "boolean"
                 },
                 "return_type_declaration": {
                     "description": "Adjust spacing around colon in return type declarations and backed enum types.",
@@ -3284,34 +3415,44 @@
                     }
                 },
                 "self_accessor": {
-                    "description": "Inside class or interface element `self` should be preferred to the class name itself."
+                    "description": "Inside class or interface element `self` should be preferred to the class name itself.",
+                    "type": "boolean"
                 },
                 "self_static_accessor": {
-                    "description": "Inside an enum or `final`/anonymous class, `self` should be preferred over `static`."
+                    "description": "Inside an enum or `final`/anonymous class, `self` should be preferred over `static`.",
+                    "type": "boolean"
                 },
                 "semicolon_after_instruction": {
-                    "description": "Instructions must be terminated with a semicolon."
+                    "description": "Instructions must be terminated with a semicolon.",
+                    "type": "boolean"
                 },
                 "set_type_to_cast": {
-                    "description": "Cast shall be used, not `settype`."
+                    "description": "Cast shall be used, not `settype`.",
+                    "type": "boolean"
                 },
                 "short_scalar_cast": {
-                    "description": "Cast `(boolean)` and `(integer)` should be written as `(bool)` and `(int)`, `(double)` and `(real)` as `(float)`, `(binary)` as `(string)`."
+                    "description": "Cast `(boolean)` and `(integer)` should be written as `(bool)` and `(int)`, `(double)` and `(real)` as `(float)`, `(binary)` as `(string)`.",
+                    "type": "boolean"
                 },
                 "simple_to_complex_string_variable": {
-                    "description": "Converts explicit variables in double-quoted strings and heredoc syntax from simple to complex format (`${` to `{$`)."
+                    "description": "Converts explicit variables in double-quoted strings and heredoc syntax from simple to complex format (`${` to `{$`).",
+                    "type": "boolean"
                 },
                 "simplified_if_return": {
-                    "description": "Simplify `if` control structures that return the boolean result of their condition."
+                    "description": "Simplify `if` control structures that return the boolean result of their condition.",
+                    "type": "boolean"
                 },
                 "simplified_null_return": {
-                    "description": "A return statement wishing to return `void` should not return `null`."
+                    "description": "A return statement wishing to return `void` should not return `null`.",
+                    "type": "boolean"
                 },
                 "single_blank_line_at_eof": {
-                    "description": "A PHP file without end tag must always end with a single empty line feed."
+                    "description": "A PHP file without end tag must always end with a single empty line feed.",
+                    "type": "boolean"
                 },
                 "single_blank_line_before_namespace": {
-                    "description": "There should be exactly one blank line before a namespace declaration."
+                    "description": "There should be exactly one blank line before a namespace declaration.",
+                    "type": "boolean"
                 },
                 "single_class_element_per_statement": {
                     "description": "There MUST NOT be more than one property or constant declared per statement.",
@@ -3340,10 +3481,12 @@
                     }
                 },
                 "single_line_after_imports": {
-                    "description": "Each namespace use MUST go on its own line and there MUST be one blank line after the use statements block."
+                    "description": "Each namespace use MUST go on its own line and there MUST be one blank line after the use statements block.",
+                    "type": "boolean"
                 },
                 "single_line_comment_spacing": {
-                    "description": "Single-line comments must have proper spacing."
+                    "description": "Single-line comments must have proper spacing.",
+                    "type": "boolean"
                 },
                 "single_line_comment_style": {
                     "description": "Single-line comments and multi-line comments with only one line of actual content should use the `//` syntax.",
@@ -3361,10 +3504,12 @@
                     }
                 },
                 "single_line_empty_body": {
-                    "description": "Empty body of class, interface, trait, enum or function must be abbreviated as `{}` and placed on the same line as the previous symbol, separated by a single space."
+                    "description": "Empty body of class, interface, trait, enum or function must be abbreviated as `{}` and placed on the same line as the previous symbol, separated by a single space.",
+                    "type": "boolean"
                 },
                 "single_line_throw": {
-                    "description": "Throwing exception must be done in single line."
+                    "description": "Throwing exception must be done in single line.",
+                    "type": "boolean"
                 },
                 "single_quote": {
                     "description": "Convert double quotes to single quotes for simple strings.",
@@ -3683,7 +3828,8 @@
                     }
                 },
                 "single_trait_insert_per_statement": {
-                    "description": "Each trait `use` must be done as single statement."
+                    "description": "Each trait `use` must be done as single statement.",
+                    "type": "boolean"
                 },
                 "space_after_semicolon": {
                     "description": "Fix whitespace after a semicolon.",
@@ -3708,10 +3854,12 @@
                     }
                 },
                 "standardize_increment": {
-                    "description": "Increment and decrement operators should be used if possible."
+                    "description": "Increment and decrement operators should be used if possible.",
+                    "type": "boolean"
                 },
                 "standardize_not_equals": {
-                    "description": "Replace all `<>` with `!=`."
+                    "description": "Replace all `<>` with `!=`.",
+                    "type": "boolean"
                 },
                 "statement_indentation": {
                     "description": "Each statement must be indented.",
@@ -3725,16 +3873,20 @@
                     }
                 },
                 "static_lambda": {
-                    "description": "Lambdas not (indirectly) referencing `$this` must be declared `static`."
+                    "description": "Lambdas not (indirectly) referencing `$this` must be declared `static`.",
+                    "type": "boolean"
                 },
                 "static_private_method": {
-                    "description": "Converts private methods to `static` where possible."
+                    "description": "Converts private methods to `static` where possible.",
+                    "type": "boolean"
                 },
                 "strict_comparison": {
-                    "description": "Comparisons should be strict."
+                    "description": "Comparisons should be strict.",
+                    "type": "boolean"
                 },
                 "strict_param": {
-                    "description": "Functions should be used with `$strict` param set to `true`."
+                    "description": "Functions should be used with `$strict` param set to `true`.",
+                    "type": "boolean"
                 },
                 "string_implicit_backslashes": {
                     "description": "Handles implicit backslashes in strings and heredocs. Depending on the chosen strategy, it can escape implicit backslashes to ease the understanding of which are special chars interpreted by PHP and which not (`escape`), or it can remove these additional backslashes if you find them superfluous (`unescape`). You can also leave them as-is using `ignore` strategy.",
@@ -3758,31 +3910,40 @@
                     }
                 },
                 "string_length_to_empty": {
-                    "description": "String tests for empty must be done against `''`, not with `strlen`."
+                    "description": "String tests for empty must be done against `''`, not with `strlen`.",
+                    "type": "boolean"
                 },
                 "string_line_ending": {
-                    "description": "All multi-line strings must use correct line ending."
+                    "description": "All multi-line strings must use correct line ending.",
+                    "type": "boolean"
                 },
                 "stringable_for_to_string": {
-                    "description": "A class that implements the `__toString()` method must explicitly implement the `Stringable` interface."
+                    "description": "A class that implements the `__toString()` method must explicitly implement the `Stringable` interface.",
+                    "type": "boolean"
                 },
                 "switch_case_semicolon_to_colon": {
-                    "description": "A case should be followed by a colon and not a semicolon."
+                    "description": "A case should be followed by a colon and not a semicolon.",
+                    "type": "boolean"
                 },
                 "switch_case_space": {
-                    "description": "Removes extra spaces between colon and case value."
+                    "description": "Removes extra spaces between colon and case value.",
+                    "type": "boolean"
                 },
                 "switch_continue_to_break": {
-                    "description": "Switch case must not be ended with `continue` but with `break`."
+                    "description": "Switch case must not be ended with `continue` but with `break`.",
+                    "type": "boolean"
                 },
                 "ternary_operator_spaces": {
-                    "description": "Standardize spaces around ternary operator."
+                    "description": "Standardize spaces around ternary operator.",
+                    "type": "boolean"
                 },
                 "ternary_to_elvis_operator": {
-                    "description": "Use the Elvis operator `?:` where possible."
+                    "description": "Use the Elvis operator `?:` where possible.",
+                    "type": "boolean"
                 },
                 "ternary_to_null_coalescing": {
-                    "description": "Use `null` coalescing operator `??` where possible."
+                    "description": "Use `null` coalescing operator `??` where possible.",
+                    "type": "boolean"
                 },
                 "trailing_comma_in_multiline": {
                     "description": "Arguments lists, array destructuring lists, arrays that are multi-line, `match`-lines and parameters lists must have a trailing comma.",
@@ -3813,7 +3974,8 @@
                     }
                 },
                 "trim_array_spaces": {
-                    "description": "Arrays should be formatted like function/method arguments, without leading or trailing single line space."
+                    "description": "Arrays should be formatted like function/method arguments, without leading or trailing single line space.",
+                    "type": "boolean"
                 },
                 "type_declaration_spaces": {
                     "description": "Ensure single space between a variable and its type declaration in function arguments and properties.",
@@ -3858,7 +4020,8 @@
                     }
                 },
                 "use_arrow_functions": {
-                    "description": "Anonymous functions with return as the only statement must use arrow functions."
+                    "description": "Anonymous functions with return as the only statement must use arrow functions.",
+                    "type": "boolean"
                 },
                 "visibility_required": {
                     "description": "Classes, constants, properties, and methods MUST have visibility declared, and keyword modifiers MUST be in the following order: inheritance modifier (`abstract` or `final`), visibility modifier (`public`, `protected`, or `private`), set-visibility modifier (`public(set)`, `protected(set)`, or `private(set)`), scope modifier (`static`), mutation modifier (`readonly`), type declaration, name.",
@@ -3898,7 +4061,8 @@
                     }
                 },
                 "yield_from_array_to_yields": {
-                    "description": "Yield from array must be unpacked to series of yields."
+                    "description": "Yield from array must be unpacked to series of yields.",
+                    "type": "boolean"
                 },
                 "yoda_style": {
                     "description": "Write conditions in Yoda style (`true`), non-Yoda style (`['equal' => false, 'identical' => false, 'less_and_greater' => false]`) or ignore those conditions (`null`) based on configuration.",

--- a/schema.json
+++ b/schema.json
@@ -3217,6 +3217,10 @@
                 "phpdoc_var_without_name": {
                     "description": "`@var` and `@type` annotations of classy properties should not contain the name."
                 },
+                "Pint/phpdoc_type_annotations_only": {
+                    "description": "Removes all prose from comments, keeping only `@` annotations (e.g. `@param`, `@return`, `@var`, `@phpstan-type`). Use `@note`, `@warning`, or `@todo` to preserve comments.",
+                    "type": "boolean"
+                },
                 "pow_to_exponentiation": {
                     "description": "Converts `pow` to the `**` operator."
                 },


### PR DESCRIPTION
This pull request introduces a JSON schema file (schema.json) to validate configurations within the pint.json file. Following the standard of other modern configuration files like  [.oxfmtrc.json](https://raw.githubusercontent.com/oxc-project/oxc/refs/heads/main/npm/oxfmt/configuration_schema.json), [.prettierrc](https://www.schemastore.org/prettierrc.json),  [components.json](https://ui.shadcn.com/schema.json), [composer.json](https://getcomposer.org/schema.json), [package.json](https://www.schemastore.org/package.json), and more. This addition ensures that pint.json is simple to configure rather than cumbersome.

## Usage example

### Path

```json
{
    "$schema": "./vendor/laravel/pint/schema.json"
}
```

### Url

```json
{
    "$schema": "https://raw.githubusercontent.com/laravel/pint/main/schema.json"
}
```

## Resources used
- https://github.com/open-southeners/vscode-laravel-pint/blob/main/pint-schema.json
- https://cs.symfony.com/doc/rules/index.html
- https://laravel.com/docs/13.x/pint#custom-rules