### PR TITLE
Preserve Blade formatter ignore ranges

### DIFF
--- a/app/BladeFormatter.php
+++ b/app/BladeFormatter.php
@@ -4,6 +4,7 @@ namespace App;
 
 use App\Contracts\PrettierPostFormatter;
 use App\Contracts\PrettierPreFormatter;
+use App\Exceptions\PrettierException;
 use App\PrettierFormatters\CollapseShortSlots;
 use App\PrettierFormatters\CollapseSingleAttribute;
 use App\PrettierFormatters\DedentHuggedTerminator;
@@ -86,6 +87,7 @@ class BladeFormatter
      */
     public function format(string $path, string $content): string
     {
+        $original = $content;
         $ranges = $this->prettier->ignoreRanges($path, $content);
         $content = $this->protectIgnoreRanges($content, $ranges, $content);
 
@@ -100,7 +102,7 @@ class BladeFormatter
             $content,
         );
 
-        $content = $this->restoreIgnoreRanges($content);
+        $content = $this->restoreIgnoreRanges($content, $original);
 
         if ($ranges === []) {
             $formatted = $this->prettier->format($path, $content);
@@ -116,13 +118,13 @@ class BladeFormatter
             $formatted,
         );
 
-        return $this->restoreIgnoreRanges($formatted);
+        return $this->restoreIgnoreRanges($formatted, $original);
     }
 
     /**
      * Protect the given formatter ignore ranges.
      *
-     * @param  array<int, array{start: int, end: int, sourceStart?: int, sourceEnd?: int}>  $ranges
+     * @param  array<int, mixed>  $ranges
      */
     private function protectIgnoreRanges(string $content, array $ranges, string $source): string
     {
@@ -136,15 +138,38 @@ class BladeFormatter
 
         $result = '';
         $cursor = 0;
+        $sourceCursor = 0;
+        $contentLength = strlen($content);
+        $sourceLength = strlen($source);
 
         foreach ($ranges as $range) {
-            $token = $this->makeIgnoreRangeToken();
+            if (! is_array($range)
+                || ! isset($range['start'], $range['end'])
+                || ! is_int($range['start'])
+                || ! is_int($range['end'])
+                || array_key_exists('sourceStart', $range) !== array_key_exists('sourceEnd', $range)) {
+                throw new PrettierException('Laravel Pint\'s Prettier worker returned invalid Blade ignore ranges.');
+            }
+
             $sourceStart = $range['sourceStart'] ?? $range['start'];
             $sourceEnd = $range['sourceEnd'] ?? $range['end'];
 
+            if (! is_int($sourceStart)
+                || ! is_int($sourceEnd)
+                || $range['start'] < $cursor
+                || $range['end'] < $range['start']
+                || $range['end'] > $contentLength
+                || $sourceStart < $sourceCursor
+                || $sourceEnd < $sourceStart
+                || $sourceEnd > $sourceLength) {
+                throw new PrettierException('Laravel Pint\'s Prettier worker returned invalid Blade ignore ranges.');
+            }
+
+            $token = $this->makeIgnoreRangeToken();
             $this->ignoreRangeMap[$token] = substr($source, $sourceStart, $sourceEnd - $sourceStart);
             $result .= substr($content, $cursor, $range['start'] - $cursor).$token;
             $cursor = $range['end'];
+            $sourceCursor = $sourceEnd;
         }
 
         return $result.substr($content, $cursor);
@@ -153,7 +178,7 @@ class BladeFormatter
     /**
      * Restore the contents of formatter ignore ranges.
      */
-    private function restoreIgnoreRanges(string $content): string
+    private function restoreIgnoreRanges(string $content, string $fallback): string
     {
         if ($this->ignoreRangeMap === []) {
             $this->ignoreRangeOriginal = '';
@@ -162,14 +187,13 @@ class BladeFormatter
         }
 
         $map = $this->ignoreRangeMap;
-        $original = $this->ignoreRangeOriginal;
 
         $this->ignoreRangeMap = [];
         $this->ignoreRangeOriginal = '';
 
         foreach (array_keys($map) as $token) {
             if (substr_count($content, $token) !== 1) {
-                return $original;
+                return $fallback;
             }
         }
 

--- a/app/BladeFormatter.php
+++ b/app/BladeFormatter.php
@@ -19,6 +19,23 @@ use App\Support\Prettier;
 class BladeFormatter
 {
     /**
+     * The placeholder to original-text map.
+     *
+     * @var array<string, string>
+     */
+    private array $ignoreRangeMap = [];
+
+    /**
+     * The content as it entered protectIgnoreRanges().
+     */
+    private string $ignoreRangeOriginal = '';
+
+    /**
+     * The index used to build unique placeholder tokens.
+     */
+    private int $ignoreRangeCounter = 0;
+
+    /**
      * The formatters applied around prettier's Blade output.
      *
      * @var array<int, class-string>
@@ -69,6 +86,9 @@ class BladeFormatter
      */
     public function format(string $path, string $content): string
     {
+        $ranges = $this->prettier->ignoreRanges($path, $content);
+        $content = $this->protectIgnoreRanges($content, $ranges, $content);
+
         $formatters = collect(static::$formatters)->map(
             fn (string $formatter): PrettierPreFormatter|PrettierPostFormatter => resolve($formatter),
         );
@@ -80,13 +100,93 @@ class BladeFormatter
             $content,
         );
 
-        $formatted = $this->prettier->format($path, $content);
+        $content = $this->restoreIgnoreRanges($content);
 
-        return $formatters->reduce(
+        if ($ranges === []) {
+            $formatted = $this->prettier->format($path, $content);
+        } else {
+            $result = $this->prettier->formatWithIgnoreRanges($path, $content);
+            $formatted = $this->protectIgnoreRanges($result['formatted'], $result['ranges'], $content);
+        }
+
+        $formatted = $formatters->reduce(
             fn (string $formatted, PrettierPreFormatter|PrettierPostFormatter $formatter): string => $formatter instanceof PrettierPostFormatter
                 ? $formatter->postFormat($formatted)
                 : $formatted,
             $formatted,
         );
+
+        return $this->restoreIgnoreRanges($formatted);
+    }
+
+    /**
+     * Protect the given formatter ignore ranges.
+     *
+     * @param  array<int, array{start: int, end: int, sourceStart?: int, sourceEnd?: int}>  $ranges
+     */
+    private function protectIgnoreRanges(string $content, array $ranges, string $source): string
+    {
+        $this->ignoreRangeMap = [];
+        $this->ignoreRangeOriginal = $content;
+        $this->ignoreRangeCounter = 0;
+
+        if ($ranges === []) {
+            return $content;
+        }
+
+        $result = '';
+        $cursor = 0;
+
+        foreach ($ranges as $range) {
+            $token = $this->makeIgnoreRangeToken();
+            $sourceStart = $range['sourceStart'] ?? $range['start'];
+            $sourceEnd = $range['sourceEnd'] ?? $range['end'];
+
+            $this->ignoreRangeMap[$token] = substr($source, $sourceStart, $sourceEnd - $sourceStart);
+            $result .= substr($content, $cursor, $range['start'] - $cursor).$token;
+            $cursor = $range['end'];
+        }
+
+        return $result.substr($content, $cursor);
+    }
+
+    /**
+     * Restore the contents of formatter ignore ranges.
+     */
+    private function restoreIgnoreRanges(string $content): string
+    {
+        if ($this->ignoreRangeMap === []) {
+            $this->ignoreRangeOriginal = '';
+
+            return $content;
+        }
+
+        $map = $this->ignoreRangeMap;
+        $original = $this->ignoreRangeOriginal;
+
+        $this->ignoreRangeMap = [];
+        $this->ignoreRangeOriginal = '';
+
+        foreach (array_keys($map) as $token) {
+            if (substr_count($content, $token) !== 1) {
+                return $original;
+            }
+        }
+
+        return str_replace(array_keys($map), array_values($map), $content);
+    }
+
+    /**
+     * Build a unique placeholder token.
+     */
+    private function makeIgnoreRangeToken(): string
+    {
+        while (true) {
+            $token = sprintf('__PINT_BLADE_IGNORE_%d__', $this->ignoreRangeCounter++);
+
+            if (! str_contains($this->ignoreRangeOriginal, $token)) {
+                return $token;
+            }
+        }
     }
 }

--- a/app/BladeFormatter.php
+++ b/app/BladeFormatter.php
@@ -4,6 +4,7 @@ namespace App;
 
 use App\Contracts\PrettierPostFormatter;
 use App\Contracts\PrettierPreFormatter;
+use App\Exceptions\PrettierException;
 use App\Exceptions\UnrestorableContentException;
 use App\PrettierFormatters\AlpineMaskPatterns;
 use App\PrettierFormatters\CollapseShortSlots;
@@ -94,47 +95,55 @@ class BladeFormatter
      */
     public function format(string $path, string $content): string
     {
+        $original = $content;
         $ranges = $this->prettier->ignoreRanges($path, $content);
-        $content = $this->protectIgnoreRanges($content, $ranges, $content);
-
         $formatters = collect(static::$formatters)->map(
             fn (string $formatter): PrettierPreFormatter|PrettierPostFormatter => resolve($formatter),
         );
 
-        $masked = $formatters->reduce(
-            fn (string $content, PrettierPreFormatter|PrettierPostFormatter $formatter): string => $formatter instanceof PrettierPreFormatter
-                ? $formatter->preFormat($content)
-                : $content,
-            $content,
-        );
-
-        $content = $this->restoreIgnoreRanges($masked);
-
-        if ($ranges === []) {
-            $formatted = $this->prettier->format($path, $content);
-        } else {
-            $result = $this->prettier->formatWithIgnoreRanges($path, $content);
-            $formatted = $this->protectIgnoreRanges($result['formatted'], $result['ranges'], $content);
-        }
-
         try {
+            $content = $this->protectIgnoreRanges($content, $ranges, $content);
+
+            $masked = $formatters->reduce(
+                fn (string $content, PrettierPreFormatter|PrettierPostFormatter $formatter): string => $formatter instanceof PrettierPreFormatter
+                    ? $formatter->preFormat($content)
+                    : $content,
+                $content,
+            );
+
+            $content = $this->restoreIgnoreRanges($masked);
+
+            if ($ranges === []) {
+                $formatted = $this->prettier->format($path, $content);
+            } else {
+                $result = $this->prettier->formatWithIgnoreRanges($path, $content);
+                $formatted = $this->protectIgnoreRanges($result['formatted'], $result['ranges'], $content);
+            }
+
             $formatted = $formatters->reduce(
                 fn (string $formatted, PrettierPreFormatter|PrettierPostFormatter $formatter): string => $formatter instanceof PrettierPostFormatter
                     ? $formatter->postFormat($formatted)
                     : $formatted,
                 $formatted,
             );
-        } catch (UnrestorableContentException) {
-            return $this->ignoreRangeOriginal;
-        }
 
-        return $this->restoreIgnoreRanges($formatted);
+            return $this->restoreIgnoreRanges($formatted);
+        } catch (UnrestorableContentException) {
+            // A masking pass could not undo its own work, which means prettier lost or
+            // duplicated one of its placeholders. Discard the whole run and hand back the
+            // untouched file: only the original content is guaranteed to be intact once a
+            // masking pass has been given up on.
+            $this->ignoreRangeMap = [];
+            $this->ignoreRangeOriginal = '';
+
+            return $original;
+        }
     }
 
     /**
      * Protect the given formatter ignore ranges.
      *
-     * @param  array<int, array{start: int, end: int, sourceStart?: int, sourceEnd?: int}>  $ranges
+     * @param  array<int, mixed>  $ranges
      */
     private function protectIgnoreRanges(string $content, array $ranges, string $source): string
     {
@@ -148,18 +157,55 @@ class BladeFormatter
 
         $result = '';
         $cursor = 0;
+        $sourceCursor = 0;
+        $contentLength = strlen($content);
+        $sourceLength = strlen($source);
 
         foreach ($ranges as $range) {
-            $token = $this->makeIgnoreRangeToken();
-            $sourceStart = $range['sourceStart'] ?? $range['start'];
-            $sourceEnd = $range['sourceEnd'] ?? $range['end'];
+            [$start, $end, $sourceStart, $sourceEnd] = $this->parseIgnoreRange(
+                $range,
+                $cursor,
+                $sourceCursor,
+                $contentLength,
+                $sourceLength,
+            );
 
+            $token = $this->makeIgnoreRangeToken();
             $this->ignoreRangeMap[$token] = substr($source, $sourceStart, $sourceEnd - $sourceStart);
-            $result .= substr($content, $cursor, $range['start'] - $cursor).$token;
-            $cursor = $range['end'];
+            $result .= substr($content, $cursor, $start - $cursor).$token;
+            $cursor = $end;
+            $sourceCursor = $sourceEnd;
         }
 
         return $result.substr($content, $cursor);
+    }
+
+    /**
+     * Validate and return a formatter ignore range.
+     *
+     * @return array{int, int, int, int}
+     */
+    private function parseIgnoreRange(mixed $range, int $cursor, int $sourceCursor, int $contentLength, int $sourceLength): array
+    {
+        if (! is_array($range)
+            || ! isset($range['start'], $range['end'], $range['sourceStart'], $range['sourceEnd'])
+            || ! is_int($range['start'])
+            || ! is_int($range['end'])
+            || ! is_int($range['sourceStart'])
+            || ! is_int($range['sourceEnd'])) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker returned invalid Blade ignore ranges.');
+        }
+
+        if ($range['start'] < $cursor
+            || $range['end'] < $range['start']
+            || $range['end'] > $contentLength
+            || $range['sourceStart'] < $sourceCursor
+            || $range['sourceEnd'] < $range['sourceStart']
+            || $range['sourceEnd'] > $sourceLength) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker returned invalid Blade ignore ranges.');
+        }
+
+        return [$range['start'], $range['end'], $range['sourceStart'], $range['sourceEnd']];
     }
 
     /**
@@ -174,14 +220,13 @@ class BladeFormatter
         }
 
         $map = $this->ignoreRangeMap;
-        $original = $this->ignoreRangeOriginal;
 
         $this->ignoreRangeMap = [];
         $this->ignoreRangeOriginal = '';
 
         foreach (array_keys($map) as $token) {
             if (substr_count($content, $token) !== 1) {
-                return $original;
+                throw new UnrestorableContentException;
             }
         }
 

--- a/app/BladeFormatter.php
+++ b/app/BladeFormatter.php
@@ -21,6 +21,23 @@ use App\Support\Prettier;
 class BladeFormatter
 {
     /**
+     * The placeholder to original-text map.
+     *
+     * @var array<string, string>
+     */
+    private array $ignoreRangeMap = [];
+
+    /**
+     * The content as it entered protectIgnoreRanges().
+     */
+    private string $ignoreRangeOriginal = '';
+
+    /**
+     * The index used to build unique placeholder tokens.
+     */
+    private int $ignoreRangeCounter = 0;
+
+    /**
      * The formatters applied around prettier's Blade output.
      *
      * @var array<int, class-string>
@@ -77,6 +94,9 @@ class BladeFormatter
      */
     public function format(string $path, string $content): string
     {
+        $ranges = $this->prettier->ignoreRanges($path, $content);
+        $content = $this->protectIgnoreRanges($content, $ranges, $content);
+
         $formatters = collect(static::$formatters)->map(
             fn (string $formatter): PrettierPreFormatter|PrettierPostFormatter => resolve($formatter),
         );
@@ -88,21 +108,97 @@ class BladeFormatter
             $content,
         );
 
-        $formatted = $this->prettier->format($path, $masked);
+        $content = $this->restoreIgnoreRanges($masked);
+
+        if ($ranges === []) {
+            $formatted = $this->prettier->format($path, $content);
+        } else {
+            $result = $this->prettier->formatWithIgnoreRanges($path, $content);
+            $formatted = $this->protectIgnoreRanges($result['formatted'], $result['ranges'], $content);
+        }
 
         try {
-            return $formatters->reduce(
+            $formatted = $formatters->reduce(
                 fn (string $formatted, PrettierPreFormatter|PrettierPostFormatter $formatter): string => $formatter instanceof PrettierPostFormatter
                     ? $formatter->postFormat($formatted)
                     : $formatted,
                 $formatted,
             );
         } catch (UnrestorableContentException) {
-            // A pre-formatter could not undo its own work, which means prettier lost or
-            // duplicated one of its placeholders. Discard the whole run and hand back the
-            // untouched file: only the original content is guaranteed to be intact once a
-            // masking pass has been given up on.
+            return $this->ignoreRangeOriginal;
+        }
+
+        return $this->restoreIgnoreRanges($formatted);
+    }
+
+    /**
+     * Protect the given formatter ignore ranges.
+     *
+     * @param  array<int, array{start: int, end: int, sourceStart?: int, sourceEnd?: int}>  $ranges
+     */
+    private function protectIgnoreRanges(string $content, array $ranges, string $source): string
+    {
+        $this->ignoreRangeMap = [];
+        $this->ignoreRangeOriginal = $content;
+        $this->ignoreRangeCounter = 0;
+
+        if ($ranges === []) {
             return $content;
+        }
+
+        $result = '';
+        $cursor = 0;
+
+        foreach ($ranges as $range) {
+            $token = $this->makeIgnoreRangeToken();
+            $sourceStart = $range['sourceStart'] ?? $range['start'];
+            $sourceEnd = $range['sourceEnd'] ?? $range['end'];
+
+            $this->ignoreRangeMap[$token] = substr($source, $sourceStart, $sourceEnd - $sourceStart);
+            $result .= substr($content, $cursor, $range['start'] - $cursor).$token;
+            $cursor = $range['end'];
+        }
+
+        return $result.substr($content, $cursor);
+    }
+
+    /**
+     * Restore the contents of formatter ignore ranges.
+     */
+    private function restoreIgnoreRanges(string $content): string
+    {
+        if ($this->ignoreRangeMap === []) {
+            $this->ignoreRangeOriginal = '';
+
+            return $content;
+        }
+
+        $map = $this->ignoreRangeMap;
+        $original = $this->ignoreRangeOriginal;
+
+        $this->ignoreRangeMap = [];
+        $this->ignoreRangeOriginal = '';
+
+        foreach (array_keys($map) as $token) {
+            if (substr_count($content, $token) !== 1) {
+                return $original;
+            }
+        }
+
+        return str_replace(array_keys($map), array_values($map), $content);
+    }
+
+    /**
+     * Build a unique placeholder token.
+     */
+    private function makeIgnoreRangeToken(): string
+    {
+        while (true) {
+            $token = sprintf('__PINT_BLADE_IGNORE_%d__', $this->ignoreRangeCounter++);
+
+            if (! str_contains($this->ignoreRangeOriginal, $token)) {
+                return $token;
+            }
         }
     }
 }

--- a/app/BladeFormatter.php
+++ b/app/BladeFormatter.php
@@ -29,7 +29,7 @@ class BladeFormatter
     private array $ignoreRangeMap = [];
 
     /**
-     * The content as it entered protectIgnoreRanges().
+     * The content as it entered format().
      */
     private string $ignoreRangeOriginal = '';
 
@@ -96,6 +96,7 @@ class BladeFormatter
     public function format(string $path, string $content): string
     {
         $original = $content;
+        $this->resetIgnoreRanges($content);
         $ranges = $this->prettier->ignoreRanges($path, $content);
         $formatters = collect(static::$formatters)->map(
             fn (string $formatter): PrettierPreFormatter|PrettierPostFormatter => resolve($formatter),
@@ -111,7 +112,7 @@ class BladeFormatter
                 $content,
             );
 
-            $content = $this->restoreIgnoreRanges($masked);
+            $content = $this->restoreVisibleIgnoreRanges($masked);
 
             if ($ranges === []) {
                 $formatted = $this->prettier->format($path, $content);
@@ -133,8 +134,7 @@ class BladeFormatter
             // duplicated one of its placeholders. Discard the whole run and hand back the
             // untouched file: only the original content is guaranteed to be intact once a
             // masking pass has been given up on.
-            $this->ignoreRangeMap = [];
-            $this->ignoreRangeOriginal = '';
+            $this->resetIgnoreRanges();
 
             return $original;
         }
@@ -147,10 +147,6 @@ class BladeFormatter
      */
     private function protectIgnoreRanges(string $content, array $ranges, string $source): string
     {
-        $this->ignoreRangeMap = [];
-        $this->ignoreRangeOriginal = $content;
-        $this->ignoreRangeCounter = 0;
-
         if ($ranges === []) {
             return $content;
         }
@@ -170,7 +166,7 @@ class BladeFormatter
                 $sourceLength,
             );
 
-            $token = $this->makeIgnoreRangeToken();
+            $token = $this->makeIgnoreRangeToken($content);
             $this->ignoreRangeMap[$token] = substr($source, $sourceStart, $sourceEnd - $sourceStart);
             $result .= substr($content, $cursor, $start - $cursor).$token;
             $cursor = $end;
@@ -209,6 +205,29 @@ class BladeFormatter
     }
 
     /**
+     * Restore ignore ranges that remain visible after the pre-formatters run.
+     */
+    private function restoreVisibleIgnoreRanges(string $content): string
+    {
+        $visible = [];
+
+        foreach ($this->ignoreRangeMap as $token => $original) {
+            $count = substr_count($content, $token);
+
+            if ($count > 1) {
+                throw new UnrestorableContentException;
+            }
+
+            if ($count === 1) {
+                $visible[$token] = $original;
+                unset($this->ignoreRangeMap[$token]);
+            }
+        }
+
+        return strtr($content, $visible);
+    }
+
+    /**
      * Restore the contents of formatter ignore ranges.
      */
     private function restoreIgnoreRanges(string $content): string
@@ -230,20 +249,31 @@ class BladeFormatter
             }
         }
 
-        return str_replace(array_keys($map), array_values($map), $content);
+        return strtr($content, $map);
     }
 
     /**
      * Build a unique placeholder token.
      */
-    private function makeIgnoreRangeToken(): string
+    private function makeIgnoreRangeToken(string $content): string
     {
         while (true) {
             $token = sprintf('__PINT_BLADE_IGNORE_%d__', $this->ignoreRangeCounter++);
 
-            if (! str_contains($this->ignoreRangeOriginal, $token)) {
+            if (! str_contains($this->ignoreRangeOriginal, $token)
+                && ! str_contains($content, $token)) {
                 return $token;
             }
         }
+    }
+
+    /**
+     * Reset the formatter ignore range state.
+     */
+    private function resetIgnoreRanges(string $original = ''): void
+    {
+        $this->ignoreRangeMap = [];
+        $this->ignoreRangeOriginal = $original;
+        $this->ignoreRangeCounter = 0;
     }
 }

--- a/app/Fixers/LaravelBlade/Fixer.php
+++ b/app/Fixers/LaravelBlade/Fixer.php
@@ -35,8 +35,8 @@ class Fixer extends AbstractFixer implements HasPrettierDependencies
     public function prettierDependencies(): array
     {
         return [
-            'prettier' => '^3.8.4',
-            'prettier-plugin-blade' => '^3.2.2',
+            'prettier' => '3.9.6',
+            'prettier-plugin-blade' => '3.2.2',
             'prettier-plugin-tailwindcss' => '^0.8.0',
         ];
     }

--- a/app/Fixers/LaravelBlade/Fixer.php
+++ b/app/Fixers/LaravelBlade/Fixer.php
@@ -35,8 +35,8 @@ class Fixer extends AbstractFixer implements HasPrettierDependencies
     public function prettierDependencies(): array
     {
         return [
-            'prettier' => '3.9.6',
-            'prettier-plugin-blade' => '3.2.2',
+            'prettier' => '^3.8.4',
+            'prettier-plugin-blade' => '^3.3.0',
             'prettier-plugin-tailwindcss' => '^0.8.0',
         ];
     }

--- a/app/Support/Prettier.php
+++ b/app/Support/Prettier.php
@@ -4,7 +4,6 @@ namespace App\Support;
 
 use App\Exceptions\PrettierException;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Str;
 use Symfony\Component\Process\InputStream;
 use Symfony\Component\Process\Process;
 
@@ -23,6 +22,13 @@ class Prettier
      * @var int
      */
     public const WORKER_IDLE_TIMEOUT = 30;
+
+    /**
+     * The prefix used to identify worker response lines.
+     *
+     * @var string
+     */
+    private const RESPONSE_PREFIX = '[PINT_PRETTIER_WORKER]';
 
     /**
      * The process instance, if any.
@@ -147,7 +153,7 @@ class Prettier
                 $deadline = microtime(true) + $this->workerIdleTimeout();
             }
 
-            if (str_contains($output, '[PINT_PRETTIER_WORKER_END]')) {
+            if ($this->responseFromOutput($output) !== null) {
                 break;
             }
 
@@ -182,19 +188,11 @@ class Prettier
             throw new PrettierException($error);
         }
 
-        foreach ([
-            '[PINT_PRETTIER_WORKER_START]',
-            '[PINT_PRETTIER_WORKER_END]',
-        ] as $delimiter) {
-            if (! Str::contains($output, $delimiter)) {
-                throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
-            }
-        }
+        $response = $this->responseFromOutput($output);
 
-        $response = Str::of($output)
-            ->after('[PINT_PRETTIER_WORKER_START]')
-            ->before('[PINT_PRETTIER_WORKER_END]')
-            ->value();
+        if ($response === null) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
+        }
 
         $decoded = json_decode($response, true);
 
@@ -203,6 +201,23 @@ class Prettier
         }
 
         return $decoded;
+    }
+
+    /**
+     * Return the first complete worker response in the given output.
+     */
+    private function responseFromOutput(string $output): ?string
+    {
+        $lines = explode("\n", $output);
+        array_pop($lines);
+
+        foreach ($lines as $line) {
+            if (str_starts_with($line, self::RESPONSE_PREFIX)) {
+                return substr($line, strlen(self::RESPONSE_PREFIX));
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/app/Support/Prettier.php
+++ b/app/Support/Prettier.php
@@ -15,7 +15,7 @@ class Prettier
      *
      * @var int
      */
-    public const VERSION = 1;
+    public const VERSION = 2;
 
     /**
      * The number of seconds the worker may stay silent before it is torn down.
@@ -57,28 +57,97 @@ class Prettier
      */
     public function format(string $path, string $content): string
     {
+        $result = $this->send([
+            'type' => 'format',
+            'path' => $path,
+            'content' => $content,
+        ]);
+
+        if (! isset($result['formatted']) || ! is_string($result['formatted'])) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
+        }
+
+        return $result['formatted'];
+    }
+
+    /**
+     * Format the given file and return its formatter ignore ranges.
+     *
+     * @return array{formatted: string, ranges: array<int, array{start: int, end: int, sourceStart: int, sourceEnd: int}>}
+     *
+     * @throws PrettierException
+     */
+    public function formatWithIgnoreRanges(string $path, string $content): array
+    {
+        $result = $this->send([
+            'type' => 'format-with-ignore-ranges',
+            'path' => $path,
+            'content' => $content,
+        ]);
+
+        if (! isset($result['formatted'], $result['ranges']) || ! is_string($result['formatted']) || ! is_array($result['ranges'])) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Return the formatter ignore ranges in the given file.
+     *
+     * @return array<int, array{start: int, end: int}>
+     *
+     * @throws PrettierException
+     */
+    public function ignoreRanges(string $path, string $content): array
+    {
+        if (stripos($content, 'format-ignore-start') === false
+            && stripos($content, 'prettier-ignore-start') === false) {
+            return [];
+        }
+
+        $result = $this->send([
+            'type' => 'ranges',
+            'path' => $path,
+            'content' => $content,
+        ]);
+
+        if (! isset($result['ranges']) || ! is_array($result['ranges'])) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
+        }
+
+        return $result['ranges'];
+    }
+
+    /**
+     * Send a request to the prettier worker.
+     *
+     * @param  array<string, mixed>  $request
+     * @return array<string, mixed>
+     *
+     * @throws PrettierException
+     */
+    private function send(array $request): array
+    {
         $this->ensureStarted();
 
         $this->process->clearOutput();
         $this->process->clearErrorOutput();
 
-        $this->inputStream->write(json_encode([
-            'path' => $path,
-            'content' => $content,
-        ], JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE)."\n");
+        $this->inputStream->write(json_encode($request, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE)."\n");
 
         // Accumulate every chunk; the OS pipe may split the response across reads.
-        $formatted = '';
+        $output = '';
         $error = '';
         $deadline = microtime(true) + $this->workerIdleTimeout();
 
         while (true) {
             if (($chunk = $this->process->getIncrementalOutput()) !== '') {
-                $formatted .= $chunk;
+                $output .= $chunk;
                 $deadline = microtime(true) + $this->workerIdleTimeout();
             }
 
-            if (str_contains($formatted, '[PINT_PRETTIER_WORKER_END]')) {
+            if (str_contains($output, '[PINT_PRETTIER_WORKER_END]')) {
                 break;
             }
 
@@ -99,7 +168,7 @@ class Prettier
 
                 throw new PrettierException(sprintf(
                     'Laravel Pint\'s Prettier worker timed out while formatting [%s].',
-                    $path,
+                    $request['path'],
                 ));
             }
 
@@ -117,15 +186,23 @@ class Prettier
             '[PINT_PRETTIER_WORKER_START]',
             '[PINT_PRETTIER_WORKER_END]',
         ] as $delimiter) {
-            if (! Str::contains($formatted, $delimiter)) {
+            if (! Str::contains($output, $delimiter)) {
                 throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
             }
         }
 
-        return Str::of($formatted)
+        $response = Str::of($output)
             ->after('[PINT_PRETTIER_WORKER_START]')
             ->before('[PINT_PRETTIER_WORKER_END]')
             ->value();
+
+        $decoded = json_decode($response, true);
+
+        if (! is_array($decoded)) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
+        }
+
+        return $decoded;
     }
 
     /**

--- a/app/Support/Prettier.php
+++ b/app/Support/Prettier.php
@@ -16,7 +16,7 @@ class Prettier
      *
      * @var int
      */
-    public const VERSION = 1;
+    public const VERSION = 2;
 
     /**
      * The number of seconds the worker may stay silent before it is torn down.
@@ -58,28 +58,97 @@ class Prettier
      */
     public function format(string $path, string $content): string
     {
+        $result = $this->send([
+            'type' => 'format',
+            'path' => $path,
+            'content' => $content,
+        ]);
+
+        if (! isset($result['formatted']) || ! is_string($result['formatted'])) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
+        }
+
+        return $result['formatted'];
+    }
+
+    /**
+     * Format the given file and return its formatter ignore ranges.
+     *
+     * @return array{formatted: string, ranges: array<int, array{start: int, end: int, sourceStart: int, sourceEnd: int}>}
+     *
+     * @throws PrettierException
+     */
+    public function formatWithIgnoreRanges(string $path, string $content): array
+    {
+        $result = $this->send([
+            'type' => 'format-with-ignore-ranges',
+            'path' => $path,
+            'content' => $content,
+        ]);
+
+        if (! isset($result['formatted'], $result['ranges']) || ! is_string($result['formatted']) || ! is_array($result['ranges'])) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Return the formatter ignore ranges in the given file.
+     *
+     * @return array<int, array{start: int, end: int}>
+     *
+     * @throws PrettierException
+     */
+    public function ignoreRanges(string $path, string $content): array
+    {
+        if (stripos($content, 'format-ignore-start') === false
+            && stripos($content, 'prettier-ignore-start') === false) {
+            return [];
+        }
+
+        $result = $this->send([
+            'type' => 'ranges',
+            'path' => $path,
+            'content' => $content,
+        ]);
+
+        if (! isset($result['ranges']) || ! is_array($result['ranges'])) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
+        }
+
+        return $result['ranges'];
+    }
+
+    /**
+     * Send a request to the prettier worker.
+     *
+     * @param  array<string, mixed>  $request
+     * @return array<string, mixed>
+     *
+     * @throws PrettierException
+     */
+    private function send(array $request): array
+    {
         $this->ensureStarted();
 
         $this->process->clearOutput();
         $this->process->clearErrorOutput();
 
-        $this->inputStream->write(json_encode([
-            'path' => $path,
-            'content' => $content,
-        ], JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE)."\n");
+        $this->inputStream->write(json_encode($request, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE)."\n");
 
         // Accumulate every chunk; the OS pipe may split the response across reads.
-        $formatted = '';
+        $output = '';
         $error = '';
         $deadline = microtime(true) + $this->workerIdleTimeout();
 
         while (true) {
             if (($chunk = $this->process->getIncrementalOutput()) !== '') {
-                $formatted .= $chunk;
+                $output .= $chunk;
                 $deadline = microtime(true) + $this->workerIdleTimeout();
             }
 
-            if (str_contains($formatted, '[PINT_PRETTIER_WORKER_END]')) {
+            if (str_contains($output, '[PINT_PRETTIER_WORKER_END]')) {
                 break;
             }
 
@@ -100,7 +169,7 @@ class Prettier
 
                 throw new PrettierException(sprintf(
                     'Laravel Pint\'s Prettier worker timed out while formatting [%s].',
-                    $path,
+                    $request['path'],
                 ));
             }
 
@@ -118,15 +187,23 @@ class Prettier
             '[PINT_PRETTIER_WORKER_START]',
             '[PINT_PRETTIER_WORKER_END]',
         ] as $delimiter) {
-            if (! Str::contains($formatted, $delimiter)) {
+            if (! Str::contains($output, $delimiter)) {
                 throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
             }
         }
 
-        return Str::of($formatted)
+        $response = Str::of($output)
             ->after('[PINT_PRETTIER_WORKER_START]')
             ->before('[PINT_PRETTIER_WORKER_END]')
             ->value();
+
+        $decoded = json_decode($response, true);
+
+        if (! is_array($decoded)) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
+        }
+
+        return $decoded;
     }
 
     /**

--- a/app/Support/Prettier.php
+++ b/app/Support/Prettier.php
@@ -5,7 +5,6 @@ namespace App\Support;
 use App\Enums\NodePackageManager;
 use App\Exceptions\PrettierException;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Str;
 use Symfony\Component\Process\InputStream;
 use Symfony\Component\Process\Process;
 
@@ -24,6 +23,13 @@ class Prettier
      * @var int
      */
     public const WORKER_IDLE_TIMEOUT = 30;
+
+    /**
+     * The prefix used to identify worker response lines.
+     *
+     * @var string
+     */
+    private const RESPONSE_PREFIX = '[PINT_PRETTIER_WORKER]';
 
     /**
      * The process instance, if any.
@@ -96,7 +102,7 @@ class Prettier
     /**
      * Return the formatter ignore ranges in the given file.
      *
-     * @return array<int, array{start: int, end: int}>
+     * @return array<int, array{start: int, end: int, sourceStart: int, sourceEnd: int}>
      *
      * @throws PrettierException
      */
@@ -105,6 +111,10 @@ class Prettier
         if (stripos($content, 'format-ignore-start') === false
             && stripos($content, 'prettier-ignore-start') === false) {
             return [];
+        }
+
+        if (! mb_check_encoding($content, 'UTF-8')) {
+            throw new PrettierException('Laravel Pint cannot preserve Blade formatter ignore ranges in files containing invalid UTF-8.');
         }
 
         $result = $this->send([
@@ -148,7 +158,7 @@ class Prettier
                 $deadline = microtime(true) + $this->workerIdleTimeout();
             }
 
-            if (str_contains($output, '[PINT_PRETTIER_WORKER_END]')) {
+            if ($this->responseFromOutput($output) !== null) {
                 break;
             }
 
@@ -183,19 +193,11 @@ class Prettier
             throw new PrettierException($error);
         }
 
-        foreach ([
-            '[PINT_PRETTIER_WORKER_START]',
-            '[PINT_PRETTIER_WORKER_END]',
-        ] as $delimiter) {
-            if (! Str::contains($output, $delimiter)) {
-                throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
-            }
-        }
+        $response = $this->responseFromOutput($output);
 
-        $response = Str::of($output)
-            ->after('[PINT_PRETTIER_WORKER_START]')
-            ->before('[PINT_PRETTIER_WORKER_END]')
-            ->value();
+        if ($response === null) {
+            throw new PrettierException('Laravel Pint\'s Prettier worker did not return a valid response.');
+        }
 
         $decoded = json_decode($response, true);
 
@@ -204,6 +206,23 @@ class Prettier
         }
 
         return $decoded;
+    }
+
+    /**
+     * Return the first complete worker response in the given output.
+     */
+    private function responseFromOutput(string $output): ?string
+    {
+        $start = strpos($output, self::RESPONSE_PREFIX);
+
+        if ($start === false) {
+            return null;
+        }
+
+        $start += strlen(self::RESPONSE_PREFIX);
+        $end = strpos($output, "\n", $start);
+
+        return $end === false ? null : substr($output, $start, $end - $start);
     }
 
     /**

--- a/resources/js/worker.cjs
+++ b/resources/js/worker.cjs
@@ -2,8 +2,17 @@ const projectRoot = process.argv[2] || process.cwd();
 const configPath = process.argv[3];
 
 const prettier = require(require.resolve("prettier", { paths: [projectRoot] }));
+const { getBladeIgnoreRanges } = require(
+    require.resolve("prettier-plugin-blade", { paths: [projectRoot] }),
+);
 
 const bundledOptions = require(configPath);
+
+if (typeof getBladeIgnoreRanges !== "function") {
+    throw new Error(
+        "The installed Blade plugin does not expose its ignore range API.",
+    );
+}
 
 function resolvePlugins(plugins) {
     if (!Array.isArray(plugins)) {
@@ -61,12 +70,6 @@ async function handleMessage(input) {
     try {
         const { type = "format", path: filepath, content } = JSON.parse(input);
 
-        if (type === "ranges" && !hasIgnoreRangeMarker(content)) {
-            writeResponse({ ranges: [] });
-
-            return;
-        }
-
         const resolved = filepath.trim();
 
         const options = resolveOptionPlugins({ ...bundledOptions });
@@ -84,17 +87,10 @@ async function handleMessage(input) {
             return;
         }
 
-        if (
-            typeof prettier.__debug?.parse !== "function" ||
-            typeof prettier.__debug?.formatAST !== "function"
-        ) {
-            throw new Error(
-                "The installed Prettier version does not expose the Blade ignore range formatter API.",
-            );
-        }
-
-        const { ast } = await prettier.__debug.parse(content, parseOptions);
-        const sourceRanges = ignoreRanges(ast, normalizedLength(content));
+        const sourceRanges = ignoreRanges(
+            getBladeIgnoreRanges(content, parseOptions),
+            content.length,
+        );
 
         if (type === "ranges") {
             writeResponse({
@@ -106,19 +102,10 @@ async function handleMessage(input) {
             return;
         }
 
-        let { formatted } = await prettier.__debug.formatAST(ast, parseOptions);
-
-        if (content.charCodeAt(0) === 0xfeff) {
-            formatted = `\ufeff${formatted}`;
-        }
-
-        const { ast: formattedAst } = await prettier.__debug.parse(
-            formatted,
-            parseOptions,
-        );
+        const formatted = await prettier.format(content, parseOptions);
         const formattedRanges = ignoreRanges(
-            formattedAst,
-            normalizedLength(formatted),
+            getBladeIgnoreRanges(formatted, parseOptions),
+            formatted.length,
         );
 
         if (formattedRanges.length !== sourceRanges.length) {
@@ -145,18 +132,7 @@ async function handleMessage(input) {
     }
 }
 
-function hasIgnoreRangeMarker(content) {
-    const lower = content.toLowerCase();
-
-    return (
-        lower.includes("format-ignore-start") ||
-        lower.includes("prettier-ignore-start")
-    );
-}
-
-function ignoreRanges(ast, contentLength) {
-    const ranges = ast?.buildResult?.ignoreRanges;
-
+function ignoreRanges(ranges, contentLength) {
     if (
         !Array.isArray(ranges) ||
         !ranges.every(
@@ -181,49 +157,11 @@ function ignoreRanges(ast, contentLength) {
 
 function toByteRange(content, { start, end }) {
     return {
-        start: Buffer.byteLength(
-            content.slice(0, sourceOffset(content, start)),
-            "utf8",
-        ),
-        end: Buffer.byteLength(
-            content.slice(0, sourceOffset(content, end)),
-            "utf8",
-        ),
+        start: Buffer.byteLength(content.slice(0, start), "utf8"),
+        end: Buffer.byteLength(content.slice(0, end), "utf8"),
     };
 }
 
-function normalizedLength(content) {
-    let length = content.length;
-    let offset = 0;
-
-    if (content.charCodeAt(0) === 0xfeff) {
-        length--;
-        offset++;
-    }
-
-    while ((offset = content.indexOf("\r\n", offset)) !== -1) {
-        length--;
-        offset += 2;
-    }
-
-    return length;
-}
-
-function sourceOffset(content, normalizedOffset) {
-    let offset = content.charCodeAt(0) === 0xfeff ? 1 : 0;
-    let normalized = 0;
-
-    while (normalized < normalizedOffset) {
-        offset +=
-            content[offset] === "\r" && content[offset + 1] === "\n" ? 2 : 1;
-        normalized++;
-    }
-
-    return offset;
-}
-
 function writeResponse(response) {
-    process.stdout.write(
-        `[PINT_PRETTIER_WORKER_START]${JSON.stringify(response)}[PINT_PRETTIER_WORKER_END]`,
-    );
+    process.stdout.write(`[PINT_PRETTIER_WORKER]${JSON.stringify(response)}\n`);
 }

--- a/resources/js/worker.cjs
+++ b/resources/js/worker.cjs
@@ -59,21 +59,171 @@ process.stdin.on("data", function (chunk) {
 
 async function handleMessage(input) {
     try {
-        const { path: filepath, content } = JSON.parse(input);
+        const { type = "format", path: filepath, content } = JSON.parse(input);
+
+        if (type === "ranges" && !hasIgnoreRangeMarker(content)) {
+            writeResponse({ ranges: [] });
+
+            return;
+        }
 
         const resolved = filepath.trim();
 
         const options = resolveOptionPlugins({ ...bundledOptions });
 
-        const formatted = await prettier.format(content, {
+        const parseOptions = {
             ...options,
             filepath: resolved,
-        });
+        };
 
-        process.stdout.write(
-            `[PINT_PRETTIER_WORKER_START]${formatted}[PINT_PRETTIER_WORKER_END]`,
+        if (type === "format") {
+            writeResponse({
+                formatted: await prettier.format(content, parseOptions),
+            });
+
+            return;
+        }
+
+        if (
+            typeof prettier.__debug?.parse !== "function" ||
+            typeof prettier.__debug?.formatAST !== "function"
+        ) {
+            throw new Error(
+                "The installed Prettier version does not expose the Blade ignore range formatter API.",
+            );
+        }
+
+        const { ast } = await prettier.__debug.parse(content, parseOptions);
+        const sourceRanges = ignoreRanges(ast, normalizedLength(content));
+
+        if (type === "ranges") {
+            writeResponse({
+                ranges: sourceRanges.map((range) =>
+                    toByteRange(content, range),
+                ),
+            });
+
+            return;
+        }
+
+        let { formatted } = await prettier.__debug.formatAST(ast, parseOptions);
+
+        if (content.charCodeAt(0) === 0xfeff) {
+            formatted = `\ufeff${formatted}`;
+        }
+
+        const { ast: formattedAst } = await prettier.__debug.parse(
+            formatted,
+            parseOptions,
         );
+        const formattedRanges = ignoreRanges(
+            formattedAst,
+            normalizedLength(formatted),
+        );
+
+        if (formattedRanges.length !== sourceRanges.length) {
+            throw new Error(
+                "Prettier did not preserve every Blade ignore range.",
+            );
+        }
+
+        writeResponse({
+            formatted,
+            ranges: formattedRanges.map((range, index) => {
+                const formattedRange = toByteRange(formatted, range);
+                const sourceRange = toByteRange(content, sourceRanges[index]);
+
+                return {
+                    ...formattedRange,
+                    sourceStart: sourceRange.start,
+                    sourceEnd: sourceRange.end,
+                };
+            }),
+        });
     } catch (error) {
         process.stderr.write(`${error.stack || error.message}\n`);
     }
+}
+
+function hasIgnoreRangeMarker(content) {
+    const lower = content.toLowerCase();
+
+    return (
+        lower.includes("format-ignore-start") ||
+        lower.includes("prettier-ignore-start")
+    );
+}
+
+function ignoreRanges(ast, contentLength) {
+    const ranges = ast?.buildResult?.ignoreRanges;
+
+    if (
+        !Array.isArray(ranges) ||
+        !ranges.every(
+            (range, index) =>
+                range !== null &&
+                typeof range === "object" &&
+                Number.isInteger(range.start) &&
+                Number.isInteger(range.end) &&
+                range.start >= 0 &&
+                range.end >= range.start &&
+                range.end <= contentLength &&
+                (index === 0 || range.start >= ranges[index - 1].end),
+        )
+    ) {
+        throw new Error(
+            "The installed Blade plugin did not return valid ignore ranges.",
+        );
+    }
+
+    return ranges;
+}
+
+function toByteRange(content, { start, end }) {
+    return {
+        start: Buffer.byteLength(
+            content.slice(0, sourceOffset(content, start)),
+            "utf8",
+        ),
+        end: Buffer.byteLength(
+            content.slice(0, sourceOffset(content, end)),
+            "utf8",
+        ),
+    };
+}
+
+function normalizedLength(content) {
+    let length = content.length;
+    let offset = 0;
+
+    if (content.charCodeAt(0) === 0xfeff) {
+        length--;
+        offset++;
+    }
+
+    while ((offset = content.indexOf("\r\n", offset)) !== -1) {
+        length--;
+        offset += 2;
+    }
+
+    return length;
+}
+
+function sourceOffset(content, normalizedOffset) {
+    let offset = content.charCodeAt(0) === 0xfeff ? 1 : 0;
+    let normalized = 0;
+
+    while (normalized < normalizedOffset) {
+        offset +=
+            content[offset] === "\r" && content[offset + 1] === "\n" ? 2 : 1;
+        normalized++;
+    }
+
+    return offset;
+}
+
+function writeResponse(response) {
+    process.stdout.write(
+        `[PINT_PRETTIER_WORKER_START]${JSON.stringify(response)}[PINT_PRETTIER_WORKER_END]`,
+    );
 }

--- a/resources/js/worker.cjs
+++ b/resources/js/worker.cjs
@@ -2,8 +2,17 @@ const projectRoot = process.argv[2] || process.cwd();
 const configPath = process.argv[3];
 
 const prettier = require(require.resolve("prettier", { paths: [projectRoot] }));
+const { getBladeIgnoreRanges } = require(
+    require.resolve("prettier-plugin-blade", { paths: [projectRoot] }),
+);
 
 const bundledOptions = require(configPath);
+
+if (typeof getBladeIgnoreRanges !== "function") {
+    throw new Error(
+        "The installed Blade plugin does not expose its ignore range API.",
+    );
+}
 
 function resolvePlugins(plugins) {
     if (!Array.isArray(plugins)) {
@@ -61,12 +70,6 @@ async function handleMessage(input) {
     try {
         const { type = "format", path: filepath, content } = JSON.parse(input);
 
-        if (type === "ranges" && !hasIgnoreRangeMarker(content)) {
-            writeResponse({ ranges: [] });
-
-            return;
-        }
-
         const resolved = filepath.trim();
 
         const options = resolveOptionPlugins({ ...bundledOptions });
@@ -84,41 +87,31 @@ async function handleMessage(input) {
             return;
         }
 
-        if (
-            typeof prettier.__debug?.parse !== "function" ||
-            typeof prettier.__debug?.formatAST !== "function"
-        ) {
-            throw new Error(
-                "The installed Prettier version does not expose the Blade ignore range formatter API.",
-            );
-        }
-
-        const { ast } = await prettier.__debug.parse(content, parseOptions);
-        const sourceRanges = ignoreRanges(ast, normalizedLength(content));
+        const sourceRanges = ignoreRanges(
+            getBladeIgnoreRanges(content, parseOptions),
+            content.length,
+        );
 
         if (type === "ranges") {
             writeResponse({
-                ranges: sourceRanges.map((range) =>
-                    toByteRange(content, range),
-                ),
+                ranges: sourceRanges.map((range) => {
+                    const byteRange = toByteRange(content, range);
+
+                    return {
+                        ...byteRange,
+                        sourceStart: byteRange.start,
+                        sourceEnd: byteRange.end,
+                    };
+                }),
             });
 
             return;
         }
 
-        let { formatted } = await prettier.__debug.formatAST(ast, parseOptions);
-
-        if (content.charCodeAt(0) === 0xfeff) {
-            formatted = `\ufeff${formatted}`;
-        }
-
-        const { ast: formattedAst } = await prettier.__debug.parse(
-            formatted,
-            parseOptions,
-        );
+        const formatted = await prettier.format(content, parseOptions);
         const formattedRanges = ignoreRanges(
-            formattedAst,
-            normalizedLength(formatted),
+            getBladeIgnoreRanges(formatted, parseOptions),
+            formatted.length,
         );
 
         if (formattedRanges.length !== sourceRanges.length) {
@@ -145,18 +138,7 @@ async function handleMessage(input) {
     }
 }
 
-function hasIgnoreRangeMarker(content) {
-    const lower = content.toLowerCase();
-
-    return (
-        lower.includes("format-ignore-start") ||
-        lower.includes("prettier-ignore-start")
-    );
-}
-
-function ignoreRanges(ast, contentLength) {
-    const ranges = ast?.buildResult?.ignoreRanges;
-
+function ignoreRanges(ranges, contentLength) {
     if (
         !Array.isArray(ranges) ||
         !ranges.every(
@@ -181,49 +163,11 @@ function ignoreRanges(ast, contentLength) {
 
 function toByteRange(content, { start, end }) {
     return {
-        start: Buffer.byteLength(
-            content.slice(0, sourceOffset(content, start)),
-            "utf8",
-        ),
-        end: Buffer.byteLength(
-            content.slice(0, sourceOffset(content, end)),
-            "utf8",
-        ),
+        start: Buffer.byteLength(content.slice(0, start), "utf8"),
+        end: Buffer.byteLength(content.slice(0, end), "utf8"),
     };
 }
 
-function normalizedLength(content) {
-    let length = content.length;
-    let offset = 0;
-
-    if (content.charCodeAt(0) === 0xfeff) {
-        length--;
-        offset++;
-    }
-
-    while ((offset = content.indexOf("\r\n", offset)) !== -1) {
-        length--;
-        offset += 2;
-    }
-
-    return length;
-}
-
-function sourceOffset(content, normalizedOffset) {
-    let offset = content.charCodeAt(0) === 0xfeff ? 1 : 0;
-    let normalized = 0;
-
-    while (normalized < normalizedOffset) {
-        offset +=
-            content[offset] === "\r" && content[offset + 1] === "\n" ? 2 : 1;
-        normalized++;
-    }
-
-    return offset;
-}
-
 function writeResponse(response) {
-    process.stdout.write(
-        `[PINT_PRETTIER_WORKER_START]${JSON.stringify(response)}[PINT_PRETTIER_WORKER_END]`,
-    );
+    process.stdout.write(`[PINT_PRETTIER_WORKER]${JSON.stringify(response)}\n`);
 }

--- a/tests/Feature/Blade/IgnoreRangesTest.php
+++ b/tests/Feature/Blade/IgnoreRangesTest.php
@@ -1,11 +1,35 @@
 <?php
 
 use App\BladeFormatter;
+use App\Contracts\PrettierPostFormatter;
+use App\Contracts\PrettierPreFormatter;
+use App\Exceptions\PrettierException;
+use App\Support\Prettier;
+
+class CorruptingIgnoreRangeFormatter implements PrettierPostFormatter, PrettierPreFormatter
+{
+    public function preFormat(string $content): string
+    {
+        return $content.'INTERMEDIATE';
+    }
+
+    public function postFormat(string $content): string
+    {
+        return str_replace('__PINT_BLADE_IGNORE_0__', '', $content);
+    }
+}
+
+class BladeFormatterWithCorruptingIgnoreRangeFormatter extends BladeFormatter
+{
+    protected static array $formatters = [
+        CorruptingIgnoreRangeFormatter::class,
+    ];
+}
 
 bladeFixtureTest('ignore-ranges');
 
 it('preserves all supported ignore marker variants case-insensitively', function () {
-    $input = "{{-- format-ignore-start --}}\n"
+    $in = "{{-- format-ignore-start --}}\n"
         ."@php    \$format = !\$hidden; @endphp\n"
         ."{{-- format-ignore-end --}}\n"
         ."{{-- PRETTIER-IGNORE-START --}}\n"
@@ -18,32 +42,46 @@ it('preserves all supported ignore marker variants case-insensitively', function
         ."<div  id=\"html-prettier\"></div>\n"
         ."<!-- prettier-ignore-end -->\n"
         ."<div  id=\"after\"></div>\n";
-    $expected = str_replace('<div  id="after"></div>', '<div id="after"></div>', $input);
+    $out = "{{-- format-ignore-start --}}\n"
+        ."@php    \$format = !\$hidden; @endphp\n"
+        ."{{-- format-ignore-end --}}\n"
+        ."{{-- PRETTIER-IGNORE-START --}}\n"
+        ."<div  id=\"blade-prettier\"></div>\n"
+        ."{{-- PRETTIER-IGNORE-END --}}\n"
+        ."<!-- FORMAT-IGNORE-START -->\n"
+        ."<div  id=\"html-format\"></div>\n"
+        ."<!-- FORMAT-IGNORE-END -->\n"
+        ."<!-- prettier-ignore-start -->\n"
+        ."<div  id=\"html-prettier\"></div>\n"
+        ."<!-- prettier-ignore-end -->\n"
+        ."<div id=\"after\"></div>\n";
 
-    expect(app(BladeFormatter::class)->format('markers.blade.php', $input))->toBe($expected);
+    expect(app(BladeFormatter::class)->format('markers.blade.php', $in))->toBe($out);
 });
 
 it('preserves byte-sensitive ignored content while formatting its surroundings', function () {
-    $input = "\u{FEFF}<p>𠮷</p>\r\n"
+    $in = "\u{FEFF}<p>𠮷</p>\r\n"
         ."<div  id=\"before\"></div>\n"
         ."{{-- format-ignore-start --}}\r\n"
         ."𠮷 __PINT_BLADE_IGNORE_0__  \r\n"
+        ."{\"formatted\":\"x\"} [PINT_PRETTIER_WORKER]\r\n"
         ."@php    \$x = !\$y; @endphp\n"
         ."{{-- format-ignore-end --}}\r\n"
         ."<div  id=\"after\"></div>\r\n";
-    $expected = "\u{FEFF}<p>𠮷</p>\n"
+    $out = "\u{FEFF}<p>𠮷</p>\n"
         ."<div id=\"before\"></div>\n"
         ."{{-- format-ignore-start --}}\r\n"
         ."𠮷 __PINT_BLADE_IGNORE_0__  \r\n"
+        ."{\"formatted\":\"x\"} [PINT_PRETTIER_WORKER]\r\n"
         ."@php    \$x = !\$y; @endphp\n"
         ."{{-- format-ignore-end --}}\n"
         ."<div id=\"after\"></div>\n";
 
-    expect(app(BladeFormatter::class)->format('bytes.blade.php', $input))->toBe($expected);
+    expect(app(BladeFormatter::class)->format('bytes.blade.php', $in))->toBe($out);
 });
 
-it('safely handles malformed and non-marker occurrences', function (string $input, string $expected) {
-    expect(app(BladeFormatter::class)->format('malformed.blade.php', $input))->toBe($expected);
+it('safely handles malformed and non-marker occurrences', function (string $in, string $out) {
+    expect(app(BladeFormatter::class)->format('malformed.blade.php', $in))->toBe($out);
 })->with([
     'stray end marker' => [
         "{{-- format-ignore-end --}}\n<div  id=\"formatted\"></div>\n",
@@ -58,3 +96,29 @@ it('safely handles malformed and non-marker occurrences', function (string $inpu
         "<div title=\"{{-- format-ignore-start --}}\">content</div>\n<div id=\"after\">{{ \$value }}</div>\n",
     ],
 ]);
+
+it('rejects invalid ignore ranges returned by the worker', function () {
+    $prettier = Mockery::mock(Prettier::class);
+    $prettier->shouldReceive('ignoreRanges')->once()->andReturn([
+        ['start' => 0, 'end' => 100],
+    ]);
+
+    (new BladeFormatter($prettier))->format('invalid.blade.php', '<div></div>');
+})->throws(PrettierException::class, 'Laravel Pint\'s Prettier worker returned invalid Blade ignore ranges.');
+
+it('returns pristine input if an ignore range placeholder is corrupted', function () {
+    $in = "{{-- format-ignore-start --}}\nraw\n{{-- format-ignore-end --}}\n";
+    $end = strlen($in);
+    $prettier = Mockery::mock(Prettier::class);
+    $prettier->shouldReceive('ignoreRanges')->once()->andReturn([
+        ['start' => 0, 'end' => $end],
+    ]);
+    $prettier->shouldReceive('formatWithIgnoreRanges')->once()->andReturn([
+        'formatted' => $in.'INTERMEDIATE',
+        'ranges' => [
+            ['start' => 0, 'end' => $end, 'sourceStart' => 0, 'sourceEnd' => $end],
+        ],
+    ]);
+
+    expect((new BladeFormatterWithCorruptingIgnoreRangeFormatter($prettier))->format('fallback.blade.php', $in))->toBe($in);
+});

--- a/tests/Feature/Blade/IgnoreRangesTest.php
+++ b/tests/Feature/Blade/IgnoreRangesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\BladeFormatter;
+
+bladeFixtureTest('ignore-ranges');
+
+it('preserves all supported ignore marker variants case-insensitively', function () {
+    $input = "{{-- format-ignore-start --}}\n"
+        ."@php    \$format = !\$hidden; @endphp\n"
+        ."{{-- format-ignore-end --}}\n"
+        ."{{-- PRETTIER-IGNORE-START --}}\n"
+        ."<div  id=\"blade-prettier\"></div>\n"
+        ."{{-- PRETTIER-IGNORE-END --}}\n"
+        ."<!-- FORMAT-IGNORE-START -->\n"
+        ."<div  id=\"html-format\"></div>\n"
+        ."<!-- FORMAT-IGNORE-END -->\n"
+        ."<!-- prettier-ignore-start -->\n"
+        ."<div  id=\"html-prettier\"></div>\n"
+        ."<!-- prettier-ignore-end -->\n"
+        ."<div  id=\"after\"></div>\n";
+    $expected = str_replace('<div  id="after"></div>', '<div id="after"></div>', $input);
+
+    expect(app(BladeFormatter::class)->format('markers.blade.php', $input))->toBe($expected);
+});
+
+it('preserves byte-sensitive ignored content while formatting its surroundings', function () {
+    $input = "\u{FEFF}<p>𠮷</p>\r\n"
+        ."<div  id=\"before\"></div>\n"
+        ."{{-- format-ignore-start --}}\r\n"
+        ."𠮷 __PINT_BLADE_IGNORE_0__  \r\n"
+        ."@php    \$x = !\$y; @endphp\n"
+        ."{{-- format-ignore-end --}}\r\n"
+        ."<div  id=\"after\"></div>\r\n";
+    $expected = "\u{FEFF}<p>𠮷</p>\n"
+        ."<div id=\"before\"></div>\n"
+        ."{{-- format-ignore-start --}}\r\n"
+        ."𠮷 __PINT_BLADE_IGNORE_0__  \r\n"
+        ."@php    \$x = !\$y; @endphp\n"
+        ."{{-- format-ignore-end --}}\n"
+        ."<div id=\"after\"></div>\n";
+
+    expect(app(BladeFormatter::class)->format('bytes.blade.php', $input))->toBe($expected);
+});
+
+it('safely handles malformed and non-marker occurrences', function (string $input, string $expected) {
+    expect(app(BladeFormatter::class)->format('malformed.blade.php', $input))->toBe($expected);
+})->with([
+    'stray end marker' => [
+        "{{-- format-ignore-end --}}\n<div  id=\"formatted\"></div>\n",
+        "{{-- format-ignore-end --}}\n<div id=\"formatted\"></div>\n",
+    ],
+    'unclosed range' => [
+        "<div  id=\"before\"></div>\n{{-- format-ignore-start --}}\n@php    \$visible = !\$hidden; @endphp\n<div  id=\"preserved\"></div>\n",
+        "<div id=\"before\"></div>\n{{-- format-ignore-start --}}\n@php    \$visible = !\$hidden; @endphp\n<div  id=\"preserved\"></div>\n",
+    ],
+    'start marker in a quoted attribute' => [
+        "<div title=\"{{-- format-ignore-start --}}\">content</div>\n<div  id=\"after\">{{  \$value  }}</div>\n",
+        "<div title=\"{{-- format-ignore-start --}}\">content</div>\n<div id=\"after\">{{ \$value }}</div>\n",
+    ],
+]);

--- a/tests/Feature/Blade/IgnoreRangesTest.php
+++ b/tests/Feature/Blade/IgnoreRangesTest.php
@@ -1,30 +1,8 @@
 <?php
 
 use App\BladeFormatter;
-use App\Contracts\PrettierPostFormatter;
-use App\Contracts\PrettierPreFormatter;
-use App\Exceptions\PrettierException;
+use App\PrettierFormatters\EmbeddedBladeMasker;
 use App\Support\Prettier;
-
-class CorruptingIgnoreRangeFormatter implements PrettierPostFormatter, PrettierPreFormatter
-{
-    public function preFormat(string $content): string
-    {
-        return $content.'INTERMEDIATE';
-    }
-
-    public function postFormat(string $content): string
-    {
-        return str_replace('__PINT_BLADE_IGNORE_0__', '', $content);
-    }
-}
-
-class BladeFormatterWithCorruptingIgnoreRangeFormatter extends BladeFormatter
-{
-    protected static array $formatters = [
-        CorruptingIgnoreRangeFormatter::class,
-    ];
-}
 
 bladeFixtureTest('ignore-ranges');
 
@@ -97,31 +75,35 @@ it('safely handles malformed and non-marker occurrences', function (string $in, 
     ],
 ]);
 
-it('rejects invalid ignore ranges returned by the worker', function () {
-    $prettier = Mockery::mock(Prettier::class);
-    $prettier->shouldReceive('ignoreRanges')->once()->andReturn([
-        ['start' => 0, 'end' => 100],
-    ]);
+it('formats surrounding content when an ignore range is nested in an embedded directive block', function (string $element, string $ignored) {
+    $formatter = new class(app(Prettier::class)) extends BladeFormatter
+    {
+        protected static array $formatters = [
+            EmbeddedBladeMasker::class,
+        ];
+    };
+    $ignoreRange = "{{-- format-ignore-start --}}\n"
+        .$ignored."\n"
+        .'{{-- format-ignore-end --}}';
+    $visibleIgnoreRange = "{{-- prettier-ignore-start --}}\n"
+        ."<section  id=\"visible\"></section>\n"
+        .'{{-- prettier-ignore-end --}}';
+    $in = "<{$element}>\n"
+        ."@if(\$ready)\n"
+        .$ignoreRange."\n"
+        ."@endif\n"
+        ."</{$element}>\n"
+        ."<div  id=\"after\"></div>\n"
+        .$visibleIgnoreRange."\n";
 
-    (new BladeFormatter($prettier))->format('invalid.blade.php', '<div></div>');
-})->throws(PrettierException::class, 'Laravel Pint\'s Prettier worker returned invalid Blade ignore ranges.');
+    $formatted = $formatter->format('nested.blade.php', $in);
 
-it('returns pristine input if an ignore range placeholder is corrupted', function () {
-    $in = "{{-- format-ignore-start --}}\nraw\n{{-- format-ignore-end --}}\n";
-    $end = strlen($in);
-    $prettier = Mockery::mock(Prettier::class);
-    $prettier->shouldReceive('ignoreRanges')->once()->andReturn([
-        ['start' => 0, 'end' => $end, 'sourceStart' => 0, 'sourceEnd' => $end],
-    ]);
-    $prettier->shouldReceive('formatWithIgnoreRanges')
-        ->once()
-        ->with('fallback.blade.php', $in.'INTERMEDIATE')
-        ->andReturn([
-            'formatted' => $in.'INTERMEDIATE',
-            'ranges' => [
-                ['start' => 0, 'end' => $end, 'sourceStart' => 0, 'sourceEnd' => $end],
-            ],
-        ]);
-
-    expect((new BladeFormatterWithCorruptingIgnoreRangeFormatter($prettier))->format('fallback.blade.php', $in))->toBe($in);
-});
+    expect($formatted)->toContain($ignoreRange)
+        ->toContain($visibleIgnoreRange)
+        ->toContain('<div id="after"></div>');
+    expect($formatter->format('nested.blade.php', $formatted))->toBe($formatted);
+})->with([
+    'script' => ['script', 'const  keep = [1,  2];'],
+    'script with token-like content' => ['script', 'const  keep = "__PINT_BLADE_IGNORE_2__";'],
+    'style' => ['style', '.keep  { color:  red; }'],
+]);

--- a/tests/Feature/Blade/IgnoreRangesTest.php
+++ b/tests/Feature/Blade/IgnoreRangesTest.php
@@ -1,11 +1,35 @@
 <?php
 
 use App\BladeFormatter;
+use App\Contracts\PrettierPostFormatter;
+use App\Contracts\PrettierPreFormatter;
+use App\Exceptions\PrettierException;
+use App\Support\Prettier;
+
+class CorruptingIgnoreRangeFormatter implements PrettierPostFormatter, PrettierPreFormatter
+{
+    public function preFormat(string $content): string
+    {
+        return $content.'INTERMEDIATE';
+    }
+
+    public function postFormat(string $content): string
+    {
+        return str_replace('__PINT_BLADE_IGNORE_0__', '', $content);
+    }
+}
+
+class BladeFormatterWithCorruptingIgnoreRangeFormatter extends BladeFormatter
+{
+    protected static array $formatters = [
+        CorruptingIgnoreRangeFormatter::class,
+    ];
+}
 
 bladeFixtureTest('ignore-ranges');
 
 it('preserves all supported ignore marker variants case-insensitively', function () {
-    $input = "{{-- format-ignore-start --}}\n"
+    $in = "{{-- format-ignore-start --}}\n"
         ."@php    \$format = !\$hidden; @endphp\n"
         ."{{-- format-ignore-end --}}\n"
         ."{{-- PRETTIER-IGNORE-START --}}\n"
@@ -18,32 +42,46 @@ it('preserves all supported ignore marker variants case-insensitively', function
         ."<div  id=\"html-prettier\"></div>\n"
         ."<!-- prettier-ignore-end -->\n"
         ."<div  id=\"after\"></div>\n";
-    $expected = str_replace('<div  id="after"></div>', '<div id="after"></div>', $input);
+    $out = "{{-- format-ignore-start --}}\n"
+        ."@php    \$format = !\$hidden; @endphp\n"
+        ."{{-- format-ignore-end --}}\n"
+        ."{{-- PRETTIER-IGNORE-START --}}\n"
+        ."<div  id=\"blade-prettier\"></div>\n"
+        ."{{-- PRETTIER-IGNORE-END --}}\n"
+        ."<!-- FORMAT-IGNORE-START -->\n"
+        ."<div  id=\"html-format\"></div>\n"
+        ."<!-- FORMAT-IGNORE-END -->\n"
+        ."<!-- prettier-ignore-start -->\n"
+        ."<div  id=\"html-prettier\"></div>\n"
+        ."<!-- prettier-ignore-end -->\n"
+        ."<div id=\"after\"></div>\n";
 
-    expect(app(BladeFormatter::class)->format('markers.blade.php', $input))->toBe($expected);
+    expect(app(BladeFormatter::class)->format('markers.blade.php', $in))->toBe($out);
 });
 
 it('preserves byte-sensitive ignored content while formatting its surroundings', function () {
-    $input = "\u{FEFF}<p>𠮷</p>\r\n"
+    $in = "\u{FEFF}<p>𠮷</p>\r\n"
         ."<div  id=\"before\"></div>\n"
         ."{{-- format-ignore-start --}}\r\n"
         ."𠮷 __PINT_BLADE_IGNORE_0__  \r\n"
+        ."{\"formatted\":\"x\"} [PINT_PRETTIER_WORKER]\r\n"
         ."@php    \$x = !\$y; @endphp\n"
         ."{{-- format-ignore-end --}}\r\n"
         ."<div  id=\"after\"></div>\r\n";
-    $expected = "\u{FEFF}<p>𠮷</p>\n"
+    $out = "\u{FEFF}<p>𠮷</p>\n"
         ."<div id=\"before\"></div>\n"
         ."{{-- format-ignore-start --}}\r\n"
         ."𠮷 __PINT_BLADE_IGNORE_0__  \r\n"
+        ."{\"formatted\":\"x\"} [PINT_PRETTIER_WORKER]\r\n"
         ."@php    \$x = !\$y; @endphp\n"
         ."{{-- format-ignore-end --}}\n"
         ."<div id=\"after\"></div>\n";
 
-    expect(app(BladeFormatter::class)->format('bytes.blade.php', $input))->toBe($expected);
+    expect(app(BladeFormatter::class)->format('bytes.blade.php', $in))->toBe($out);
 });
 
-it('safely handles malformed and non-marker occurrences', function (string $input, string $expected) {
-    expect(app(BladeFormatter::class)->format('malformed.blade.php', $input))->toBe($expected);
+it('safely handles malformed and non-marker occurrences', function (string $in, string $out) {
+    expect(app(BladeFormatter::class)->format('malformed.blade.php', $in))->toBe($out);
 })->with([
     'stray end marker' => [
         "{{-- format-ignore-end --}}\n<div  id=\"formatted\"></div>\n",
@@ -58,3 +96,32 @@ it('safely handles malformed and non-marker occurrences', function (string $inpu
         "<div title=\"{{-- format-ignore-start --}}\">content</div>\n<div id=\"after\">{{ \$value }}</div>\n",
     ],
 ]);
+
+it('rejects invalid ignore ranges returned by the worker', function () {
+    $prettier = Mockery::mock(Prettier::class);
+    $prettier->shouldReceive('ignoreRanges')->once()->andReturn([
+        ['start' => 0, 'end' => 100],
+    ]);
+
+    (new BladeFormatter($prettier))->format('invalid.blade.php', '<div></div>');
+})->throws(PrettierException::class, 'Laravel Pint\'s Prettier worker returned invalid Blade ignore ranges.');
+
+it('returns pristine input if an ignore range placeholder is corrupted', function () {
+    $in = "{{-- format-ignore-start --}}\nraw\n{{-- format-ignore-end --}}\n";
+    $end = strlen($in);
+    $prettier = Mockery::mock(Prettier::class);
+    $prettier->shouldReceive('ignoreRanges')->once()->andReturn([
+        ['start' => 0, 'end' => $end, 'sourceStart' => 0, 'sourceEnd' => $end],
+    ]);
+    $prettier->shouldReceive('formatWithIgnoreRanges')
+        ->once()
+        ->with('fallback.blade.php', $in.'INTERMEDIATE')
+        ->andReturn([
+            'formatted' => $in.'INTERMEDIATE',
+            'ranges' => [
+                ['start' => 0, 'end' => $end, 'sourceStart' => 0, 'sourceEnd' => $end],
+            ],
+        ]);
+
+    expect((new BladeFormatterWithCorruptingIgnoreRangeFormatter($prettier))->format('fallback.blade.php', $in))->toBe($in);
+});

--- a/tests/Fixtures/blade-formatting/ignore-ranges/integration.blade.php
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/integration.blade.php
@@ -1,0 +1,17 @@
+{{-- format-ignore-start --}}
+@foreach($messageData as $ecrewMessage)
+Dear {{$ecrewMessage->name}}
+@endforeach
+{{-- format-ignore-end --}}
+<script>
+    {{-- prettier-ignore-start --}}
+    const  matrix = [
+        1,  2,  3,
+    ];
+    {{-- prettier-ignore-end --}}
+</script>
+<div x-show="!visible" {{-- format-ignore-start --}} id = "preserved">
+    @php    $value = !$hidden; @endphp
+</div>
+{{-- format-ignore-end --}}
+<div  id="after"></div>

--- a/tests/Fixtures/blade-formatting/ignore-ranges/integration.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/ignore-ranges/integration.blade.php.expected
@@ -1,0 +1,17 @@
+{{-- format-ignore-start --}}
+@foreach($messageData as $ecrewMessage)
+Dear {{$ecrewMessage->name}}
+@endforeach
+{{-- format-ignore-end --}}
+<script>
+    {{-- prettier-ignore-start --}}
+    const  matrix = [
+        1,  2,  3,
+    ];
+    {{-- prettier-ignore-end --}}
+</script>
+<div x-show="!visible" {{-- format-ignore-start --}} id = "preserved">
+    @php    $value = !$hidden; @endphp
+</div>
+{{-- format-ignore-end --}}
+<div id="after"></div>

--- a/tests/Fixtures/prettier-worker.cjs
+++ b/tests/Fixtures/prettier-worker.cjs
@@ -1,0 +1,16 @@
+const readline = require("node:readline");
+
+const lines = readline.createInterface({
+    input: process.stdin,
+});
+
+lines.on("line", (line) => {
+    const { content } = JSON.parse(line);
+
+    process.stdout.write("unrelated stdout");
+    process.stdout.write(
+        "[PINT_PRETTIER_WORKER]" +
+            JSON.stringify({ formatted: content }) +
+            "\n",
+    );
+});

--- a/tests/Unit/BladeFormatterTest.php
+++ b/tests/Unit/BladeFormatterTest.php
@@ -1,7 +1,30 @@
 <?php
 
 use App\BladeFormatter;
+use App\Contracts\PrettierPostFormatter;
+use App\Contracts\PrettierPreFormatter;
+use App\Exceptions\PrettierException;
 use App\Support\Prettier;
+
+class CorruptingIgnoreRangeFormatter implements PrettierPostFormatter, PrettierPreFormatter
+{
+    public function preFormat(string $content): string
+    {
+        return $content.'INTERMEDIATE';
+    }
+
+    public function postFormat(string $content): string
+    {
+        return (string) preg_replace('/__PINT_BLADE_IGNORE_\d+__/', '', $content);
+    }
+}
+
+class BladeFormatterWithCorruptingIgnoreRangeFormatter extends BladeFormatter
+{
+    protected static array $formatters = [
+        CorruptingIgnoreRangeFormatter::class,
+    ];
+}
 
 /**
  * A prettier double whose "format" is the given callback, so a formatter pipeline can be
@@ -75,4 +98,33 @@ it('hands back the untouched file when an embedded Blade placeholder cannot be r
     expect($out)->toBe($in);
     expect($out)->not->toContain('pm0');
     expect($out)->not->toContain('gone');
+});
+
+it('rejects invalid ignore ranges returned by the worker', function () {
+    $prettier = Mockery::mock(Prettier::class);
+    $prettier->shouldReceive('ignoreRanges')->once()->andReturn([
+        ['start' => 0, 'end' => 100],
+    ]);
+
+    (new BladeFormatter($prettier))->format('invalid.blade.php', '<div></div>');
+})->throws(PrettierException::class, 'Laravel Pint\'s Prettier worker returned invalid Blade ignore ranges.');
+
+it('returns pristine input if an ignore range placeholder is corrupted', function () {
+    $in = "{{-- format-ignore-start --}}\nraw\n{{-- format-ignore-end --}}\n";
+    $end = strlen($in);
+    $prettier = Mockery::mock(Prettier::class);
+    $prettier->shouldReceive('ignoreRanges')->once()->andReturn([
+        ['start' => 0, 'end' => $end, 'sourceStart' => 0, 'sourceEnd' => $end],
+    ]);
+    $prettier->shouldReceive('formatWithIgnoreRanges')
+        ->once()
+        ->with('fallback.blade.php', $in.'INTERMEDIATE')
+        ->andReturn([
+            'formatted' => $in.'INTERMEDIATE',
+            'ranges' => [
+                ['start' => 0, 'end' => $end, 'sourceStart' => 0, 'sourceEnd' => $end],
+            ],
+        ]);
+
+    expect((new BladeFormatterWithCorruptingIgnoreRangeFormatter($prettier))->format('fallback.blade.php', $in))->toBe($in);
 });

--- a/tests/Unit/Support/PrettierTest.php
+++ b/tests/Unit/Support/PrettierTest.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\Support\Prettier;
+
+it('does not start the worker for content without ignore range markers', function () {
+    $prettier = new Prettier('/missing-project');
+
+    expect($prettier->ignoreRanges('view.blade.php', '<div>Content</div>'))->toBe([]);
+});

--- a/tests/Unit/Support/PrettierTest.php
+++ b/tests/Unit/Support/PrettierTest.php
@@ -39,3 +39,9 @@ it('resolves the runtime from the project root it was given', function () {
     expect((new Prettier($this->root))->runtimeBinary())->toBe('bun')
         ->and((new Prettier(sys_get_temp_dir()))->runtimeBinary())->toBe('node');
 });
+
+it('does not start the worker for content without ignore range markers', function () {
+    $prettier = new Prettier('/missing-project');
+
+    expect($prettier->ignoreRanges('view.blade.php', '<div>Content</div>'))->toBe([]);
+});

--- a/tests/Unit/Support/PrettierTest.php
+++ b/tests/Unit/Support/PrettierTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Exceptions\PrettierException;
 use App\Support\Prettier;
 use Tests\TestCase;
 
@@ -40,8 +41,52 @@ it('resolves the runtime from the project root it was given', function () {
         ->and((new Prettier(sys_get_temp_dir()))->runtimeBinary())->toBe('node');
 });
 
+function prettierWithFakeWorker(): Prettier
+{
+    return new class(dirname(__DIR__, 3)) extends Prettier
+    {
+        public function workerPath(): string
+        {
+            return dirname(__DIR__, 2).'/Fixtures/prettier-worker.cjs';
+        }
+
+        public function configPath(): string
+        {
+            return __FILE__;
+        }
+    };
+}
+
 it('does not start the worker for content without ignore range markers', function () {
     $prettier = new Prettier('/missing-project');
 
     expect($prettier->ignoreRanges('view.blade.php', '<div>Content</div>'))->toBe([]);
+});
+
+it('rejects invalid UTF-8 before calculating ignore range offsets', function () {
+    $prettier = new Prettier('/missing-project');
+    $content = "<div>\xFF</div>\n{{-- format-ignore-start --}}\nraw\n{{-- format-ignore-end --}}\n";
+
+    $prettier->ignoreRanges('view.blade.php', $content);
+})->throws(PrettierException::class, 'Laravel Pint cannot preserve Blade formatter ignore ranges in files containing invalid UTF-8.');
+
+it('reads a worker response after stdout noise without a trailing newline', function () {
+    $prettier = prettierWithFakeWorker();
+
+    try {
+        expect($prettier->format('view.blade.php', '<div>Content</div>'))->toBe('<div>Content</div>');
+    } finally {
+        $prettier->ensureTerminated();
+    }
+});
+
+it('preserves response-prefix text in formatted content', function () {
+    $prettier = prettierWithFakeWorker();
+    $content = "[PINT_PRETTIER_WORKER]\n";
+
+    try {
+        expect($prettier->format('view.blade.php', $content))->toBe($content);
+    } finally {
+        $prettier->ensureTerminated();
+    }
 });


### PR DESCRIPTION
This preserves content wrapped in Blade formatter ignore markers. For example:

```blade
{{-- format-ignore-start --}}
@php
    $message = <<<'TEXT'
Order received

    Item: Coffee beans
Quantity: 2

Thank you!
TEXT;
@endphp
{{-- format-ignore-end --}}
```

That is useful when a Blade view produces whitespace-sensitive plain text, where re-indenting the template would also change the rendered message. Content outside the markers continues to be formatted normally.

Both `format-ignore-start` / `format-ignore-end` and Prettier's `prettier-ignore-start` / `prettier-ignore-end` variants are supported in Blade and HTML comments.

Pint asks the Blade plugin for the ignore ranges, protects those ranges while its own pre- and post-formatters run, and then restores the original bytes.

## Dependency

The public ignore-range API was introduced in `prettier-plugin-blade` 3.3.0 through fortephp/chisel#184. Pint now requires 3.3.3, so the API is already available through Pint's current dependencies and this PR no longer needs to change them.

## Testing

- Blade formatter and Prettier support tests: 415 passed (491 assertions)
- PHPStan
- Pint and JavaScript formatting checks
- Node and Bun worker protocol checks
- JavaScript syntax and `git diff --check`
