### PR TITLE
Surface abort errors when --dirty or --diff is used without Git

### DIFF
--- a/app/Actions/FixCode.php
+++ b/app/Actions/FixCode.php
@@ -47,7 +47,11 @@ class FixCode
         try {
             [$resolver, $totalFiles] = ConfigurationResolverFactory::fromIO($this->input, $this->output);
         } catch (ConsoleException $exception) {
-            return [$exception->getCode(), []];
+            if ($exception->getExitCode() !== 0) {
+                throw $exception;
+            }
+
+            return [0, []];
         }
 
         if (is_null($this->input->getOption('format')) && ! ConfigurationResolverFactory::runningInAgent()) {

--- a/tests/Feature/DiffTest.php
+++ b/tests/Feature/DiffTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Contracts\PathsRepository;
+use LaravelZero\Framework\Exceptions\ConsoleException;
 
 it('determines diff files', function () {
     $paths = Mockery::mock(PathsRepository::class);
@@ -43,6 +44,20 @@ it('ignores the path argument', function () {
         ->and($output)
         ->toContain('── Laravel', ' 1 file');
 });
+
+it('fails when git is not available', function () {
+    $paths = Mockery::mock(PathsRepository::class);
+
+    $paths
+        ->shouldReceive('diff')
+        ->with('main')
+        ->once()
+        ->andThrow(new ConsoleException(1, 'The [--diff] option is only available when using Git.'));
+
+    $this->swap(PathsRepository::class, $paths);
+
+    run('default', ['--diff' => 'main']);
+})->throws(ConsoleException::class, 'The [--diff] option is only available when using Git.');
 
 it('does not abort when there are no diff files', function () {
     $paths = Mockery::mock(PathsRepository::class);

--- a/tests/Feature/DirtyTest.php
+++ b/tests/Feature/DirtyTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Contracts\PathsRepository;
+use LaravelZero\Framework\Exceptions\ConsoleException;
 
 it('determines dirty files', function () {
     $paths = Mockery::mock(PathsRepository::class);
@@ -42,6 +43,19 @@ it('ignores the path argument', function () {
         ->and($output)
         ->toContain('── Laravel', ' 1 file');
 });
+
+it('fails when git is not available', function () {
+    $paths = Mockery::mock(PathsRepository::class);
+
+    $paths
+        ->shouldReceive('dirty')
+        ->once()
+        ->andThrow(new ConsoleException(1, 'The [--dirty] option is only available when using Git.'));
+
+    $this->swap(PathsRepository::class, $paths);
+
+    run('default', ['--dirty' => true]);
+})->throws(ConsoleException::class, 'The [--dirty] option is only available when using Git.');
 
 it('does not abort when there are no dirty files', function () {
     $paths = Mockery::mock(PathsRepository::class);


### PR DESCRIPTION
Fixes #474.

**Problem**

When `git` is unavailable (not installed, or the working directory is not a Git repository), `pint --dirty` silently reports success:

```
$ pint --dirty      # in a directory that is not a Git repository
  PASS ........... 0 files
$ echo $?
0
```

In agent mode the report is `{"tool":"pint","result":"passed"}` — CI scripts and AI agents are told the codebase passed when nothing was ever inspected. `--diff` behaves the same way.

**Cause**

`GitPathsRepository::dirty()` correctly calls `abort(1, 'The [--dirty] option is only available when using Git.')`, but the exception is swallowed by the `catch` in `FixCode::execute()`, introduced in #140 for the benign `abort(0, 'No dirty files found.')` case. The catch returns `[$exception->getCode(), []]` — and `ConsoleException` stores the abort code in its own `$exitCode` property (`getExitCode()`), while `getCode()` is always `0`. The first tuple element is the file count, so the command renders an empty `PASS` summary and exits `0`. The same catch also swallows `abort(1, 'Preset not found.')` and invalid finder-option aborts raised inside `ConfigurationResolverFactory::fromIO()`.

**Fix**

The catch now treats only `getExitCode() === 0` aborts (no dirty/changed files) as benign; any non-zero abort is rethrown, so it renders its message and fails the command — exactly like Pint's other aborts (unsupported `--format`, invalid configuration):

```
$ pint --dirty
  The [--dirty] option is only available when using Git.
$ echo $?
1
```

**Why nothing breaks**

- `--dirty` / `--diff` with no changed files still print `PASS … 0 files` and exit `0` — covered by the existing tests, which are unchanged.
- Both new regression tests fail on `main` and pass with this change; the full suite (740 tests) and PHPStan are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
