### PR TITLE
Keep a wrapped attribute's body in place when collapsing the tag

### DIFF
--- a/app/PrettierFormatters/CollapseSingleAttribute.php
+++ b/app/PrettierFormatters/CollapseSingleAttribute.php
@@ -157,9 +157,10 @@ class CollapseSingleAttribute implements PrettierPostFormatter
         $suffix = $terminator === '/>' ? ' />' : '>';
 
         $result = [$indent.'<'.$tag.' '.rtrim($trimmedFirst)];
+        $shift = $this->blockShift($lines, $start + 1, $end, strlen($indent));
 
         for ($continuation = $start + 1; $continuation <= $end; $continuation++) {
-            $line = $this->dedent($lines[$continuation], $dedent);
+            $line = $this->dedent($lines[$continuation], $shift);
 
             if ($continuation === $end) {
                 $line = rtrim($line).$suffix;
@@ -235,6 +236,29 @@ class CollapseSingleAttribute implements PrettierPostFormatter
         }
 
         return null;
+    }
+
+    /**
+     * How far left the continuation lines must move to sit at the tag's indentation.
+     *
+     * @param  array<int, string>  $lines
+     */
+    private function blockShift(array $lines, int $start, int $end, int $indent): int
+    {
+        $shallowest = null;
+
+        for ($index = $start; $index <= $end; $index++) {
+            $line = $lines[$index];
+
+            if (trim($line) === '') {
+                continue;
+            }
+
+            $leading = strlen($line) - strlen(ltrim($line, ' '));
+            $shallowest = $shallowest === null ? $leading : min($shallowest, $leading);
+        }
+
+        return max(0, ($shallowest ?? $indent) - $indent);
     }
 
     /**

--- a/tests/Unit/PrettierFormatters/CollapseSingleAttributeTest.php
+++ b/tests/Unit/PrettierFormatters/CollapseSingleAttributeTest.php
@@ -112,6 +112,13 @@ it('preserves indentation when hugging a wrapped directive attribute', function 
     expect((new CollapseSingleAttribute)->postFormat($in))->toBe($out);
 });
 
+it('places a wrapped directive attribute by its own body instead of by the width of the wrap', function () {
+    $in = "        <div\n            @class([\n            'a' => \$x,\n        ])\n        >\n";
+    $out = "        <div @class([\n            'a' => \$x,\n        ])>\n";
+
+    expect((new CollapseSingleAttribute)->postFormat($in))->toBe($out);
+});
+
 it('hugs a wrapped self-closing directive attribute', function () {
     $in = "<input\n    @class([\n        'a' => \$x,\n    ])\n/>\n";
     $out = "<input @class([\n    'a' => \$x,\n]) />\n";


### PR DESCRIPTION
Follow-up to #477, reported in https://github.com/laravel/pint/pull/477#issuecomment-5229101337: a `<div @class([...])>` whose array body sits inside the tag still moves on every run.

Prettier wraps the attribute onto its own line but leaves the lines under it where they are. `CollapseSingleAttribute` then undoes the wrap and dedents those lines by the width of the wrap, so the body drifts four spaces left each time. Under a ruleset with no indentation fixer nothing pulls it back, and the file cycles through three shapes instead of settling on one.

The collapse now shifts the block by its own shallowest line, so a body already sitting at the tag's indentation is left alone.