### PR TITLE
Prevent trailing comma on conditional attribute directives

### DIFF
--- a/app/PrettierFormatters/DirectiveTrailingCommas.php
+++ b/app/PrettierFormatters/DirectiveTrailingCommas.php
@@ -13,6 +13,7 @@ class DirectiveTrailingCommas implements PrettierPostFormatter
      */
     private const CONTROL_DIRECTIVES = [
         'if', 'elseif', 'unless', 'while', 'for', 'foreach', 'forelse', 'switch', 'case',
+        'checked', 'selected', 'disabled', 'readonly', 'required',
     ];
 
     /**

--- a/tests/Unit/PrettierFormatters/DirectiveTrailingCommasTest.php
+++ b/tests/Unit/PrettierFormatters/DirectiveTrailingCommasTest.php
@@ -35,6 +35,12 @@ it('never adds a comma to a control-structure condition', function () {
     expect((new DirectiveTrailingCommas)->postFormat($in))->toBe($in);
 });
 
+it('never adds a comma to a conditional attribute directive', function () {
+    $in = "@checked(\n    \$active &&\n    \$enabled\n)\n";
+
+    expect((new DirectiveTrailingCommas)->postFormat($in))->toBe($in);
+});
+
 it('adds a comma to a nested array but never to its enclosing condition', function () {
     $in = "@if (in_array(\$x, [\n    'a',\n    'b'\n]))\n@endif\n";
     $out = "@if (in_array(\$x, [\n    'a',\n    'b',\n]))\n@endif\n";


### PR DESCRIPTION
Pint's Blade formatter was adding a trailing comma to multiline `@checked(...)` directives, treating them like a call. The conditional attribute directives (`@checked`, `@selected`, `@disabled`, `@readonly`, `@required`) compile to `if (...):`, so a trailing comma there is a fatal parse error, not a harmless call argument. This adds them to the list of directives whose parentheses hold a condition instead of a call, so the formatter leaves them alone.

Fixes #468