### PR TITLE
Keep multiline Blade directive arguments stable across runs

### DIFF
--- a/app/PrettierFormatters/PhpBlockFormatting.php
+++ b/app/PrettierFormatters/PhpBlockFormatting.php
@@ -145,10 +145,12 @@ class PhpBlockFormatting implements PrettierPostFormatter
             return $arg;
         }
 
+        $core = $this->unindentArg($arg, $indent);
+
         if ($keyword = self::CONTROL_DIRECTIVES[strtolower($name)] ?? null) {
-            $host = $keyword.' ('.$arg.') {}';
+            $host = $keyword.' ('.$core.') {}';
         } else {
-            $host = '__pint__('.$arg.');';
+            $host = '__pint__('.$core.');';
         }
 
         $formatted = $this->stripPhpWrapper($this->formatter->format("<?php\n".$host."\n", fragment: true));
@@ -172,6 +174,23 @@ class PhpBlockFormatting implements PrettierPostFormatter
         return Str::of($inner)
             ->explode("\n")
             ->map(fn (string $line, int $index): string => $index === 0 || $line === '' ? $line : $indent.$line)
+            ->implode("\n");
+    }
+
+    /**
+     * Strip the indentation an earlier run added to the continuation lines of an argument.
+     */
+    private function unindentArg(string $inner, string $indent): string
+    {
+        if ($indent === '') {
+            return $inner;
+        }
+
+        $width = strlen($indent);
+
+        return Str::of($inner)
+            ->explode("\n")
+            ->map(fn (string $line, int $index): string => $index === 0 || ! str_starts_with($line, $indent) ? $line : substr($line, $width))
             ->implode("\n");
     }
 

--- a/tests/Unit/PrettierFormatters/PhpBlockFormattingTest.php
+++ b/tests/Unit/PrettierFormatters/PhpBlockFormattingTest.php
@@ -81,3 +81,30 @@ it('keeps a whitespace-only empty @php block collapsed and idempotent', function
     expect($once)->toBe("<div>\n    @php @endphp\n</div>\n")
         ->and($formatter->postFormat($once))->toBe($once);
 });
+
+it('leaves a nested multiline directive argument untouched when no fixer re-indents it', function () {
+    $formatter = new PhpBlockFormatting(new class extends PhpFragmentFormatter
+    {
+        public function format(string $code, bool $fragment = false): string
+        {
+            return $code;
+        }
+    });
+
+    $in = <<<'BLADE'
+    <div>
+        <div
+            @class([
+                'button',
+                'button--active' => $isActive,
+            ])
+        ></div>
+
+        @include('partials.card', [
+            'title' => $title,
+        ])
+    </div>
+    BLADE;
+
+    expect($formatter->postFormat($in))->toBe($in);
+});


### PR DESCRIPTION
When the Blade formatter reformats a directive argument, it re-indents the continuation lines to the directive's column, but it never removes the indentation the previous run put there. With a ruleset that includes `array_indentation` this goes unnoticed, since php-cs-fixer collapses the argument back to column zero first. With a Blade-only setup (`"preset": "empty"` plus `Pint/laravel_blade`) no fixer does that, so every run pushes a nested `@class([...])` or `@include(..., [...])` another level to the right and `pint --test` never passes.

This strips the directive's own indentation from the argument before formatting it, so re-indenting afterwards puts the lines back where they were instead of stacking on top.

Fixes #476