### PR TITLE
chore: update actions/checkout and actions/upload-artifact to latest versions

### DIFF
--- a/.github/workflows/publish-phar.yml
+++ b/.github/workflows/publish-phar.yml
@@ -28,7 +28,7 @@ jobs:
           echo "tag=${GITHUB_REF##*v}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: v${{ steps.tag.outputs.tag }}
 
@@ -48,7 +48,7 @@ jobs:
         run: ./pint app:build pint.phar --build-version=${{ steps.tag.outputs.tag }}
 
       - name: Upload the PHAR artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pint.phar
           path: builds/pint.phar

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,10 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout skeleton code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: 'skeleton'
           repository: 'laravel/laravel'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use the latest versions of key action, because of upcoming deprecation of Node 20 actions.

This PR only effects Github Actions
