### PR TITLE
feat: enable caching when blade formatting is active

### DIFF
--- a/app/Actions/EnsurePrettierIsConfigured.php
+++ b/app/Actions/EnsurePrettierIsConfigured.php
@@ -20,6 +20,11 @@ use function Laravel\Prompts\warning;
 class EnsurePrettierIsConfigured
 {
     /**
+     * @var array<string, string>
+     */
+    protected array $cacheFingerprints = [];
+
+    /**
      * Create a new ensure prettier is configured action instance.
      */
     public function __construct(
@@ -27,6 +32,14 @@ class EnsurePrettierIsConfigured
         protected ConfigurationJsonRepository $configuration,
     ) {
         //
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function cacheFingerprints(): array
+    {
+        return $this->cacheFingerprints;
     }
 
     /**
@@ -159,6 +172,21 @@ class EnsurePrettierIsConfigured
                 )->all())),
             ));
         }
+
+        $fingerprints = [];
+
+        foreach ($this->enabledPrettierFixers() as $fixer) {
+            $dependencies = $fixer->prettierDependencies();
+            ksort($dependencies);
+
+            $versions = collect(array_keys($dependencies))
+                ->map(fn (string $package): string => $package.':'.($probes[$package]['version'] ?? ''))
+                ->implode('|');
+
+            $fingerprints[$fixer->getName()] = md5($versions);
+        }
+
+        $this->cacheFingerprints = $fingerprints;
 
         return $this;
     }

--- a/app/Actions/EnsurePrettierIsConfigured.php
+++ b/app/Actions/EnsurePrettierIsConfigured.php
@@ -173,22 +173,31 @@ class EnsurePrettierIsConfigured
             ));
         }
 
-        $fingerprints = [];
-
-        foreach ($this->enabledPrettierFixers() as $fixer) {
-            $dependencies = $fixer->prettierDependencies();
-            ksort($dependencies);
-
-            $versions = collect(array_keys($dependencies))
-                ->map(fn (string $package): string => $package.':'.($probes[$package]['version'] ?? ''))
-                ->implode('|');
-
-            $fingerprints[$fixer->getName()] = md5($versions);
-        }
-
-        $this->cacheFingerprints = $fingerprints;
+        $this->cacheFingerprints = $this->enabledPrettierFixers()
+            ->mapWithKeys(fn (HasPrettierDependencies&FixerInterface $fixer): array => [
+                $fixer->getName() => $this->fingerprint($fixer, $probes),
+            ])
+            ->all();
 
         return $this;
+    }
+
+    /**
+     * Compute the cache fingerprint for the given fixer.
+     *
+     * @param  array<string, array{resolved: bool, version: string|null}>  $probes
+     */
+    public function fingerprint(HasPrettierDependencies $fixer, array $probes): string
+    {
+        $dependencies = $fixer->prettierDependencies();
+        ksort($dependencies);
+
+        $versions = collect(array_keys($dependencies))
+            ->map(fn (string $package): string => $package.':'.($probes[$package]['version'] ?? ''))
+            ->prepend('pint:'.config('app.version'))
+            ->implode('|');
+
+        return md5($versions);
     }
 
     /**

--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -2,8 +2,10 @@
 
 namespace App\Factories;
 
+use App\Actions\EnsurePrettierIsConfigured;
 use App\BladeFormatter;
 use App\Fixers\LaravelBlade\Fixer;
+use App\Fixers\PrettierCacheFingerprint;
 use App\Repositories\ConfigurationJsonRepository;
 use PhpCsFixer\Config;
 use PhpCsFixer\ConfigInterface;
@@ -45,12 +47,20 @@ class ConfigurationFactory
      */
     public static function preset($rules)
     {
+        $mergedRules = array_merge($rules, resolve(ConfigurationJsonRepository::class)->rules());
+
+        $fingerprints = resolve(EnsurePrettierIsConfigured::class)->cacheFingerprints();
+
+        if ($fingerprints !== []) {
+            $mergedRules[(new PrettierCacheFingerprint)->getName()] = ['fingerprints' => $fingerprints];
+        }
+
         return (new Config)
             ->setParallelConfig(ParallelConfigFactory::detect())
             ->setFinder(self::finder())
-            ->setRules(array_merge($rules, resolve(ConfigurationJsonRepository::class)->rules()))
+            ->setRules($mergedRules)
             ->setRiskyAllowed(true)
-            ->setUsingCache(static::shouldExcludeBladeFiles())
+            ->setUsingCache(true)
             ->setUnsupportedPhpVersionAllowed(true)
             ->registerCustomFixers(self::customFixers());
     }
@@ -64,6 +74,7 @@ class ConfigurationFactory
     {
         return [
             new Fixer(resolve(BladeFormatter::class)),
+            new PrettierCacheFingerprint,
         ];
     }
 

--- a/app/Fixers/PrettierCacheFingerprint.php
+++ b/app/Fixers/PrettierCacheFingerprint.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Fixers;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\Fixer\ConfigurableFixerTrait;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
+use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * A no-op fixer that never runs on any file. Its sole purpose is to
+ * carry prettier dependency version fingerprints inside the rules array
+ * so that they become part of PHP-CS-Fixer's cache Signature. When any
+ * prettier-related package version changes, the fingerprints change,
+ * the Signature no longer matches, and the entire cache is invalidated.
+ *
+ * This avoids the need to disable caching entirely when blade formatting
+ * is enabled, while still guaranteeing correctness when external tool
+ * versions change.
+ *
+ * @implements ConfigurableFixerInterface<array<string, mixed>, array<string, mixed>>
+ */
+class PrettierCacheFingerprint extends AbstractFixer implements ConfigurableFixerInterface
+{
+    /** @use ConfigurableFixerTrait<array<string, mixed>, array<string, mixed>> */
+    use ConfigurableFixerTrait;
+
+    public function getName(): string
+    {
+        return 'Pint/prettier_cache_fingerprint';
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Carries prettier dependency version fingerprints for cache invalidation.',
+            [],
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return false;
+    }
+
+    protected function applyFix(\SplFileInfo $file, Tokens $tokens): void {}
+
+    protected function createConfigurationDefinition(): FixerConfigurationResolverInterface
+    {
+        return new FixerConfigurationResolver([
+            (new FixerOptionBuilder('fingerprints', 'Map of fixer names to their prettier dependency version hashes.'))
+                ->setAllowedTypes(['array'])
+                ->setDefault([])
+                ->getOption(),
+        ]);
+    }
+}

--- a/overrides/FixerFactory.php
+++ b/overrides/FixerFactory.php
@@ -17,6 +17,7 @@ namespace PhpCsFixer;
 use App\BladeFormatter;
 use App\Fixers\LaravelBlade\Fixer as LaravelBladeFixer;
 use App\Fixers\LaravelBlade\NoUnusedImportsFixer as BladeAwareNoUnusedImportsFixer;
+use App\Fixers\PrettierCacheFingerprint;
 use App\Fixers\TypeAnnotationsOnlyFixer;
 use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
@@ -113,6 +114,7 @@ final class FixerFactory
         $this->registerCustomFixers([
             new TypeAnnotationsOnlyFixer,
             new LaravelBladeFixer(resolve(BladeFormatter::class)),
+            new PrettierCacheFingerprint,
         ]);
 
         return $this;

--- a/tests/Feature/CacheFingerprintTest.php
+++ b/tests/Feature/CacheFingerprintTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Actions\EnsurePrettierIsConfigured;
+use App\BladeFormatter;
+use App\Fixers\LaravelBlade\Fixer;
+use App\Repositories\ConfigurationJsonRepository;
+use App\Support\Prettier;
+
+beforeEach(function () {
+    $prettier = new Prettier(getcwd());
+
+    $this->action = new EnsurePrettierIsConfigured($prettier, new ConfigurationJsonRepository(null, null));
+    $this->fixer = new Fixer(new BladeFormatter($prettier));
+
+    $this->probes = [
+        'prettier' => ['resolved' => true, 'version' => '3.8.4'],
+        'prettier-plugin-blade' => ['resolved' => true, 'version' => '3.2.2'],
+        'prettier-plugin-tailwindcss' => ['resolved' => true, 'version' => '0.8.0'],
+    ];
+});
+
+it('computes a stable fingerprint from the probed package versions', function () {
+    $first = $this->action->fingerprint($this->fixer, $this->probes);
+    $second = $this->action->fingerprint($this->fixer, array_reverse($this->probes, true));
+
+    expect($first)->toMatch('/^[a-f0-9]{32}$/')
+        ->and($second)->toBe($first);
+});
+
+it('changes the fingerprint when a prettier package version changes', function () {
+    $before = $this->action->fingerprint($this->fixer, $this->probes);
+
+    $this->probes['prettier-plugin-blade']['version'] = '3.3.0';
+
+    expect($this->action->fingerprint($this->fixer, $this->probes))->not->toBe($before);
+});
+
+it('changes the fingerprint when the pint version changes', function () {
+    config(['app.version' => '1.0.0']);
+    $before = $this->action->fingerprint($this->fixer, $this->probes);
+
+    config(['app.version' => '1.0.1']);
+
+    expect($this->action->fingerprint($this->fixer, $this->probes))->not->toBe($before);
+});
+
+it('exposes no cache fingerprints before prettier is configured', function () {
+    expect($this->action->cacheFingerprints())->toBe([]);
+});

--- a/tests/Feature/CacheTest.php
+++ b/tests/Feature/CacheTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Fixers\PrettierCacheFingerprint;
+use Symfony\Component\Process\Process;
+
+/**
+ * Run pint over the given directory using the given cache file, returning its exit code.
+ *
+ * @param  array<int, string>  $options
+ */
+function runPintWithCache(string $directory, string $cacheFile, array $options = []): int
+{
+    $command = array_merge(
+        ['php', 'pint', '--config', $directory.'/pint.json', '--cache-file', $cacheFile],
+        $options,
+        [$directory],
+    );
+
+    $process = new Process($command, base_path());
+    $process->setTimeout(120);
+    $process->run();
+
+    return $process->getExitCode();
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function cacheSignature(string $cacheFile): array
+{
+    expect($cacheFile)->toBeFile();
+
+    return json_decode((string) file_get_contents($cacheFile), true, flags: JSON_THROW_ON_ERROR);
+}
+
+beforeEach(function () {
+    $this->directory = sys_get_temp_dir().DIRECTORY_SEPARATOR.'pint-cache-'.bin2hex(random_bytes(8));
+    $this->cacheFile = $this->directory.DIRECTORY_SEPARATOR.'.pint.cache';
+
+    mkdir($this->directory.'/resources/views', 0777, true);
+
+    file_put_contents($this->directory.'/pint.json', '{"preset":"laravel"}'."\n");
+    file_put_contents($this->directory.'/resources/views/welcome.blade.php', "<div   class=\"p-4 flex\"><x-foo    :bar=\"\$baz\"/></div>\n");
+    file_put_contents($this->directory.'/Example.php', "<?php\n\nclass Example\n{\n    public function handle()\n    {\n        return array(1, 2);\n    }\n}\n");
+});
+
+afterEach(function () {
+    foreach (['/resources/views/welcome.blade.php', '/Example.php', '/pint.json', '/.pint.cache'] as $file) {
+        @unlink($this->directory.$file);
+    }
+
+    @rmdir($this->directory.'/resources/views');
+    @rmdir($this->directory.'/resources');
+    @rmdir($this->directory);
+});
+
+it('uses the cache when blade formatting is active', function () {
+    expect(runPintWithCache($this->directory, $this->cacheFile, ['--blade']))->toBe(0);
+
+    $signature = cacheSignature($this->cacheFile);
+
+    $cached = array_map('basename', array_keys($signature['hashes']));
+
+    expect($signature['rules'])->toHaveKey('Pint/laravel_blade')
+        ->and($cached)->toContain('welcome.blade.php')
+        ->and($cached)->toContain('Example.php');
+});
+
+it('carries the prettier fingerprints in the cache signature', function () {
+    expect(runPintWithCache($this->directory, $this->cacheFile, ['--blade']))->toBe(0);
+
+    $rules = cacheSignature($this->cacheFile)['rules'];
+    $fingerprints = $rules[(new PrettierCacheFingerprint)->getName()]['fingerprints'] ?? null;
+
+    expect($fingerprints)->toHaveKey('Pint/laravel_blade')
+        ->and($fingerprints['Pint/laravel_blade'])->toMatch('/^[a-f0-9]{32}$/');
+});
+
+it('does not carry prettier fingerprints when blade formatting is inactive', function () {
+    expect(runPintWithCache($this->directory, $this->cacheFile))->toBe(0);
+
+    $rules = cacheSignature($this->cacheFile)['rules'];
+
+    expect($rules)->not->toHaveKey((new PrettierCacheFingerprint)->getName())
+        ->and($rules)->not->toHaveKey('Pint/laravel_blade');
+});
+
+it('reports no changes on a second run served from the cache', function () {
+    expect(runPintWithCache($this->directory, $this->cacheFile, ['--blade']))->toBe(0);
+
+    $signature = cacheSignature($this->cacheFile);
+
+    expect(runPintWithCache($this->directory, $this->cacheFile, ['--blade', '--test']))->toBe(0)
+        ->and(cacheSignature($this->cacheFile))->toBe($signature);
+});


### PR DESCRIPTION
Previously, caching was unconditionally disabled whenever the Blade rule was enabled because PHP-CS-Fixer's cache signature has no awareness of external tool versions (`prettier`, `prettier-plugin-blade`, `prettier-plugin-tailwindcss`). Upgrading any of those packages could silently serve stale cached results.

This introduces a dedicated no-op fixer (`PrettierCacheFingerprint`) whose sole purpose is to carry version fingerprints inside the rules array so they become part of PHP-CS-Fixer's cache Signature. When any prettier-related package version changes, the fingerprints change, the Signature no longer matches, and the entire cache is invalidated.

I've created a [php-cs-fixer PR](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9781) to hopefully allow this to be configurable on a per-rule basis---and would remove the need for `PrettierCacheFingerprint`

### Performance
For a project with ~7,800 files:
- **~40x speedup** in serial (~654s => ~16s)
- **~3x speedup** in parallel (~31s => ~11s)

Thanks!