### PR TITLE
Report parse errors to stderr for machine-readable formats

### DIFF
--- a/app/Actions/ElaborateSummary.php
+++ b/app/Actions/ElaborateSummary.php
@@ -8,6 +8,7 @@ use App\Output\SummaryOutput;
 use Illuminate\Console\Command;
 use PhpCsFixer\Console\Report\FixReport;
 use PhpCsFixer\Console\Report\FixReport\ReportSummary;
+use PhpCsFixer\Error\Error;
 use PhpCsFixer\Error\ErrorsManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -65,6 +66,10 @@ class ElaborateSummary
             $this->displayUsingFormatter($summary, $outputFormat ?: $format, $file);
         }
 
+        if ($this->shouldDisplayErrorsUsingErrorOutput($format, $this->input->getOption('output-format'))) {
+            $this->displayErrorsUsingErrorOutput();
+        }
+
         $failure = (($summary->isDryRun() || $this->input->getOption('repair')) && count($changes) > 0)
             || count($this->errors->getInvalidErrors()) > 0
             || count($this->errors->getExceptionErrors()) > 0
@@ -101,5 +106,87 @@ class ElaborateSummary
         }
 
         $this->output->write($reporter->generate($summary));
+    }
+
+    /**
+     * Determine if formatter-based output should be accompanied by stderr errors.
+     *
+     * @param  string|null  $format
+     * @param  string|null  $outputFormat
+     * @return bool
+     */
+    protected function shouldDisplayErrorsUsingErrorOutput($format, $outputFormat)
+    {
+        $formats = array_filter([$format, $outputFormat]);
+
+        return count(array_intersect($formats, [
+            'checkstyle',
+            'gitlab',
+            'json',
+            'junit',
+            'xml',
+        ])) > 0;
+    }
+
+    /**
+     * Display linting and fixing errors on stderr when available.
+     *
+     * This preserves machine-readable stdout output while still surfacing
+     * the reason the command failed.
+     *
+     * @return void
+     */
+    protected function displayErrorsUsingErrorOutput()
+    {
+        $errorOutput = fopen('php://stderr', 'w');
+
+        if ($errorOutput === false) {
+            return;
+        }
+
+        if (count($this->errors->getInvalidErrors()) > 0) {
+            $this->writeErrors($errorOutput, 'linting before fixing', $this->errors->getInvalidErrors());
+        }
+
+        if (count($this->errors->getExceptionErrors()) > 0) {
+            $this->writeErrors($errorOutput, 'fixing', $this->errors->getExceptionErrors());
+        }
+
+        if (count($this->errors->getLintErrors()) > 0) {
+            $this->writeErrors($errorOutput, 'linting after fixing', $this->errors->getLintErrors());
+        }
+
+        fclose($errorOutput);
+    }
+
+    /**
+     * Write the given errors to stderr in a concise human-readable format.
+     *
+     * @param  resource  $output
+     * @param  array<int, Error>  $errors
+     * @return void
+     */
+    protected function writeErrors($output, string $process, $errors)
+    {
+        fwrite($output, PHP_EOL);
+        fwrite($output, sprintf(
+            'Files that were not fixed due to errors reported during %s:',
+            $process,
+        ).PHP_EOL);
+
+        foreach ($errors as $index => $error) {
+            fwrite($output, sprintf(
+                '  %d) %s',
+                $index + 1,
+                $error->getFilePath(),
+            ).PHP_EOL);
+
+            if ($error->getSource() !== null) {
+                fwrite($output, sprintf(
+                    '     %s',
+                    $error->getSource()->getMessage(),
+                ).PHP_EOL);
+            }
+        }
     }
 }

--- a/tests/Feature/FormatTest.php
+++ b/tests/Feature/FormatTest.php
@@ -5,6 +5,31 @@ afterEach(function () {
     putenv('CLAUDECODE');
 });
 
+it('writes parse errors to stderr when using junit format', function () {
+    $stdout = tempnam(sys_get_temp_dir(), 'pint-stdout-');
+    $stderr = tempnam(sys_get_temp_dir(), 'pint-stderr-');
+    $exitCode = null;
+
+    exec(sprintf(
+        'env -u CODEX_THREAD_ID -u CODEX_SANDBOX -u OPENCODE -u CLAUDECODE ./pint tests/Fixtures/with-non-fixable-issues --format=junit > %s 2> %s',
+        escapeshellarg($stdout),
+        escapeshellarg($stderr),
+    ), $unusedOutput, $exitCode);
+
+    expect($exitCode)->toBe(1)
+        ->and(file_get_contents($stdout))
+        ->toContain('<?xml version="1.0" encoding="UTF-8"?>')
+        ->and(file_get_contents($stderr))
+        ->toContain('Files that were not fixed due to errors reported during linting before fixing:')
+        ->toContain(implode(DIRECTORY_SEPARATOR, [
+            'tests', 'Fixtures', 'with-non-fixable-issues', 'file.php',
+        ]))
+        ->toContain('Parse error: syntax error');
+
+    @unlink($stdout);
+    @unlink($stderr);
+});
+
 it('outputs checkstyle format', function () {
     [$statusCode, $output] = run('default', [
         'path' => base_path('tests/Fixtures/with-fixable-issues'),


### PR DESCRIPTION
This fixes #396.

When Pint is run with a machine-readable format such as `--format=junit`, parse/lint errors currently cause an exit code of `1` without surfacing a useful human-readable error message.

In CI this makes failures hard to diagnose because stdout contains only formatter output, while the actual reason for the failure is not visible.

## What changed

- preserved the existing machine-readable formatter output on stdout
- wrote lint / parse / fixing errors to stderr for machine-readable formats
- added a regression test for the junit parse-error scenario

## Why this approach

This keeps the current formatter contract intact while making failures actionable in CI logs.

## Reproduction

Run Pint against a file with a syntax error using a machine-readable format, for example:

```bash
./pint tests/Fixtures/with-non-fixable-issues --format=junit
