### PR TITLE
Write Issues to Stderr When --quiet Is Set

### DIFF
--- a/app/Actions/ElaborateSummary.php
+++ b/app/Actions/ElaborateSummary.php
@@ -5,6 +5,7 @@ namespace App\Actions;
 use App\Factories\ConfigurationResolverFactory;
 use App\Output\AgentReporter;
 use App\Output\SummaryOutput;
+use App\Project;
 use Illuminate\Console\Command;
 use PhpCsFixer\Console\Report\FixReport;
 use PhpCsFixer\Console\Report\FixReport\ReportSummary;
@@ -58,6 +59,8 @@ class ElaborateSummary
             $this->displayUsingFormatter($summary, 'agent');
         } elseif ($format) {
             $this->displayUsingFormatter($summary, $format);
+        } elseif ($this->output->isQuiet()) {
+            $this->writeIssuesToErrorOutput($summary);
         } else {
             $this->summaryOutput->handle($summary, $totalFiles);
         }
@@ -106,6 +109,31 @@ class ElaborateSummary
         }
 
         $this->output->write($reporter->generate($summary));
+    }
+
+    /**
+     * Write style issues and errors to stderr so they remain visible when --quiet suppresses stdout.
+     */
+    protected function writeIssuesToErrorOutput(ReportSummary $summary): void
+    {
+        $issues = $this->summaryOutput->getIssues(Project::path(), $summary);
+
+        if ($issues->isEmpty()) {
+            return;
+        }
+
+        $errorOutput = $this->output instanceof ConsoleOutputInterface
+            ? $this->output->getErrorOutput()
+            : $this->output;
+
+        foreach ($issues as $issue) {
+            $errorOutput->writeln(sprintf(
+                '  %s %s: %s',
+                $issue->symbol(),
+                $issue->file(),
+                $issue->description($summary->isDryRun()),
+            ), OutputInterface::VERBOSITY_QUIET);
+        }
     }
 
     /**

--- a/tests/Feature/SummaryTest.php
+++ b/tests/Feature/SummaryTest.php
@@ -38,3 +38,28 @@ it('may pass', function () {
         ->and($output)
         ->toContain('PASS');
 });
+
+it('writes style issues to stderr and nothing to stdout when --quiet is set', function () {
+    [$statusCode, $stdout, $stderr] = run('default', [
+        'path' => base_path('tests/Fixtures/with-fixable-issues'),
+        '--preset' => 'psr12',
+        '--quiet' => true,
+    ]);
+
+    expect($statusCode)->toBe(1)
+        ->and($stdout)->toBe('')
+        ->and($stderr)->toContain(implode(DIRECTORY_SEPARATOR, [
+            'tests', 'Fixtures', 'with-fixable-issues', 'file.php',
+        ]));
+});
+
+it('writes nothing to stderr when --quiet is set and there are no issues', function () {
+    [$statusCode, $stdout, $stderr] = run('default', [
+        'path' => base_path('tests/Fixtures/without-issues-laravel'),
+        '--quiet' => true,
+    ]);
+
+    expect($statusCode)->toBe(0)
+        ->and($stdout)->toBe('')
+        ->and($stderr)->toBe('');
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -35,6 +35,12 @@ class TestConsoleOutput extends BufferedOutput implements ConsoleOutputInterface
         $this->errorBuffer = new BufferedOutput(BufferedOutput::VERBOSITY_VERBOSE);
     }
 
+    public function setVerbosity(int $level): void
+    {
+        parent::setVerbosity($level);
+        $this->errorBuffer->setVerbosity($level);
+    }
+
     public function getErrorOutput(): OutputInterface
     {
         return $this->errorBuffer;
@@ -108,7 +114,10 @@ function run($command, $arguments)
         'default' => resolve(DefaultCommand::class),
     };
 
-    $input = new ArrayInput($arguments, $commandInstance->getDefinition());
+    // Strip global Symfony options — the command definition in tests excludes them because Application::mergeApplicationDefinition() is not called in the test path.
+    $inputArguments = array_diff_key($arguments, array_flip(['--quiet', '-q']));
+
+    $input = new ArrayInput($inputArguments, $commandInstance->getDefinition());
     $output = new TestConsoleOutput;
 
     app()->singleton(InputInterface::class, fn () => $input);


### PR DESCRIPTION
Fixes #430

When running with `--quiet`, style violations were silently swallowed — `--quiet` ended up behaving identically to `--silent`. Mirrors the approach from #437 (`writeErrorsToErrorOutput()`): routes style issues to stderr instead of stdout when quiet mode is active, so the exit code and empty stdout are preserved while the file list is still available.

Added two tests: quiet with violations (exit 1, stderr has the path), quiet without violations (exit 0, stderr empty).