### PR TITLE
[1.x] Reject loading configuration over plaintext HTTP

### DIFF
--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -101,7 +101,8 @@ class ConfigurationJsonRepository
     protected function fileExists(string $path)
     {
         return match (true) {
-            str_starts_with($path, 'http://') || str_starts_with($path, 'https://') => str_contains(get_headers($path)[0], '200 OK'),
+            str_starts_with($path, 'http://') => abort(1, 'Loading the configuration over plaintext HTTP is not allowed. Use HTTPS.'),
+            str_starts_with($path, 'https://') => str_contains(get_headers($path)[0], '200 OK'),
             default => file_exists($path)
         };
     }

--- a/tests/Feature/ConfigurationTest.php
+++ b/tests/Feature/ConfigurationTest.php
@@ -7,3 +7,9 @@ it('ensures configuration file is valid', function () {
         'path' => base_path('tests/Fixtures/with-invalid-configuration'),
     ]);
 })->throws(ConsoleException::class, 'is not valid JSON.');
+
+it('rejects a configuration loaded over plaintext http', function () {
+    run('default', [
+        '--config' => 'http://example.com/pint.json',
+    ]);
+})->throws(ConsoleException::class, 'Loading the configuration over plaintext HTTP is not allowed. Use HTTPS.');


### PR DESCRIPTION
## What

Pint can load its configuration from a URL (`--config https://.../pint.json`), and the remote-fetch branch in `ConfigurationJsonRepository` accepted `http://` as well as `https://`. This rejects `http://`; `https://` keeps working.

## Why

The configuration drives php-cs-fixer's rule set, and Pint runs with risky fixers allowed. Loading rules over plaintext HTTP lets anyone on the network path swap the rule set in transit and change how your code gets rewritten.