### PR TITLE
Preserve Alpine x-mask attribute values

### DIFF
--- a/app/BladeFormatter.php
+++ b/app/BladeFormatter.php
@@ -11,6 +11,7 @@ use App\PrettierFormatters\DirectiveTrailingCommas;
 use App\PrettierFormatters\EmbeddedBladeMasker;
 use App\PrettierFormatters\JoinDanglingCloseBracket;
 use App\PrettierFormatters\JoinDanglingOpenBracket;
+use App\PrettierFormatters\MaskAttributeValues;
 use App\PrettierFormatters\NotOperatorSpacing;
 use App\PrettierFormatters\PhpBlockFormatting;
 use App\PrettierFormatters\StripSensitiveLeadingBlankLines;
@@ -53,6 +54,9 @@ class BladeFormatter
 
         // Runs Pint over the PHP in @php blocks, <?php islands, directives, and echoes.
         PhpBlockFormatting::class,
+
+        // Keeps an Alpine "x-mask" literal byte-stable, since prettier formats it as a JS expression.
+        MaskAttributeValues::class,
     ];
 
     /**

--- a/app/PrettierFormatters/MaskAttributeValues.php
+++ b/app/PrettierFormatters/MaskAttributeValues.php
@@ -39,11 +39,21 @@ class MaskAttributeValues implements PrettierPostFormatter, PrettierPreFormatter
         return (string) preg_replace_callback(
             '/(?<![-\w:])x-mask\s*=\s*(["\'])(.+?)\1/i',
             function (array $matches): string {
-                $token = $this->mask($matches[2]);
+                [$whole, $wholeOffset] = $matches[0];
+                [$value, $valueOffset] = $matches[2];
 
-                return str_replace($matches[2], $token, $matches[0]);
+                $token = $this->mask($value);
+
+                // Splice the token in at the value's exact position within the match, so a value
+                // that also appears inside the attribute name (e.g. "a" in "x-mask") is left alone.
+                $position = $valueOffset - $wholeOffset;
+
+                return substr($whole, 0, $position)
+                    .$token
+                    .substr($whole, $position + strlen($value));
             },
             $content,
+            flags: PREG_OFFSET_CAPTURE,
         );
     }
 

--- a/app/PrettierFormatters/MaskAttributeValues.php
+++ b/app/PrettierFormatters/MaskAttributeValues.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\PrettierFormatters;
+
+use App\Contracts\PrettierPostFormatter;
+use App\Contracts\PrettierPreFormatter;
+
+class MaskAttributeValues implements PrettierPostFormatter, PrettierPreFormatter
+{
+    /**
+     * The placeholder to original-value map.
+     *
+     * @var array<string, string>
+     */
+    private array $map = [];
+
+    /**
+     * The content as it entered preFormat().
+     */
+    private string $original = '';
+
+    /**
+     * The index used to build unique placeholder tokens.
+     */
+    private int $counter = 0;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function preFormat(string $content): string
+    {
+        $this->map = [];
+        $this->original = $content;
+        $this->counter = 0;
+
+        // Alpine reads "x-mask" as a literal template, but prettier formats it as a JS
+        // expression and spaces out the hyphen in patterns like "9999-999". "x-mask:dynamic"
+        // holds a real expression and is left alone.
+        return (string) preg_replace_callback(
+            '/(?<![-\w:])x-mask\s*=\s*(["\'])(.+?)\1/i',
+            function (array $matches): string {
+                $token = $this->mask($matches[2]);
+
+                return str_replace($matches[2], $token, $matches[0]);
+            },
+            $content,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function postFormat(string $content): string
+    {
+        if ($this->map === []) {
+            return $content;
+        }
+
+        // Every token must appear exactly once; otherwise fall back to the original to avoid corrupting the file.
+        foreach (array_keys($this->map) as $token) {
+            if (substr_count($content, $token) !== 1) {
+                return $this->original;
+            }
+        }
+
+        return str_replace(array_keys($this->map), array_values($this->map), $content);
+    }
+
+    /**
+     * Record the value under a fresh placeholder token and return that token.
+     */
+    private function mask(string $value): string
+    {
+        $token = $this->makeToken();
+
+        $this->map[$token] = $value;
+
+        return $token;
+    }
+
+    /**
+     * Build a unique placeholder token that prettier leaves untouched.
+     */
+    private function makeToken(): string
+    {
+        while (true) {
+            $token = "__PINT_MASK_{$this->counter}__";
+            $this->counter++;
+
+            if (! str_contains($this->original, $token)) {
+                return $token;
+            }
+        }
+    }
+}

--- a/tests/Fixtures/blade-formatting/alpine/mask-short-value.blade.php
+++ b/tests/Fixtures/blade-formatting/alpine/mask-short-value.blade.php
@@ -1,0 +1,4 @@
+<div>
+        <input x-mask="a" />
+                <span>badly indented</span>
+</div>

--- a/tests/Fixtures/blade-formatting/alpine/mask-short-value.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/alpine/mask-short-value.blade.php.expected
@@ -1,0 +1,4 @@
+<div>
+    <input x-mask="a" />
+    <span>badly indented</span>
+</div>

--- a/tests/Fixtures/blade-formatting/alpine/mask.blade.php
+++ b/tests/Fixtures/blade-formatting/alpine/mask.blade.php
@@ -1,0 +1,5 @@
+<div>
+    <input x-mask="9999-999" placeholder="1234-567" />
+        <input x-mask="(999) 999-9999" />
+   <input x-mask:dynamic="$money($input, '.')" />
+</div>

--- a/tests/Fixtures/blade-formatting/alpine/mask.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/alpine/mask.blade.php.expected
@@ -1,0 +1,5 @@
+<div>
+    <input x-mask="9999-999" placeholder="1234-567" />
+    <input x-mask="(999) 999-9999" />
+    <input x-mask:dynamic="$money($input, '.')" />
+</div>


### PR DESCRIPTION
When the Blade formatter is enabled, prettier treats an Alpine `x-mask` value as a JS expression, so a mask like `9999-999` gets read as a subtraction and rewritten to `9999 - 999`. That breaks the mask. Alpine reads the value as a literal template, so this keeps the `x-mask` value intact across formatting and leaves `x-mask:dynamic`, which really is an expression, alone.

Fixes #466
