### PR TITLE
Fix cache regression when Blade formatting is disabled

### DIFF
--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -45,12 +45,15 @@ class ConfigurationFactory
      */
     public static function preset($rules)
     {
+        $rules = array_merge($rules, resolve(ConfigurationJsonRepository::class)->rules());
+
+        // PHP CS Fixer's cache signature cannot represent Prettier configuration or Node dependency versions.
         return (new Config)
             ->setParallelConfig(ParallelConfigFactory::detect())
             ->setFinder(self::finder())
-            ->setRules(array_merge($rules, resolve(ConfigurationJsonRepository::class)->rules()))
+            ->setRules($rules)
             ->setRiskyAllowed(true)
-            ->setUsingCache(false)
+            ->setUsingCache(($rules['Pint/laravel_blade'] ?? false) === false)
             ->setUnsupportedPhpVersionAllowed(true)
             ->registerCustomFixers(self::customFixers());
     }

--- a/tests/Feature/CacheTest.php
+++ b/tests/Feature/CacheTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Symfony\Component\Process\Process;
+
+it('reads and updates a configured cache file and skips unchanged files', function () {
+    $directory = sys_get_temp_dir().'/pint-cache-'.bin2hex(random_bytes(6));
+    $cache = $directory.'/cache.json';
+    $config = $directory.'/pint.json';
+    $source = $directory.'/Example.php';
+
+    mkdir($directory, 0777, true);
+
+    file_put_contents($config, json_encode([
+        'preset' => 'laravel',
+        'cache-file' => $cache,
+    ]));
+    file_put_contents($source, "<?php\n\nfunction cachedExample(): void\n{\n    // Cached.\n}\n");
+
+    $run = function () use ($config, $source): Process {
+        $process = new Process([PHP_BINARY, base_path('pint'), '--config', $config, $source], base_path());
+        $process->setTimeout(30);
+        $process->run();
+
+        expect($process->getExitCode())->toBe(0, $process->getErrorOutput().$process->getOutput());
+
+        return $process;
+    };
+
+    try {
+        $run();
+
+        expect($cache)->toBeFile();
+
+        $firstCache = file_get_contents($cache);
+        $cacheData = json_decode($firstCache, true, flags: JSON_THROW_ON_ERROR);
+
+        expect($cacheData['hashes'])->toHaveCount(1);
+
+        touch($cache, 946684800);
+        clearstatcache(true, $cache);
+
+        $run();
+
+        clearstatcache(true, $cache);
+
+        expect(filemtime($cache))->toBe(946684800)
+            ->and(file_get_contents($cache))->toBe($firstCache);
+
+        file_put_contents($source, "<?php\n\nfunction cachedExample(): void\n{\n    // Changed.\n}\n");
+
+        $run();
+
+        clearstatcache(true, $cache);
+
+        expect(filemtime($cache))->toBeGreaterThan(946684800)
+            ->and(file_get_contents($cache))->not->toBe($firstCache);
+    } finally {
+        @unlink($source);
+        @unlink($config);
+        @unlink($cache);
+        @rmdir($directory);
+    }
+});

--- a/tests/Unit/Factories/ConfigurationFactoryTest.php
+++ b/tests/Unit/Factories/ConfigurationFactoryTest.php
@@ -1,7 +1,31 @@
 <?php
 
+use App\BladeFormatter;
 use App\Factories\ConfigurationFactory;
 use App\Repositories\ConfigurationJsonRepository;
+
+it('enables caching when blade formatting is disabled', function () {
+    app()->bind(ConfigurationJsonRepository::class, fn () => new ConfigurationJsonRepository(null, null));
+    app()->bind(BladeFormatter::class, fn () => Mockery::mock(BladeFormatter::class));
+
+    expect(ConfigurationFactory::preset([])->getUsingCache())->toBeTrue();
+});
+
+it('disables caching when blade formatting is enabled', function () {
+    $configPath = tempnam(sys_get_temp_dir(), 'pint-config-');
+    file_put_contents($configPath, json_encode([
+        'rules' => ['Pint/laravel_blade' => true],
+    ]));
+
+    try {
+        app()->bind(ConfigurationJsonRepository::class, fn () => new ConfigurationJsonRepository($configPath, null));
+        app()->bind(BladeFormatter::class, fn () => Mockery::mock(BladeFormatter::class));
+
+        expect(ConfigurationFactory::preset([])->getUsingCache())->toBeFalse();
+    } finally {
+        @unlink($configPath);
+    }
+});
 
 it('returns false for non-excluded files', function () {
     app()->bind(ConfigurationJsonRepository::class, fn () => new ConfigurationJsonRepository(null, null));


### PR DESCRIPTION
- restore PHP CS Fixer caching for normal PHP formatting
- disable caching only when `Pint/laravel_blade` is enabled
- avoid stale Blade results because PHP CS Fixer's cache signature does not include Prettier configuration or Node dependency versions
- add regression coverage for configured cache files, warm-cache runs, cache updates, and Blade-enabled configurations