### PR TITLE
Fix stdin formatting losing the name passed to --stdin-filename

### DIFF
--- a/app/Commands/DefaultCommand.php
+++ b/app/Commands/DefaultCommand.php
@@ -87,6 +87,10 @@ class DefaultCommand extends Command
      * The stdin-filename option provides file path context. If the path matches
      * exclusion rules, the original code is returned unchanged. Falls back to
      * 'stdin.php' if not provided.
+     *
+     * The temporary file keeps the name of the document it came from, so fixers
+     * that derive behavior from the file name, such as [psr_autoloading] and
+     * [Pint/laravel_blade], see the name the code will actually be saved under.
      */
     protected function fixStdinInput(FixCode $fixCode): int
     {
@@ -98,7 +102,15 @@ class DefaultCommand extends Command
             return self::SUCCESS;
         }
 
-        $tempFile = sys_get_temp_dir().DIRECTORY_SEPARATOR.'pint_stdin_'.uniqid().'.php';
+        $directory = sys_get_temp_dir().DIRECTORY_SEPARATOR.'pint_stdin_'.uniqid();
+
+        if (! @mkdir($directory, 0700, true) && ! is_dir($directory)) {
+            fwrite(STDERR, "pint: unable to create a temporary directory for {$contextPath}\n");
+
+            return self::FAILURE;
+        }
+
+        $tempFile = $directory.DIRECTORY_SEPARATOR.basename($contextPath);
 
         $this->input->setArgument('path', [$tempFile]);
         $this->input->setOption('format', 'json');
@@ -116,6 +128,10 @@ class DefaultCommand extends Command
         } finally {
             if (file_exists($tempFile)) {
                 @unlink($tempFile);
+            }
+
+            if (is_dir($directory)) {
+                @rmdir($directory);
             }
         }
     }

--- a/tests/Feature/StdinTest.php
+++ b/tests/Feature/StdinTest.php
@@ -176,3 +176,32 @@ it('respects pint.json exclusion rules', function (string $filename, bool $shoul
     'excluded notPath pattern' => ['path/to/excluded-file.php', false],
     'not excluded' => ['src/MyClass.php', true],
 ]);
+
+it('gives filename derived fixers the stdin-filename', function () {
+    $input = <<<'PHP'
+    <?php
+
+    namespace App\Models;
+
+    class Wrong
+    {
+    }
+
+    PHP;
+
+    $expected = <<<'PHP'
+    <?php
+
+    namespace App\Models;
+
+    class User {}
+
+    PHP;
+
+    $result = Process::input($input)
+        ->path(base_path('tests/Fixtures/psr-autoloading'))
+        ->run('php '.base_path('pint').' --stdin-filename=app/Models/User.php')
+        ->throw();
+
+    expect($result)->output()->toBe($expected)->errorOutput()->toBe('');
+});

--- a/tests/Fixtures/psr-autoloading/pint.json
+++ b/tests/Fixtures/psr-autoloading/pint.json
@@ -1,0 +1,6 @@
+{
+    "preset": "laravel",
+    "rules": {
+        "psr_autoloading": true
+    }
+}


### PR DESCRIPTION
fixStdinInput() buffers stdin into pint_stdin_<uniqid>.php, so every fixer that reads the file name sees the temp name instead of the one passed to --stdin-filename.

psr_autoloading renames the class to match it, so piping a buffer through Pint hands back `class pint_stdin_6a79349caf3a6` with exit code 0 — silent corruption for anything formatting an editor buffer. Pint/laravel_blade never runs at all, since applyFix() bails unless the path ends in .blade.php.

Put the uniqid on a containing directory instead and name the temp file after basename($contextPath), so both fixers see the real name.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
