### PR TITLE
Mask escaped @@ inside script and style blocks

### DIFF
--- a/app/PrettierFormatters/EmbeddedBladeMasker.php
+++ b/app/PrettierFormatters/EmbeddedBladeMasker.php
@@ -143,7 +143,7 @@ class EmbeddedBladeMasker implements PrettierPostFormatter, PrettierPreFormatter
 
         return (string) preg_replace_callback(
             '/@@/',
-            fn (): string => $this->mask('@@', $isCss ? 'value' : 'js-expression'),
+            fn (): string => $this->mask('@@', $isCss ? 'value' : 'js-string'),
             $literal,
         );
     }
@@ -439,6 +439,10 @@ class EmbeddedBladeMasker implements PrettierPostFormatter, PrettierPreFormatter
         return match ($context) {
             'value', 'js-expression' => "__PINT_BLADE_{$index}__",
             'js-statement' => "__PINT_BLADE_{$index}__;",
+            // Lives only inside a JS string literal. The leading digit keeps it from ever
+            // looking like a bare identifier, so prettier's "quoteProps: as-needed" cannot
+            // strip the surrounding quotes when the string sits in an object-key position.
+            'js-string' => "0__PINT_BLADE_{$index}__",
             default => "--pint-blade-{$index}: 1;",
         };
     }

--- a/app/PrettierFormatters/EmbeddedBladeMasker.php
+++ b/app/PrettierFormatters/EmbeddedBladeMasker.php
@@ -91,13 +91,21 @@ class EmbeddedBladeMasker implements PrettierPostFormatter, PrettierPreFormatter
         while ($offset < $length) {
             $char = $region[$offset];
 
+            // Escaped "@@" is a literal "@"; mask it so prettier can't re-indent the raw-text block around it.
+            if ($char === '@' && $offset + 1 < $length && $region[$offset + 1] === '@') {
+                $result .= $this->mask('@@', $isCss ? 'value' : 'js-expression');
+                $offset += 2;
+
+                continue;
+            }
+
             if ($this->isStringDelimiter($char, $isCss)) {
                 $end = $this->scanStringLiteral($region, $length, $offset, $char);
                 $literal = substr($region, $offset, $end - $offset);
 
                 $result .= $this->containsEcho($literal)
                     ? $this->mask($literal, $isCss ? 'value' : 'js-expression')
-                    : $literal;
+                    : $this->maskEscapedAt($literal, $isCss);
 
                 $offset = $end;
 
@@ -122,6 +130,22 @@ class EmbeddedBladeMasker implements PrettierPostFormatter, PrettierPreFormatter
         }
 
         return $result;
+    }
+
+    /**
+     * Mask every escaped "@@" left inside a string literal that prettier would otherwise re-indent around.
+     */
+    private function maskEscapedAt(string $literal, bool $isCss): string
+    {
+        if (! str_contains($literal, '@@')) {
+            return $literal;
+        }
+
+        return (string) preg_replace_callback(
+            '/@@/',
+            fn (): string => $this->mask('@@', $isCss ? 'value' : 'js-expression'),
+            $literal,
+        );
     }
 
     /**

--- a/tests/Fixtures/blade-formatting/script/escaped-at.blade.php
+++ b/tests/Fixtures/blade-formatting/script/escaped-at.blade.php
@@ -7,3 +7,9 @@
 <script>
     const email = "support@@example.com";
 </script>
+<script>
+    const handler = {
+      "@@click": "doThing",
+        "@@keyup.enter": "submit",
+    };
+</script>

--- a/tests/Fixtures/blade-formatting/script/escaped-at.blade.php
+++ b/tests/Fixtures/blade-formatting/script/escaped-at.blade.php
@@ -1,0 +1,9 @@
+<script type="application/ld+json">
+    {
+      "@@context": "https://schema.org",
+      "@@type": "Organization"
+    }
+</script>
+<script>
+    const email = "support@@example.com";
+</script>

--- a/tests/Fixtures/blade-formatting/script/escaped-at.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/script/escaped-at.blade.php.expected
@@ -7,3 +7,9 @@
 <script>
     const email = 'support@@example.com';
 </script>
+<script>
+    const handler = {
+        '@@click': 'doThing',
+        '@@keyup.enter': 'submit',
+    };
+</script>

--- a/tests/Fixtures/blade-formatting/script/escaped-at.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/script/escaped-at.blade.php.expected
@@ -1,0 +1,9 @@
+<script type="application/ld+json">
+    {
+        "@@context": "https://schema.org",
+        "@@type": "Organization"
+    }
+</script>
+<script>
+    const email = 'support@@example.com';
+</script>


### PR DESCRIPTION
Running `pint --blade` on a Blade file that has an escaped `@@` inside a `<script>` or `<style>` block never reaches a stable result. Every run pushes everything after the first `@@` one level deeper, so the file keeps growing, `pint --test` fails permanently in CI, and a format-on-save hook rewrites the file on each save.

Pint already masks Blade constructs inside raw-text elements before Prettier sees them, but it deliberately left `@@` alone since it renders as a literal `@`. Prettier's Blade plugin then re-indents around that `@@` differently on each pass. Masking the `@@` as well and restoring it afterwards keeps the escape intact and makes the output converge on the first pass.

Fixes #459
