### PR TITLE
fix: catch \ParseError in PhpFragmentFormatter

### DIFF
--- a/app/Support/PhpFragmentFormatter.php
+++ b/app/Support/PhpFragmentFormatter.php
@@ -50,7 +50,7 @@ class PhpFragmentFormatter
     {
         try {
             $tokens = Tokens::fromCode($code);
-        } catch (\CompileError) {
+        } catch (\CompileError|\ParseError) {
             // Not a syntactically-complete PHP document on its own; leave it as-is.
             return $code;
         }

--- a/tests/Unit/Support/PhpFragmentFormatterTest.php
+++ b/tests/Unit/Support/PhpFragmentFormatterTest.php
@@ -74,6 +74,29 @@ it('keeps the imports of a single file component it formats', function () {
         ->toContain("public string \$mode = 'all';");
 });
 
+it('returns unparseable code unchanged instead of throwing', function () {
+    $in = <<<'PHP'
+    <?php
+    $x = 1;
+    @extends('layouts.app')
+    PHP;
+
+    $out = (new PhpFragmentFormatter)->format($in);
+
+    expect($out)->toBe($in);
+});
+
+it('returns unparseable fragment unchanged instead of throwing', function () {
+    $in = <<<'PHP'
+    <?php
+    $x = [
+    PHP;
+
+    $out = (new PhpFragmentFormatter)->format($in, fragment: true);
+
+    expect($out)->toBe($in);
+});
+
 it('formats an island the same way twice', function () {
     $in = <<<'PHP'
     <?php


### PR DESCRIPTION
Hello!

I found that I was getting parse errors when running in serial mode but not in parallel mode, this catches them so that they're not reported for fragments

Thanks!