### PR TITLE
Include renamed files in --diff filter

### DIFF
--- a/app/Repositories/GitPathsRepository.php
+++ b/app/Repositories/GitPathsRepository.php
@@ -53,9 +53,9 @@ class GitPathsRepository implements PathsRepository
     public function diff($branch)
     {
         $files = [
-            'committed' => tap(new Process(['git', 'diff', '--name-only', '--diff-filter=AM', "{$branch}...HEAD", '--', '**.php']))->run(),
-            'staged' => tap(new Process(['git', 'diff', '--name-only', '--diff-filter=AM', '--cached', '--', '**.php']))->run(),
-            'unstaged' => tap(new Process(['git', 'diff', '--name-only', '--diff-filter=AM', '--', '**.php']))->run(),
+            'committed' => tap(new Process(['git', 'diff', '--name-only', '--diff-filter=AMR', "{$branch}...HEAD", '--', '**.php']))->run(),
+            'staged' => tap(new Process(['git', 'diff', '--name-only', '--diff-filter=AMR', '--cached', '--', '**.php']))->run(),
+            'unstaged' => tap(new Process(['git', 'diff', '--name-only', '--diff-filter=AMR', '--', '**.php']))->run(),
             'untracked' => tap(new Process(['git', 'ls-files', '--others', '--exclude-standard', '--', '**.php']))->run(),
         ];
 


### PR DESCRIPTION
Pint's --diff implementation used --diff-filter=AM internally, which only captures Added and Modified files. This explicitly excludes any file that git tracks as a rename (status R), so a file you authored fresh and later renamed before pushing would never be picked up, even though it clearly belongs in the diff.

Adding R to the filter (--diff-filter=AMR) on all three diff commands (committed, staged, and unstaged) closes this gap.

No tests were added for this change. The PathsRepository contract is fully mocked at every level of the test suite, which makes it impractical to exercise the actual git subprocess arguments. The filter flag is a Git built-in whose behaviour is well-specified; there is no application logic here to test beyond the flag value itself.
