### PR TITLE
Write parse/lint errors to stderr when using --format

### DIFF
--- a/app/Actions/ElaborateSummary.php
+++ b/app/Actions/ElaborateSummary.php
@@ -79,36 +79,6 @@ class ElaborateSummary
     }
 
     /**
-     * Writes lint, parse, and exception errors to stderr so they remain visible
-     * when stdout is redirected to a file via --format.
-     */
-    protected function writeErrorsToErrorOutput(): void
-    {
-        $allErrors = array_merge(
-            $this->errors->getInvalidErrors(),
-            $this->errors->getExceptionErrors(),
-            $this->errors->getLintErrors()
-        );
-
-        if (count($allErrors) === 0) {
-            return;
-        }
-
-        $errorOutput = $this->output instanceof ConsoleOutputInterface
-            ? $this->output->getErrorOutput()
-            : $this->output;
-
-        foreach ($allErrors as $error) {
-            $source = $error->getSource();
-            $errorOutput->writeln(sprintf(
-                '  <error>ERROR</error> %s: %s',
-                $error->getFilePath(),
-                $source !== null ? $source->getMessage() : 'Unknown error',
-            ));
-        }
-    }
-
-    /**
      * Formats the given summary using the "selected" formatter.
      *
      * @param  ReportSummary  $summary
@@ -136,5 +106,35 @@ class ElaborateSummary
         }
 
         $this->output->write($reporter->generate($summary));
+    }
+
+    /**
+     * Write lint, parse, and exception errors to stderr so they remain visible when stdout is redirected to a file via --format.
+     */
+    protected function writeErrorsToErrorOutput(): void
+    {
+        $allErrors = array_merge(
+            $this->errors->getInvalidErrors(),
+            $this->errors->getExceptionErrors(),
+            $this->errors->getLintErrors()
+        );
+
+        if (count($allErrors) === 0) {
+            return;
+        }
+
+        $errorOutput = $this->output instanceof ConsoleOutputInterface
+            ? $this->output->getErrorOutput()
+            : $this->output;
+
+        foreach ($allErrors as $error) {
+            $source = $error->getSource();
+
+            $errorOutput->writeln(sprintf(
+                '  <error>ERROR</error> %s: %s',
+                $error->getFilePath(),
+                $source !== null ? $source->getMessage() : 'Unknown error',
+            ));
+        }
     }
 }

--- a/app/Actions/ElaborateSummary.php
+++ b/app/Actions/ElaborateSummary.php
@@ -10,6 +10,7 @@ use PhpCsFixer\Console\Report\FixReport;
 use PhpCsFixer\Console\Report\FixReport\ReportSummary;
 use PhpCsFixer\Error\ErrorsManager;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ElaborateSummary
@@ -65,12 +66,46 @@ class ElaborateSummary
             $this->displayUsingFormatter($summary, $outputFormat ?: $format, $file);
         }
 
+        if ($format) {
+            $this->writeErrorsToErrorOutput();
+        }
+
         $failure = (($summary->isDryRun() || $this->input->getOption('repair')) && count($changes) > 0)
             || count($this->errors->getInvalidErrors()) > 0
             || count($this->errors->getExceptionErrors()) > 0
             || count($this->errors->getLintErrors()) > 0;
 
         return $failure ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    /**
+     * Writes lint, parse, and exception errors to stderr so they remain visible
+     * when stdout is redirected to a file via --format.
+     */
+    protected function writeErrorsToErrorOutput(): void
+    {
+        $allErrors = array_merge(
+            $this->errors->getInvalidErrors(),
+            $this->errors->getExceptionErrors(),
+            $this->errors->getLintErrors()
+        );
+
+        if (count($allErrors) === 0) {
+            return;
+        }
+
+        $errorOutput = $this->output instanceof ConsoleOutputInterface
+            ? $this->output->getErrorOutput()
+            : $this->output;
+
+        foreach ($allErrors as $error) {
+            $source = $error->getSource();
+            $errorOutput->writeln(sprintf(
+                '  <error>ERROR</error> %s: %s',
+                $error->getFilePath(),
+                $source !== null ? $source->getMessage() : 'Unknown error',
+            ));
+        }
     }
 
     /**

--- a/tests/Feature/OutputFormatTest.php
+++ b/tests/Feature/OutputFormatTest.php
@@ -139,3 +139,14 @@ it('outputs json format file and xml format in cli', function () use ($file) {
         ])));
 
 });
+
+it('writes parse errors to stderr when using --format', function () {
+    [$statusCode, $output, $errorOutput] = run('default', [
+        'path' => base_path('tests/Fixtures/with-non-fixable-issues'),
+        '--format' => 'junit',
+    ]);
+
+    expect($statusCode)->toBe(1)
+        ->and($output)->toContain('<?xml version="1.0" encoding="UTF-8"?>')
+        ->and($errorOutput)->toContain('Parse error');
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -16,8 +16,47 @@ use Illuminate\Foundation\Console\Kernel;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Tests\TestCase;
+
+/**
+ * A buffered output that also implements ConsoleOutputInterface so that
+ * code writing to getErrorOutput() can be captured in tests.
+ */
+class TestConsoleOutput extends BufferedOutput implements ConsoleOutputInterface
+{
+    private BufferedOutput $errorBuffer;
+
+    public function __construct()
+    {
+        parent::__construct(BufferedOutput::VERBOSITY_VERBOSE);
+        $this->errorBuffer = new BufferedOutput(BufferedOutput::VERBOSITY_VERBOSE);
+    }
+
+    public function getErrorOutput(): OutputInterface
+    {
+        return $this->errorBuffer;
+    }
+
+    public function setErrorOutput(OutputInterface $error): void
+    {
+        $this->errorBuffer = $error;
+    }
+
+    public function section(): ConsoleSectionOutput
+    {
+        $sections = [];
+
+        return new ConsoleSectionOutput($this->getStream() ?: fopen('php://memory', 'rw+'), $sections, $this->getVerbosity(), $this->isDecorated(), $this->getFormatter());
+    }
+
+    public function fetchError(): string
+    {
+        return preg_replace('#\\x1b[[][^A-Za-z]*[A-Za-z]#', '', $this->errorBuffer->fetch()) ?? '';
+    }
+}
 
 uses(TestCase::class)->in('Feature');
 
@@ -52,7 +91,7 @@ expect()->extend('toBeOne', function () {
  *
  * @param  string  $command
  * @param  array<string, string>  $arguments
- * @return array{int, BufferedOutput}
+ * @return array{int, string, string}
  */
 function run($command, $arguments)
 {
@@ -70,16 +109,15 @@ function run($command, $arguments)
     };
 
     $input = new ArrayInput($arguments, $commandInstance->getDefinition());
-    $output = new BufferedOutput(
-        BufferedOutput::VERBOSITY_VERBOSE,
-    );
+    $output = new TestConsoleOutput;
 
     app()->singleton(InputInterface::class, fn () => $input);
     app()->singleton(OutputInterface::class, fn () => $output);
 
     $statusCode = resolve(Kernel::class)->call($command, $arguments, $output);
 
-    $output = preg_replace('#\\x1b[[][^A-Za-z]*[A-Za-z]#', '', $output->fetch());
+    $stdout = preg_replace('#\\x1b[[][^A-Za-z]*[A-Za-z]#', '', $output->fetch()) ?? '';
+    $stderr = $output->fetchError();
 
-    return [$statusCode, $output];
+    return [$statusCode, $stdout, $stderr];
 }


### PR DESCRIPTION
When --format is used, stdout is typically redirected to a file (e.g. --format=junit > report.xml). Errors from ErrorsManager (lint errors, parse errors, invalid file errors) were only embedded in the formatter output, making them invisible to the user and silently producing exit code 1 with no explanation.

This commit writes those errors to stderr via ConsoleOutputInterface when a --format is set, so they remain visible even when stdout is redirected. The TestConsoleOutput helper in tests/Pest.php now implements ConsoleOutputInterface to allow stderr to be captured in tests.

Fixes #396

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
