### PR TITLE
Support Blade formatter ignore ranges

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
+[tests/Fixtures/blade-formatting/ignore-ranges/**]
+trim_trailing_whitespace = false
+
 [*.md]
 trim_trailing_whitespace = false
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
 * text=auto
 
 tests/Fixtures/blade-formatting/normalization/crlf.blade.php -text
+tests/Fixtures/blade-formatting/ignore-ranges/crlf.blade.php -text
+tests/Fixtures/blade-formatting/ignore-ranges/crlf.blade.php.expected -text
 
 *.blade.php diff=html
 *.css diff=css

--- a/app/BladeFormatter.php
+++ b/app/BladeFormatter.php
@@ -14,6 +14,7 @@ use App\PrettierFormatters\JoinDanglingOpenBracket;
 use App\PrettierFormatters\NotOperatorSpacing;
 use App\PrettierFormatters\PhpBlockFormatting;
 use App\PrettierFormatters\StripSensitiveLeadingBlankLines;
+use App\Support\BladeIgnoreRanges;
 use App\Support\Prettier;
 
 class BladeFormatter
@@ -60,6 +61,7 @@ class BladeFormatter
      */
     public function __construct(
         protected Prettier $prettier,
+        protected BladeIgnoreRanges $ignoreRanges,
     ) {
         //
     }
@@ -69,6 +71,9 @@ class BladeFormatter
      */
     public function format(string $path, string $content): string
     {
+        $ranges = $this->prettier->ignoreRanges($path, $content);
+        $content = $this->ignoreRanges->protect($content, $ranges, $content);
+
         $formatters = collect(static::$formatters)->map(
             fn (string $formatter): PrettierPreFormatter|PrettierPostFormatter => resolve($formatter),
         );
@@ -80,13 +85,22 @@ class BladeFormatter
             $content,
         );
 
-        $formatted = $this->prettier->format($path, $content);
+        $content = $this->ignoreRanges->restore($content);
 
-        return $formatters->reduce(
+        if ($ranges === []) {
+            $formatted = $this->prettier->format($path, $content);
+        } else {
+            $result = $this->prettier->formatWithIgnoreRanges($path, $content);
+            $formatted = $this->ignoreRanges->protect($result['formatted'], $result['ranges'], $content);
+        }
+
+        $formatted = $formatters->reduce(
             fn (string $formatted, PrettierPreFormatter|PrettierPostFormatter $formatter): string => $formatter instanceof PrettierPostFormatter
                 ? $formatter->postFormat($formatted)
                 : $formatted,
             $formatted,
         );
+
+        return $this->ignoreRanges->restore($formatted);
     }
 }

--- a/app/Fixers/LaravelBlade/Fixer.php
+++ b/app/Fixers/LaravelBlade/Fixer.php
@@ -35,8 +35,8 @@ class Fixer extends AbstractFixer implements HasPrettierDependencies
     public function prettierDependencies(): array
     {
         return [
-            'prettier' => '^3.8.4',
-            'prettier-plugin-blade' => '^3.2.2',
+            'prettier' => '3.9.6',
+            'prettier-plugin-blade' => '3.2.2',
             'prettier-plugin-tailwindcss' => '^0.8.0',
         ];
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use App\Actions\EnsurePrettierIsConfigured;
 use App\BladeFormatter;
 use App\Project;
 use App\Repositories\ConfigurationJsonRepository;
+use App\Support\BladeIgnoreRanges;
 use App\Support\Prettier;
 use Illuminate\Support\ServiceProvider;
 use PhpCsFixer\Error\ErrorsManager;
@@ -54,7 +55,10 @@ class AppServiceProvider extends ServiceProvider
         });
 
         $this->app->bind(BladeFormatter::class, function ($app) {
-            return new BladeFormatter($app->make(Prettier::class));
+            return new BladeFormatter(
+                $app->make(Prettier::class),
+                $app->make(BladeIgnoreRanges::class),
+            );
         });
     }
 }

--- a/app/Support/BladeIgnoreRanges.php
+++ b/app/Support/BladeIgnoreRanges.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Support;
+
+class BladeIgnoreRanges
+{
+    /**
+     * The placeholder to original-text map.
+     *
+     * @var array<string, string>
+     */
+    private array $map = [];
+
+    /**
+     * The content as it entered protect().
+     */
+    private string $original = '';
+
+    /**
+     * The index used to build unique placeholder tokens.
+     */
+    private int $counter = 0;
+
+    /**
+     * Protect the given formatter ignore ranges.
+     *
+     * @param  array<int, array{start: int, end: int, sourceStart?: int, sourceEnd?: int}>  $ranges
+     */
+    public function protect(string $content, array $ranges, string $source): string
+    {
+        $this->map = [];
+        $this->original = $content;
+        $this->counter = 0;
+
+        if ($ranges === []) {
+            return $content;
+        }
+
+        $result = '';
+        $cursor = 0;
+
+        foreach ($ranges as $range) {
+            $token = $this->makeToken();
+            $sourceStart = $range['sourceStart'] ?? $range['start'];
+            $sourceEnd = $range['sourceEnd'] ?? $range['end'];
+
+            $this->map[$token] = substr($source, $sourceStart, $sourceEnd - $sourceStart);
+            $result .= substr($content, $cursor, $range['start'] - $cursor).$token;
+            $cursor = $range['end'];
+        }
+
+        return $result.substr($content, $cursor);
+    }
+
+    /**
+     * Restore the contents of formatter ignore ranges.
+     */
+    public function restore(string $content): string
+    {
+        if ($this->map === []) {
+            $this->original = '';
+
+            return $content;
+        }
+
+        $map = $this->map;
+        $original = $this->original;
+
+        $this->map = [];
+        $this->original = '';
+
+        // Every token must appear exactly once; otherwise fall back to the original to avoid corrupting the file.
+        foreach (array_keys($map) as $token) {
+            if (substr_count($content, $token) !== 1) {
+                return $original;
+            }
+        }
+
+        return str_replace(array_keys($map), array_values($map), $content);
+    }
+
+    /**
+     * Build a unique placeholder token.
+     */
+    private function makeToken(): string
+    {
+        while (true) {
+            $token = sprintf('__PINT_BLADE_IGNORE_%d__', $this->counter++);
+
+            if (! str_contains($this->original, $token)) {
+                return $token;
+            }
+        }
+    }
+}

--- a/app/Support/Prettier.php
+++ b/app/Support/Prettier.php
@@ -15,7 +15,7 @@ class Prettier
      *
      * @var int
      */
-    public const VERSION = 1;
+    public const VERSION = 2;
 
     /**
      * The number of seconds the worker may stay silent before it is torn down.
@@ -57,28 +57,97 @@ class Prettier
      */
     public function format(string $path, string $content): string
     {
+        $result = $this->send([
+            'type' => 'format',
+            'path' => $path,
+            'content' => $content,
+        ]);
+
+        if (! isset($result['formatted']) || ! is_string($result['formatted'])) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
+        }
+
+        return $result['formatted'];
+    }
+
+    /**
+     * Format the given file and return its formatter ignore ranges.
+     *
+     * @return array{formatted: string, ranges: array<int, array{start: int, end: int, sourceStart: int, sourceEnd: int}>}
+     *
+     * @throws PrettierException
+     */
+    public function formatWithIgnoreRanges(string $path, string $content): array
+    {
+        $result = $this->send([
+            'type' => 'format-with-ignore-ranges',
+            'path' => $path,
+            'content' => $content,
+        ]);
+
+        if (! isset($result['formatted'], $result['ranges']) || ! is_string($result['formatted']) || ! is_array($result['ranges'])) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Return the formatter ignore ranges in the given file.
+     *
+     * @return array<int, array{start: int, end: int}>
+     *
+     * @throws PrettierException
+     */
+    public function ignoreRanges(string $path, string $content): array
+    {
+        if (stripos($content, 'format-ignore-start') === false
+            && stripos($content, 'prettier-ignore-start') === false) {
+            return [];
+        }
+
+        $result = $this->send([
+            'type' => 'ranges',
+            'path' => $path,
+            'content' => $content,
+        ]);
+
+        if (! isset($result['ranges']) || ! is_array($result['ranges'])) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
+        }
+
+        return $result['ranges'];
+    }
+
+    /**
+     * Send a request to the prettier worker.
+     *
+     * @param  array<string, mixed>  $request
+     * @return array<string, mixed>
+     *
+     * @throws PrettierException
+     */
+    private function send(array $request): array
+    {
         $this->ensureStarted();
 
         $this->process->clearOutput();
         $this->process->clearErrorOutput();
 
-        $this->inputStream->write(json_encode([
-            'path' => $path,
-            'content' => $content,
-        ], JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE)."\n");
+        $this->inputStream->write(json_encode($request, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE)."\n");
 
         // Accumulate every chunk; the OS pipe may split the response across reads.
-        $formatted = '';
+        $output = '';
         $error = '';
         $deadline = microtime(true) + $this->workerIdleTimeout();
 
         while (true) {
             if (($chunk = $this->process->getIncrementalOutput()) !== '') {
-                $formatted .= $chunk;
+                $output .= $chunk;
                 $deadline = microtime(true) + $this->workerIdleTimeout();
             }
 
-            if (str_contains($formatted, '[PINT_PRETTIER_WORKER_END]')) {
+            if (str_contains($output, '[PINT_PRETTIER_WORKER_END]')) {
                 break;
             }
 
@@ -99,7 +168,7 @@ class Prettier
 
                 throw new PrettierException(sprintf(
                     'Laravel Pint\'s Prettier worker timed out while formatting [%s].',
-                    $path,
+                    $request['path'],
                 ));
             }
 
@@ -117,15 +186,23 @@ class Prettier
             '[PINT_PRETTIER_WORKER_START]',
             '[PINT_PRETTIER_WORKER_END]',
         ] as $delimiter) {
-            if (! Str::contains($formatted, $delimiter)) {
+            if (! Str::contains($output, $delimiter)) {
                 throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
             }
         }
 
-        return Str::of($formatted)
+        $response = Str::of($output)
             ->after('[PINT_PRETTIER_WORKER_START]')
             ->before('[PINT_PRETTIER_WORKER_END]')
             ->value();
+
+        $decoded = json_decode($response, true);
+
+        if (! is_array($decoded)) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
+        }
+
+        return $decoded;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
   "packages": {
     "": {
       "devDependencies": {
-        "prettier": "^3.9.6",
-        "prettier-plugin-blade": "^3.2.2",
+        "prettier": "3.9.6",
+        "prettier-plugin-blade": "3.2.2",
         "prettier-plugin-tailwindcss": "^0.8.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
-    "prettier": "^3.9.6",
-    "prettier-plugin-blade": "^3.2.2",
+    "prettier": "3.9.6",
+    "prettier-plugin-blade": "3.2.2",
     "prettier-plugin-tailwindcss": "^0.8.1"
   }
 }

--- a/resources/js/worker.cjs
+++ b/resources/js/worker.cjs
@@ -59,21 +59,171 @@ process.stdin.on("data", function (chunk) {
 
 async function handleMessage(input) {
     try {
-        const { path: filepath, content } = JSON.parse(input);
+        const { type = "format", path: filepath, content } = JSON.parse(input);
+
+        if (type === "ranges" && !hasIgnoreRangeMarker(content)) {
+            writeResponse({ ranges: [] });
+
+            return;
+        }
 
         const resolved = filepath.trim();
 
         const options = resolveOptionPlugins({ ...bundledOptions });
 
-        const formatted = await prettier.format(content, {
+        const parseOptions = {
             ...options,
             filepath: resolved,
-        });
+        };
 
-        process.stdout.write(
-            `[PINT_PRETTIER_WORKER_START]${formatted}[PINT_PRETTIER_WORKER_END]`,
+        if (type === "format") {
+            writeResponse({
+                formatted: await prettier.format(content, parseOptions),
+            });
+
+            return;
+        }
+
+        if (
+            typeof prettier.__debug?.parse !== "function" ||
+            typeof prettier.__debug?.formatAST !== "function"
+        ) {
+            throw new Error(
+                "The installed Prettier version does not expose the Blade ignore range formatter API.",
+            );
+        }
+
+        const { ast } = await prettier.__debug.parse(content, parseOptions);
+        const sourceRanges = ignoreRanges(ast, normalizedLength(content));
+
+        if (type === "ranges") {
+            writeResponse({
+                ranges: sourceRanges.map((range) =>
+                    toByteRange(content, range),
+                ),
+            });
+
+            return;
+        }
+
+        let { formatted } = await prettier.__debug.formatAST(ast, parseOptions);
+
+        if (content.charCodeAt(0) === 0xfeff) {
+            formatted = `\ufeff${formatted}`;
+        }
+
+        const { ast: formattedAst } = await prettier.__debug.parse(
+            formatted,
+            parseOptions,
         );
+        const formattedRanges = ignoreRanges(
+            formattedAst,
+            normalizedLength(formatted),
+        );
+
+        if (formattedRanges.length !== sourceRanges.length) {
+            throw new Error(
+                "Prettier did not preserve every Blade ignore range.",
+            );
+        }
+
+        writeResponse({
+            formatted,
+            ranges: formattedRanges.map((range, index) => {
+                const formattedRange = toByteRange(formatted, range);
+                const sourceRange = toByteRange(content, sourceRanges[index]);
+
+                return {
+                    ...formattedRange,
+                    sourceStart: sourceRange.start,
+                    sourceEnd: sourceRange.end,
+                };
+            }),
+        });
     } catch (error) {
         process.stderr.write(`${error.stack || error.message}\n`);
     }
+}
+
+function hasIgnoreRangeMarker(content) {
+    const lower = content.toLowerCase();
+
+    return (
+        lower.includes("format-ignore-start") ||
+        lower.includes("prettier-ignore-start")
+    );
+}
+
+function ignoreRanges(ast, contentLength) {
+    const ranges = ast?.buildResult?.ignoreRanges;
+
+    if (
+        !Array.isArray(ranges) ||
+        !ranges.every(
+            (range, index) =>
+                range !== null &&
+                typeof range === "object" &&
+                Number.isInteger(range.start) &&
+                Number.isInteger(range.end) &&
+                range.start >= 0 &&
+                range.end >= range.start &&
+                range.end <= contentLength &&
+                (index === 0 || range.start >= ranges[index - 1].end),
+        )
+    ) {
+        throw new Error(
+            "The installed Blade plugin did not return valid ignore ranges.",
+        );
+    }
+
+    return ranges;
+}
+
+function toByteRange(content, { start, end }) {
+    return {
+        start: Buffer.byteLength(
+            content.slice(0, sourceOffset(content, start)),
+            "utf8",
+        ),
+        end: Buffer.byteLength(
+            content.slice(0, sourceOffset(content, end)),
+            "utf8",
+        ),
+    };
+}
+
+function normalizedLength(content) {
+    let length = content.length;
+    let offset = 0;
+
+    if (content.charCodeAt(0) === 0xfeff) {
+        length--;
+        offset++;
+    }
+
+    while ((offset = content.indexOf("\r\n", offset)) !== -1) {
+        length--;
+        offset += 2;
+    }
+
+    return length;
+}
+
+function sourceOffset(content, normalizedOffset) {
+    let offset = content.charCodeAt(0) === 0xfeff ? 1 : 0;
+    let normalized = 0;
+
+    while (normalized < normalizedOffset) {
+        offset +=
+            content[offset] === "\r" && content[offset + 1] === "\n" ? 2 : 1;
+        normalized++;
+    }
+
+    return offset;
+}
+
+function writeResponse(response) {
+    process.stdout.write(
+        `[PINT_PRETTIER_WORKER_START]${JSON.stringify(response)}[PINT_PRETTIER_WORKER_END]`,
+    );
 }

--- a/tests/Feature/Blade/IgnoreRangesTest.php
+++ b/tests/Feature/Blade/IgnoreRangesTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\BladeFormatter;
+
+bladeFixtureTest('ignore-ranges');
+
+it('preserves a UTF-8 byte order mark when formatting ignore ranges', function () {
+    $input = "\u{FEFF}<div  id=\"before\"></div>\n"
+        ."{{-- format-ignore-start --}}\n"
+        ."@php    \$x = !\$y; @endphp\n"
+        ."{{-- format-ignore-end --}}\n"
+        ."<div  id=\"after\"></div>\n";
+    $expected = "\u{FEFF}<div id=\"before\"></div>\n"
+        ."{{-- format-ignore-start --}}\n"
+        ."@php    \$x = !\$y; @endphp\n"
+        ."{{-- format-ignore-end --}}\n"
+        ."<div id=\"after\"></div>\n";
+
+    $formatted = app(BladeFormatter::class)->format('bom.blade.php', $input);
+
+    expect($formatted)->toBe($expected);
+});

--- a/tests/Fixtures/blade-formatting/ignore-ranges/closing-marker-line.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/closing-marker-line.blade.php
@@ -1,0 +1,4 @@
+{{-- format-ignore-start --}}
+This action WILL NOT accept any changes for you.
+{{-- format-ignore-end --}}
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/closing-marker-line.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/closing-marker-line.blade.php.expected
@@ -1,0 +1,4 @@
+{{-- format-ignore-start --}}
+This action WILL NOT accept any changes for you.
+{{-- format-ignore-end --}}
+<div id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/crlf.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/crlf.blade.php
@@ -1,0 +1,5 @@
+<div  id="before"></div>
+{{-- format-ignore-start --}}
+@php    $x = !$y; @endphp
+{{-- format-ignore-end --}}
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/crlf.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/crlf.blade.php.expected
@@ -1,0 +1,5 @@
+<div id="before"></div>
+{{-- format-ignore-start --}}
+@php    $x = !$y; @endphp
+{{-- format-ignore-end --}}
+<div id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/directive-spacing.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/directive-spacing.blade.php
@@ -1,0 +1,8 @@
+{{-- format-ignore-start --}}
+The following ecrew messages were sent to you.
+
+@foreach($messageData as $ecrewMessage)
+=====
+@endforeach
+{{-- format-ignore-end --}}
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/directive-spacing.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/directive-spacing.blade.php.expected
@@ -1,0 +1,8 @@
+{{-- format-ignore-start --}}
+The following ecrew messages were sent to you.
+
+@foreach($messageData as $ecrewMessage)
+=====
+@endforeach
+{{-- format-ignore-end --}}
+<div id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/echo-spacing.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/echo-spacing.blade.php
@@ -1,0 +1,6 @@
+{{-- format-ignore-start --}}
+Dear {{$user->first_name}},  
+Roster on {{$date->format('d-m-Y')}}
+Distance to station: {{ $distance }}
+{{-- format-ignore-end --}}
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/echo-spacing.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/echo-spacing.blade.php.expected
@@ -1,0 +1,6 @@
+{{-- format-ignore-start --}}
+Dear {{$user->first_name}},  
+Roster on {{$date->format('d-m-Y')}}
+Distance to station: {{ $distance }}
+{{-- format-ignore-end --}}
+<div id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/end-at-eof.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/end-at-eof.blade.php
@@ -1,0 +1,6 @@
+<div>
+    text A</div>
+{{-- format-ignore-start --}}
+<div>
+    text B</div>
+{{-- format-ignore-end --}}

--- a/tests/Fixtures/blade-formatting/ignore-ranges/end-at-eof.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/end-at-eof.blade.php.expected
@@ -1,0 +1,5 @@
+<div>text A</div>
+{{-- format-ignore-start --}}
+<div>
+    text B</div>
+{{-- format-ignore-end --}}

--- a/tests/Fixtures/blade-formatting/ignore-ranges/inline-directive-body.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/inline-directive-body.blade.php
@@ -1,0 +1,3 @@
+@fields('section1_words')
+   {{-- format-ignore-start --}}<span class="word overflow-hidden">@sub('item')*</span>{{-- format-ignore-end --}}
+@endfields

--- a/tests/Fixtures/blade-formatting/ignore-ranges/inline-directive-body.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/inline-directive-body.blade.php.expected
@@ -1,0 +1,3 @@
+@fields('section1_words')
+    {{-- format-ignore-start --}}<span class="word overflow-hidden">@sub('item')*</span>{{-- format-ignore-end --}}
+@endfields

--- a/tests/Fixtures/blade-formatting/ignore-ranges/marker-variants.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/marker-variants.blade.php
@@ -1,0 +1,16 @@
+{{-- prettier-ignore-start --}}
+@php    $bladePrettier = !$hidden; @endphp
+<div  id="blade-prettier"></div>
+{{-- prettier-ignore-end --}}
+
+<!-- format-ignore-start -->
+@php    $htmlFormat = !$hidden; @endphp
+<div  id="html-format"></div>
+<!-- format-ignore-end -->
+
+<!-- prettier-ignore-start -->
+@php    $htmlPrettier = !$hidden; @endphp
+<div  id="html-prettier"></div>
+<!-- prettier-ignore-end -->
+
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/marker-variants.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/marker-variants.blade.php.expected
@@ -1,0 +1,16 @@
+{{-- prettier-ignore-start --}}
+@php    $bladePrettier = !$hidden; @endphp
+<div  id="blade-prettier"></div>
+{{-- prettier-ignore-end --}}
+
+<!-- format-ignore-start -->
+@php    $htmlFormat = !$hidden; @endphp
+<div  id="html-format"></div>
+<!-- format-ignore-end -->
+
+<!-- prettier-ignore-start -->
+@php    $htmlPrettier = !$hidden; @endphp
+<div  id="html-prettier"></div>
+<!-- prettier-ignore-end -->
+
+<div id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/nested.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/nested.blade.php
@@ -1,0 +1,9 @@
+{{-- format-ignore-start --}}
+@php    $outer = !$hidden; @endphp
+{{-- format-ignore-start --}}
+@foreach ($items as  $item)
+{{$item->name}}
+@endforeach
+{{-- format-ignore-end --}}
+@php    $tail = !$disabled; @endphp
+{{-- format-ignore-end --}}

--- a/tests/Fixtures/blade-formatting/ignore-ranges/nested.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/nested.blade.php.expected
@@ -1,0 +1,9 @@
+{{-- format-ignore-start --}}
+@php    $outer = !$hidden; @endphp
+{{-- format-ignore-start --}}
+@foreach ($items as  $item)
+{{$item->name}}
+@endforeach
+{{-- format-ignore-end --}}
+@php    $tail = !$disabled; @endphp
+{{-- format-ignore-end --}}

--- a/tests/Fixtures/blade-formatting/ignore-ranges/non-marker-contexts.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/non-marker-contexts.blade.php
@@ -1,0 +1,13 @@
+@verbatim
+{{-- format-ignore-start --}}
+<div  id="verbatim"></div>
+@endverbatim
+
+@php
+    $marker = '{{-- format-ignore-start --}}';
+    $visible = !$hidden;
+@endphp
+
+<?php $marker = '{{-- format-ignore-start --}}'; $visible = !$hidden; ?>
+
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/non-marker-contexts.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/non-marker-contexts.blade.php.expected
@@ -1,0 +1,16 @@
+@verbatim
+{{-- format-ignore-start --}}
+<div  id="verbatim"></div>
+@endverbatim
+
+@php
+    $marker = '{{-- format-ignore-start --}}';
+    $visible = ! $hidden;
+@endphp
+
+<?php
+
+$marker = '{{-- format-ignore-start --}}';
+$visible = ! $hidden; ?>
+
+<div id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/quoted-attribute.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/quoted-attribute.blade.php
@@ -1,0 +1,3 @@
+<div title="{{-- format-ignore-start --}}">content</div>
+<div  id="after">{{  $value  }}</div>
+@php    $x = !$y; @endphp

--- a/tests/Fixtures/blade-formatting/ignore-ranges/quoted-attribute.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/quoted-attribute.blade.php.expected
@@ -1,0 +1,3 @@
+<div title="{{-- format-ignore-start --}}">content</div>
+<div id="after">{{ $value }}</div>
+@php $x = ! $y; @endphp

--- a/tests/Fixtures/blade-formatting/ignore-ranges/script-stray-end.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/script-stray-end.blade.php
@@ -1,0 +1,5 @@
+<script>
+    {{-- format-ignore-end --}}
+    const  value = 1;
+</script>
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/script-stray-end.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/script-stray-end.blade.php.expected
@@ -1,0 +1,5 @@
+<script>
+    {{-- format-ignore-end --}}
+    const value = 1;
+</script>
+<div id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/script-trailing-code.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/script-trailing-code.blade.php
@@ -1,0 +1,8 @@
+<script>
+    {{-- format-ignore-start --}}
+    const  matrix = [
+        1,  2,  3,
+    ];
+    {{-- format-ignore-end --}}
+    const  values = [4,  5,  6];
+</script>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/script-trailing-code.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/script-trailing-code.blade.php.expected
@@ -1,0 +1,8 @@
+<script>
+    {{-- format-ignore-start --}}
+    const  matrix = [
+        1,  2,  3,
+    ];
+    {{-- format-ignore-end --}}const values =
+        [4, 5, 6];
+</script>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/script-unclosed.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/script-unclosed.blade.php
@@ -1,0 +1,7 @@
+<script>
+    {{-- format-ignore-start --}}
+    const  matrix = [
+        1,  2,  3,
+    ];
+</script>
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/script-unclosed.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/script-unclosed.blade.php.expected
@@ -1,0 +1,7 @@
+<script>
+    {{-- format-ignore-start --}}
+    const  matrix = [
+        1,  2,  3,
+    ];
+</script>
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/script.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/script.blade.php
@@ -1,0 +1,8 @@
+<script>
+    {{-- format-ignore-start --}}
+    const  matrix = [
+        1,  2,  3,
+    ];
+    {{-- format-ignore-end --}}
+</script>
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/script.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/script.blade.php.expected
@@ -1,0 +1,8 @@
+<script>
+    {{-- format-ignore-start --}}
+    const  matrix = [
+        1,  2,  3,
+    ];
+    {{-- format-ignore-end --}}
+</script>
+<div id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/stray-end.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/stray-end.blade.php
@@ -1,0 +1,2 @@
+{{-- format-ignore-end --}}
+<div  id="formatted"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/stray-end.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/stray-end.blade.php.expected
@@ -1,0 +1,2 @@
+{{-- format-ignore-end --}}
+<div id="formatted"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/tag-marker.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/tag-marker.blade.php
@@ -1,0 +1,5 @@
+<div x-show="!visible" {{-- format-ignore-start --}} id = "preserved">
+    @php    $value = !$hidden; @endphp
+</div>
+{{-- format-ignore-end --}}
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/tag-marker.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/tag-marker.blade.php.expected
@@ -1,0 +1,5 @@
+<div x-show="!visible" {{-- format-ignore-start --}} id = "preserved">
+    @php    $value = !$hidden; @endphp
+</div>
+{{-- format-ignore-end --}}
+<div id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/unclosed.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/unclosed.blade.php
@@ -1,0 +1,4 @@
+<div  id="before"></div>
+{{-- format-ignore-start --}}
+@php    $visible = !$hidden; @endphp
+<div  id="preserved"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/unclosed.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/unclosed.blade.php.expected
@@ -1,0 +1,4 @@
+<div id="before"></div>
+{{-- format-ignore-start --}}
+@php    $visible = !$hidden; @endphp
+<div  id="preserved"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/unicode-before-range.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/unicode-before-range.blade.php
@@ -1,0 +1,6 @@
+<p>𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷</p>
+<div  id="before"></div>
+{{-- format-ignore-start --}}
+@php    $visible = !$hidden; @endphp
+{{-- format-ignore-end --}}
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/unicode-before-range.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/unicode-before-range.blade.php.expected
@@ -1,0 +1,6 @@
+<p>𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷</p>
+<div id="before"></div>
+{{-- format-ignore-start --}}
+@php    $visible = !$hidden; @endphp
+{{-- format-ignore-end --}}
+<div id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/unicode-html-spacing.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/unicode-html-spacing.blade.php
@@ -1,0 +1,6 @@
+{{-- format-ignore-start --}}
+𠮷 <b>Stick Time Monitor Alert</b> 𠮷  
+
+<b>Date:</b> {{ $flightplan->date->format('Y-m-d') }}
+{{-- format-ignore-end --}}
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/unicode-html-spacing.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/unicode-html-spacing.blade.php.expected
@@ -1,0 +1,6 @@
+{{-- format-ignore-start --}}
+𠮷 <b>Stick Time Monitor Alert</b> 𠮷  
+
+<b>Date:</b> {{ $flightplan->date->format('Y-m-d') }}
+{{-- format-ignore-end --}}
+<div id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/unicode-inside-range.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/unicode-inside-range.blade.php
@@ -1,0 +1,5 @@
+{{-- format-ignore-start --}}
+𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷
+@php    $visible = !$hidden; @endphp
+{{-- format-ignore-end --}}
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/unicode-inside-range.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/unicode-inside-range.blade.php.expected
@@ -1,0 +1,5 @@
+{{-- format-ignore-start --}}
+𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷
+@php    $visible = !$hidden; @endphp
+{{-- format-ignore-end --}}
+<div id="after"></div>

--- a/tests/Unit/Support/BladeIgnoreRangesTest.php
+++ b/tests/Unit/Support/BladeIgnoreRangesTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Support\BladeIgnoreRanges;
+
+it('protects and restores the given ranges', function () {
+    $ranges = new BladeIgnoreRanges;
+    $input = "Before\nIgnored\nAfter";
+    $protected = $ranges->protect($input, [
+        ['start' => 7, 'end' => 14],
+    ], $input);
+
+    expect($protected)
+        ->toBe("Before\n__PINT_BLADE_IGNORE_0__\nAfter")
+        ->and($ranges->restore($protected))->toBe($input);
+});
+
+it('restores source content when prettier adds text after an unclosed range', function () {
+    $ranges = new BladeIgnoreRanges;
+    $source = "Before\nIgnored\n";
+    $formatted = "Before\nIgnored\n\n";
+    $protected = $ranges->protect($formatted, [
+        [
+            'start' => 7,
+            'end' => 17,
+            'sourceStart' => 7,
+            'sourceEnd' => 15,
+        ],
+    ], $source);
+
+    expect($ranges->restore($protected))->toBe($source);
+});
+
+it('protects multiple ranges in their original order', function () {
+    $ranges = new BladeIgnoreRanges;
+    $input = 'A one B two C';
+    $protected = $ranges->protect($input, [
+        ['start' => 2, 'end' => 5],
+        ['start' => 8, 'end' => 11],
+    ], $input);
+
+    expect($protected)->toBe('A __PINT_BLADE_IGNORE_0__ B __PINT_BLADE_IGNORE_1__ C');
+    expect($ranges->restore($protected))->toBe($input);
+});
+
+it('selects a token that does not collide with the source', function () {
+    $ranges = new BladeIgnoreRanges;
+    $input = '__PINT_BLADE_IGNORE_0__ Ignored';
+
+    expect($ranges->protect($input, [
+        ['start' => 26, 'end' => 33],
+    ], $input))->toEndWith('__PINT_BLADE_IGNORE_1__');
+});
+
+it('falls back to the original content when a token cannot be restored', function () {
+    $ranges = new BladeIgnoreRanges;
+    $input = 'Before Ignored After';
+
+    $ranges->protect($input, [
+        ['start' => 7, 'end' => 14],
+    ], $input);
+
+    expect($ranges->restore('The token is missing.'))->toBe($input);
+});

--- a/tests/Unit/Support/PrettierTest.php
+++ b/tests/Unit/Support/PrettierTest.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\Support\Prettier;
+
+it('does not start the worker for content without ignore range markers', function () {
+    $prettier = new Prettier('/missing-project');
+
+    expect($prettier->ignoreRanges('view.blade.php', '<div>Content</div>'))->toBe([]);
+});


### PR DESCRIPTION
This PR adds support for Blade formatter ignore ranges in Pint. 
Content wrapped in Blade comments such as 

`{{-- format-ignore-start --}}` and 
`{{-- format-ignore-end --}}` 

or the equivalent Prettier markers, is preserved exactly as written, while Pint continues formatting the rest of the Blade file normally.

This is useful for sections of a template that need to retain their original formatting, such as embedded syntax or deliberately arranged markup. The implementation preserves ignored content byte-for-byte and includes coverage for UTF-8 content, BOMs, mixed line endings, multiple ranges, and malformed or unmatched markers.