### PR TITLE
Add `in` array to `pint.json`

### DIFF
--- a/app/Factories/ConfigurationResolverFactory.php
+++ b/app/Factories/ConfigurationResolverFactory.php
@@ -37,9 +37,13 @@ class ConfigurationResolverFactory
      */
     public static function fromIO($input, $output)
     {
+        $localConfiguration = resolve(ConfigurationJsonRepository::class);
+
         $path = Project::paths($input);
 
-        $localConfiguration = resolve(ConfigurationJsonRepository::class);
+        if ($localConfiguration->hasIncludedPaths() && $path === [(string) Project::path()]) {
+            $path = [];
+        }
 
         $preset = $localConfiguration->preset();
 

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -11,6 +11,7 @@ class ConfigurationJsonRepository
      */
     protected $finderOptions = [
         'exclude',
+        'in',
         'notPath',
         'notName',
     ];
@@ -57,6 +58,18 @@ class ConfigurationJsonRepository
     public function cacheFile()
     {
         return $this->get()['cache-file'] ?? null;
+    }
+
+    /**
+     * Determine if the configuration defines paths to inspect.
+     *
+     * @return bool
+     */
+    public function hasIncludedPaths()
+    {
+        $includedPaths = $this->finder()['in'] ?? null;
+
+        return $includedPaths !== null && $includedPaths !== [] && $includedPaths !== '';
     }
 
     /**

--- a/app/Repositories/ConfigurationJsonRepository.php
+++ b/app/Repositories/ConfigurationJsonRepository.php
@@ -67,9 +67,7 @@ class ConfigurationJsonRepository
      */
     public function hasIncludedPaths()
     {
-        $includedPaths = $this->finder()['in'] ?? null;
-
-        return $includedPaths !== null && $includedPaths !== [] && $includedPaths !== '';
+        return ! empty($this->finder()['in'] ?? null);
     }
 
     /**

--- a/tests/Feature/ConfigurationTest.php
+++ b/tests/Feature/ConfigurationTest.php
@@ -25,11 +25,11 @@ it('uses configured in paths when no path is provided', function () {
         chdir($cwd);
     }
 
-    $json = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+    $output = str_replace('\\/', '/', $output);
 
     expect($statusCode)->toBe(1)
-        ->and($json['files'])->toHaveCount(1)
-        ->and($json['files'][0]['path'])->toBe('included/file.php');
+        ->and($output)->toContain('included/file.php')
+        ->and($output)->not->toContain('excluded/file.php');
 });
 
 it('uses explicit paths over configured in paths', function () {
@@ -47,9 +47,9 @@ it('uses explicit paths over configured in paths', function () {
         chdir($cwd);
     }
 
-    $json = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+    $output = str_replace('\\/', '/', $output);
 
     expect($statusCode)->toBe(1)
-        ->and($json['files'])->toHaveCount(1)
-        ->and($json['files'][0]['path'])->toBe('excluded/file.php');
+        ->and($output)->toContain('excluded/file.php')
+        ->and($output)->not->toContain('included/file.php');
 });

--- a/tests/Feature/ConfigurationTest.php
+++ b/tests/Feature/ConfigurationTest.php
@@ -13,3 +13,43 @@ it('rejects a configuration loaded over plaintext http', function () {
         '--config' => 'http://example.com/pint.json',
     ]);
 })->throws(ConsoleException::class, 'Loading the configuration over plaintext HTTP is not allowed. Use HTTPS.');
+
+it('uses configured in paths when no path is provided', function () {
+    $cwd = getcwd();
+
+    chdir(base_path('tests/Fixtures/finder-in'));
+
+    try {
+        [$statusCode, $output] = run('default', []);
+    } finally {
+        chdir($cwd);
+    }
+
+    $json = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+
+    expect($statusCode)->toBe(1)
+        ->and($json['files'])->toHaveCount(1)
+        ->and($json['files'][0]['path'])->toBe('included/file.php');
+});
+
+it('uses explicit paths over configured in paths', function () {
+    $fixture = base_path('tests/Fixtures/finder-in');
+    $cwd = getcwd();
+
+    chdir($fixture);
+
+    try {
+        [$statusCode, $output] = run('default', [
+            'path' => $fixture.'/excluded',
+            '--config' => $fixture.'/pint.json',
+        ]);
+    } finally {
+        chdir($cwd);
+    }
+
+    $json = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+
+    expect($statusCode)->toBe(1)
+        ->and($json['files'])->toHaveCount(1)
+        ->and($json['files'][0]['path'])->toBe('excluded/file.php');
+});

--- a/tests/Fixtures/finder-in/excluded/file.php
+++ b/tests/Fixtures/finder-in/excluded/file.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace FinderIn\Excluded;
+
+use DateTime;
+
+class ExcludedFile
+{
+}

--- a/tests/Fixtures/finder-in/included/file.php
+++ b/tests/Fixtures/finder-in/included/file.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace FinderIn\Included;
+
+use DateTime;
+
+class IncludedFile
+{
+}

--- a/tests/Fixtures/finder-in/pint.json
+++ b/tests/Fixtures/finder-in/pint.json
@@ -1,0 +1,9 @@
+{
+    "preset": "empty",
+    "in": [
+        "included"
+    ],
+    "rules": {
+        "no_unused_imports": true
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -100,7 +100,7 @@ function run($command, $arguments)
     ], $arguments);
 
     if (isset($arguments['path'])) {
-        $arguments['--config'] = $arguments['path'].'/pint.json';
+        $arguments['--config'] ??= $arguments['path'].'/pint.json';
         $arguments['path'] = [$arguments['path']];
     }
 

--- a/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
+++ b/tests/Unit/Repositories/ConfigurationJsonRepositoryTest.php
@@ -41,6 +41,16 @@ it('may have finder options', function () {
     ]);
 });
 
+it('may define paths to inspect', function () {
+    $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/finder-in/pint.json', null);
+
+    expect($repository->finder())->toMatchArray([
+        'in' => [
+            'included',
+        ],
+    ])->and($repository->hasIncludedPaths())->toBeTrue();
+});
+
 it('may have a preset option', function () {
     $repository = new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/preset/pint.json', null);
 


### PR DESCRIPTION
To allow for easily porting over a `.php-cs-fixer.php` config, we make available the ability to specify only which directories we want scanned. Previously this was available by CLI args.