### PR TITLE
fix: never adds a trailing comma to include directives

### DIFF
--- a/app/PrettierFormatters/DirectiveTrailingCommas.php
+++ b/app/PrettierFormatters/DirectiveTrailingCommas.php
@@ -9,9 +9,11 @@ class DirectiveTrailingCommas implements PrettierPostFormatter
     /**
      * Directives whose top-level "(...)" is not a comma-safe call.
      *
-     * Blade splices these straight into a control structure, a language
-     * construct, or a raw statement, so a trailing comma is a parse error
-     * rather than a harmless extra argument.
+     * Blade splices most of these straight into a control structure, a
+     * language construct, or a raw statement, so a trailing comma is a parse
+     * error rather than a harmless extra argument. The include family is a
+     * call, but Blade appends its own argument after the expression, so a
+     * trailing comma there collapses the join into an empty argument.
      *
      * @var array<int, string>
      */
@@ -24,6 +26,8 @@ class DirectiveTrailingCommas implements PrettierPostFormatter
         'break', 'continue',
         // Compiled to a language construct or a raw statement...
         'isset', 'empty', 'unset', 'php', 'use',
+        // Compiled to a call with "get_defined_vars()" appended after the expression...
+        'include', 'includeif', 'includewhen', 'includeunless', 'includefirst',
     ];
 
     /**

--- a/tests/Unit/PrettierFormatters/DirectiveTrailingCommasTest.php
+++ b/tests/Unit/PrettierFormatters/DirectiveTrailingCommasTest.php
@@ -22,6 +22,13 @@ it('adds a comma to a multiline array inside a multi-argument directive', functi
     expect((new DirectiveTrailingCommas)->postFormat($in))->toBe($out);
 });
 
+it('never adds a comma to an include directive that Blade appends an argument to', function () {
+    $in = "@include(\n    'div',\n    [\n        'text' => 'Test'\n    ]\n)\n";
+    $out = "@include(\n    'div',\n    [\n        'text' => 'Test',\n    ]\n)\n";
+
+    expect((new DirectiveTrailingCommas)->postFormat($in))->toBe($out);
+});
+
 it('adds a comma to a wrapped call argument list', function () {
     $in = "@can(\n    'update',\n    \$user,\n    \$post\n)\n";
     $out = "@can(\n    'update',\n    \$user,\n    \$post,\n)\n";


### PR DESCRIPTION
`pint --blade` was adding a trailing comma after the argument list of a multiline `@include`. Blade compiles the include family by appending its own `get_defined_vars()` argument after that expression, so the extra comma becomes a double comma and the template stops parsing. Marking the include family as non-comma-safe leaves their outer argument list alone while nested arrays still get their trailing comma.

Fixes #472
