### PR TITLE
feat: adds `tool` just like PAO

### DIFF
--- a/app/Output/AgentReporter.php
+++ b/app/Output/AgentReporter.php
@@ -39,7 +39,7 @@ final class AgentReporter implements ReporterInterface
 
         $result = match (true) {
             $errors !== [] => 'fail',
-            $changed === [] => 'pass',
+            $changed === [] => 'passed',
             $reportSummary->isDryRun() => 'fail',
             default => 'fixed',
         };

--- a/app/Output/AgentReporter.php
+++ b/app/Output/AgentReporter.php
@@ -44,7 +44,7 @@ final class AgentReporter implements ReporterInterface
             default => 'fixed',
         };
 
-        $output = ['result' => $result];
+        $output = ['tool' => 'pint', 'result' => $result];
 
         if ($changed !== []) {
             $output['files'] = [];

--- a/tests/Feature/FormatTest.php
+++ b/tests/Feature/FormatTest.php
@@ -105,7 +105,7 @@ it('outputs agent format with fail status on test mode', function () {
         ->and($json)->not->toHaveKey('memory');
 });
 
-it('outputs agent format with pass status when no issues', function () {
+it('outputs agent format with passed status when no issues', function () {
     [$statusCode, $output] = run('default', [
         'path' => base_path('tests/Fixtures/without-issues-laravel'),
         '--format' => 'agent',
@@ -115,7 +115,7 @@ it('outputs agent format with pass status when no issues', function () {
 
     expect($statusCode)->toBe(0)
         ->and($output)->toBeJson()
-        ->and($json['result'])->toBe('pass')
+        ->and($json['result'])->toBe('passed')
         ->and($json)->not->toHaveKey('files');
 });
 

--- a/tests/Unit/Output/AgentReporterTest.php
+++ b/tests/Unit/Output/AgentReporterTest.php
@@ -5,14 +5,14 @@ use PhpCsFixer\Console\Report\FixReport\ReportSummary;
 use PhpCsFixer\Error\Error;
 use PhpCsFixer\Error\ErrorsManager;
 
-it('returns pass when no changes and no errors', function () {
+it('returns passed when no changes and no errors', function () {
     $reporter = new AgentReporter;
     $summary = new ReportSummary([], 10, 0, 0, false, false, false);
 
     $output = $reporter->generate($summary);
     $json = json_decode($output, true);
 
-    expect($json['result'])->toBe('pass')
+    expect($json['result'])->toBe('passed')
         ->and($json)->not->toHaveKey('files')
         ->and($json)->not->toHaveKey('errors');
 });

--- a/tests/Unit/Output/AgentReporterTest.php
+++ b/tests/Unit/Output/AgentReporterTest.php
@@ -122,3 +122,14 @@ it('returns format name as agent', function () {
 
     expect($reporter->getFormat())->toBe('agent');
 });
+
+it('includes tool key as pint first in output', function () {
+    $reporter = new AgentReporter;
+    $summary = new ReportSummary([], 10, 0, 0, false, false, false);
+
+    $output = $reporter->generate($summary);
+    $json = json_decode($output, true);
+
+    expect($json['tool'])->toBe('pint')
+        ->and(array_key_first($json))->toBe('tool');
+});


### PR DESCRIPTION
With `PAO`, if we run in the same script

```
pint
phpstan
pest
```

The output is:

```
{"result":"pass"}
{"tool":"phpstan","result":"passed","errors":0}
{"tool":"pest","result":"passed","tests":52,"passed":52,"assertions":90,"duration_ms":534,}
```

This pull request makes pint consistent with pao, by adding the `tool` key, and moving "pass" to "passed".

```
{"tool":"pint","result":"passed"}
{"tool":"phpstan","result":"passed","errors":0}
{"tool":"pest","result":"passed","tests":52,"passed":52,"assertions":90,"duration_ms":534,}
```