### PR TITLE
feat: adds Pint/prettier_js and Pint/prettier_css rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased](https://github.com/laravel/pint/compare/v1.29.2...main)
 
-- Adds `Pint/prettier_js` and `Pint/prettier_css` rules, which format JavaScript and CSS files using Prettier.
+- Adds `Pint/prettier_js` and `Pint/prettier_css` rules, which format JavaScript, TypeScript and CSS files using Prettier.
 
 ## [v1.29.2](https://github.com/laravel/pint/compare/v1.29.1...v1.29.2) - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/laravel/pint/compare/v1.29.2...main)
 
+- Adds `Pint/prettier_js` and `Pint/prettier_css` rules, which format JavaScript and CSS files using Prettier.
+
 ## [v1.29.2](https://github.com/laravel/pint/compare/v1.29.1...v1.29.2) - 2026-06-16
 
 - fix: no longer accepts loading a configuration over insecure `http`

--- a/app/Contracts/HasFinderNames.php
+++ b/app/Contracts/HasFinderNames.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Contracts;
+
+interface HasFinderNames
+{
+    /**
+     * The finder name patterns the rule needs the finder to include, on top
+     * of the "*.php" files php-cs-fixer already discovers.
+     *
+     * @return array<int, string>
+     */
+    public function finderNames(): array;
+}

--- a/app/Contracts/HasPrettierDependencies.php
+++ b/app/Contracts/HasPrettierDependencies.php
@@ -11,12 +11,4 @@ interface HasPrettierDependencies
      * @return array<string, string>
      */
     public function prettierDependencies(): array;
-
-    /**
-     * The finder name patterns the rule needs the finder to include, on top
-     * of the "*.php" files php-cs-fixer already discovers.
-     *
-     * @return array<int, string>
-     */
-    public function finderNames(): array;
 }

--- a/app/Contracts/HasPrettierDependencies.php
+++ b/app/Contracts/HasPrettierDependencies.php
@@ -11,4 +11,12 @@ interface HasPrettierDependencies
      * @return array<string, string>
      */
     public function prettierDependencies(): array;
+
+    /**
+     * The finder name patterns the rule needs the finder to include, on top
+     * of the "*.php" files php-cs-fixer already discovers.
+     *
+     * @return array<int, string>
+     */
+    public function finderNames(): array;
 }

--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -3,8 +3,12 @@
 namespace App\Factories;
 
 use App\BladeFormatter;
+use App\Contracts\HasPrettierDependencies;
 use App\Fixers\LaravelBlade\Fixer;
+use App\Fixers\Prettier\CssFixer;
+use App\Fixers\Prettier\JsFixer;
 use App\Repositories\ConfigurationJsonRepository;
+use App\Support\Prettier;
 use PhpCsFixer\Config;
 use PhpCsFixer\ConfigInterface;
 use PhpCsFixer\Finder;
@@ -50,7 +54,7 @@ class ConfigurationFactory
             ->setFinder(self::finder())
             ->setRules(array_merge($rules, resolve(ConfigurationJsonRepository::class)->rules()))
             ->setRiskyAllowed(true)
-            ->setUsingCache(static::shouldExcludeBladeFiles())
+            ->setUsingCache(static::shouldUseCache())
             ->setUnsupportedPhpVersionAllowed(true)
             ->registerCustomFixers(self::customFixers());
     }
@@ -64,6 +68,8 @@ class ConfigurationFactory
     {
         return [
             new Fixer(resolve(BladeFormatter::class)),
+            new JsFixer(resolve(Prettier::class)),
+            new CssFixer(resolve(Prettier::class)),
         ];
     }
 
@@ -81,6 +87,10 @@ class ConfigurationFactory
             ->exclude(static::$exclude)
             ->ignoreDotFiles(true)
             ->ignoreVCS(true);
+
+        foreach (static::prettierNames() as $pattern) {
+            $finder->name($pattern);
+        }
 
         foreach ($localConfiguration->finder() as $method => $arguments) {
             if (! method_exists($finder, $method)) {
@@ -119,6 +129,45 @@ class ConfigurationFactory
         $rules = resolve(ConfigurationJsonRepository::class)->rules();
 
         return ($rules['Pint/laravel_blade'] ?? false) === false;
+    }
+
+    /**
+     * Determine whether the cache may be used.
+     *
+     * A rule whose output depends on the installed prettier dependencies cannot
+     * be cached on file contents alone, so the cache is given up entirely when
+     * any of those rules is enabled.
+     *
+     * @return bool
+     */
+    protected static function shouldUseCache()
+    {
+        $rules = resolve(ConfigurationJsonRepository::class)->rules();
+
+        foreach (static::customFixers() as $fixer) {
+            if ($fixer instanceof HasPrettierDependencies && ($rules[$fixer->getName()] ?? false) === true) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * The finder name patterns required by the enabled prettier rules.
+     *
+     * @return array<int, string>
+     */
+    protected static function prettierNames()
+    {
+        $rules = resolve(ConfigurationJsonRepository::class)->rules();
+
+        return collect(static::customFixers())
+            ->filter(fn ($fixer) => $fixer instanceof HasPrettierDependencies)
+            ->filter(fn ($fixer) => ($rules[$fixer->getName()] ?? false) === true)
+            ->flatMap(fn (HasPrettierDependencies&FixerInterface $fixer) => $fixer->finderNames())
+            ->values()
+            ->all();
     }
 
     /**

--- a/app/Factories/ConfigurationFactory.php
+++ b/app/Factories/ConfigurationFactory.php
@@ -3,6 +3,7 @@
 namespace App\Factories;
 
 use App\BladeFormatter;
+use App\Contracts\HasFinderNames;
 use App\Contracts\HasPrettierDependencies;
 use App\Fixers\LaravelBlade\Fixer;
 use App\Fixers\Prettier\CssFixer;
@@ -154,7 +155,8 @@ class ConfigurationFactory
     }
 
     /**
-     * The finder name patterns required by the enabled prettier rules.
+     * The finder name patterns required by the enabled rules that bring their
+     * own file types.
      *
      * @return array<int, string>
      */
@@ -163,9 +165,9 @@ class ConfigurationFactory
         $rules = resolve(ConfigurationJsonRepository::class)->rules();
 
         return collect(static::customFixers())
-            ->filter(fn ($fixer) => $fixer instanceof HasPrettierDependencies)
+            ->filter(fn ($fixer) => $fixer instanceof HasFinderNames)
             ->filter(fn ($fixer) => ($rules[$fixer->getName()] ?? false) === true)
-            ->flatMap(fn (HasPrettierDependencies&FixerInterface $fixer) => $fixer->finderNames())
+            ->flatMap(fn (HasFinderNames $fixer) => $fixer->finderNames())
             ->values()
             ->all();
     }

--- a/app/Fixers/LaravelBlade/Fixer.php
+++ b/app/Fixers/LaravelBlade/Fixer.php
@@ -44,15 +44,6 @@ class Fixer extends AbstractFixer implements HasPrettierDependencies
     /**
      * {@inheritdoc}
      */
-    public function finderNames(): array
-    {
-        // Blade files are ".php" files, which the finder already discovers.
-        return [];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getName(): string
     {
         return 'Pint/laravel_blade';

--- a/app/Fixers/LaravelBlade/Fixer.php
+++ b/app/Fixers/LaravelBlade/Fixer.php
@@ -44,6 +44,15 @@ class Fixer extends AbstractFixer implements HasPrettierDependencies
     /**
      * {@inheritdoc}
      */
+    public function finderNames(): array
+    {
+        // Blade files are ".php" files, which the finder already discovers.
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getName(): string
     {
         return 'Pint/laravel_blade';

--- a/app/Fixers/Prettier/BaseFixer.php
+++ b/app/Fixers/Prettier/BaseFixer.php
@@ -2,6 +2,7 @@
 
 namespace App\Fixers\Prettier;
 
+use App\Contracts\HasFinderNames;
 use App\Contracts\HasPrettierDependencies;
 use App\Exceptions\PrettierException;
 use App\Support\Prettier;
@@ -9,7 +10,7 @@ use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 
-abstract class BaseFixer extends AbstractFixer implements HasPrettierDependencies
+abstract class BaseFixer extends AbstractFixer implements HasFinderNames, HasPrettierDependencies
 {
     /**
      * Create a new prettier fixer instance.
@@ -27,14 +28,7 @@ abstract class BaseFixer extends AbstractFixer implements HasPrettierDependencie
     }
 
     /**
-     * The list of file extensions the fixer formats.
-     *
-     * @return array<int, string>
-     */
-    abstract protected function extensions(): array;
-
-    /**
-     * The prettier parser each extension is formatted with.
+     * The prettier parser each supported file extension is formatted with.
      *
      * @return array<string, string>
      */
@@ -47,7 +41,7 @@ abstract class BaseFixer extends AbstractFixer implements HasPrettierDependencie
     {
         return array_map(
             fn (string $extension): string => '*.'.$extension,
-            $this->extensions(),
+            array_keys($this->parsers()),
         );
     }
 
@@ -78,12 +72,12 @@ abstract class BaseFixer extends AbstractFixer implements HasPrettierDependencie
         // disk, e.g. one handed over through stdin, still keeps its name.
         $path = $file->getRealPath() ?: $file->getPathname();
 
-        if (! $this->matches($path)) {
+        if (($parser = $this->parserFor($path)) === null) {
             return;
         }
 
         $content = $this->prettier->format($path, $tokens->generateCode(), [
-            'parser' => $this->parsers()[$this->extensionOf($path)],
+            'parser' => $parser,
         ]);
 
         // Tokens::setCode() rejects an empty string, so clear the tokens directly.
@@ -101,17 +95,10 @@ abstract class BaseFixer extends AbstractFixer implements HasPrettierDependencie
     }
 
     /**
-     * Determine whether the given path should be formatted.
+     * The prettier parser for the given path, or null when the fixer does
+     * not format it.
      */
-    protected function matches(string $path): bool
-    {
-        return $this->extensionOf($path) !== null;
-    }
-
-    /**
-     * The extension of the given path, or null when the fixer does not format it.
-     */
-    protected function extensionOf(string $path): ?string
+    protected function parserFor(string $path): ?string
     {
         $fileName = basename(str_replace('\\', '/', $path));
 
@@ -120,9 +107,9 @@ abstract class BaseFixer extends AbstractFixer implements HasPrettierDependencie
             return null;
         }
 
-        foreach ($this->extensions() as $extension) {
+        foreach ($this->parsers() as $extension => $parser) {
             if (str_ends_with($fileName, '.'.$extension)) {
-                return $extension;
+                return $parser;
             }
         }
 

--- a/app/Fixers/Prettier/BaseFixer.php
+++ b/app/Fixers/Prettier/BaseFixer.php
@@ -6,7 +6,6 @@ use App\Contracts\HasPrettierDependencies;
 use App\Exceptions\PrettierException;
 use App\Support\Prettier;
 use PhpCsFixer\AbstractFixer;
-use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 

--- a/app/Fixers/Prettier/BaseFixer.php
+++ b/app/Fixers/Prettier/BaseFixer.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Fixers\Prettier;
+
+use App\Contracts\HasPrettierDependencies;
+use App\Exceptions\PrettierException;
+use App\Support\Prettier;
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+abstract class BaseFixer extends AbstractFixer implements HasPrettierDependencies
+{
+    /**
+     * Create a new prettier fixer instance.
+     */
+    public function __construct(protected Prettier $prettier) {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prettierDependencies(): array
+    {
+        return [
+            'prettier' => '^3.8.4',
+        ];
+    }
+
+    /**
+     * The list of file extensions the fixer formats.
+     *
+     * @return array<int, string>
+     */
+    abstract protected function extensions(): array;
+
+    /**
+     * The prettier parser each extension is formatted with.
+     *
+     * @return array<string, string>
+     */
+    abstract protected function parsers(): array;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function finderNames(): array
+    {
+        return array_map(
+            fn (string $extension): string => '*.'.$extension,
+            $this->extensions(),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPriority(): int
+    {
+        return -2;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws PrettierException
+     */
+    protected function applyFix(SplFileInfo $file, Tokens $tokens): void
+    {
+        // The real path is preferred, but a file that cannot be resolved on
+        // disk, e.g. one handed over through stdin, still keeps its name.
+        $path = $file->getRealPath() ?: $file->getPathname();
+
+        if (! $this->matches($path)) {
+            return;
+        }
+
+        $content = $this->prettier->format($path, $tokens->generateCode(), [
+            'parser' => $this->parsers()[$this->extensionOf($path)],
+        ]);
+
+        // Tokens::setCode() rejects an empty string, so clear the tokens directly.
+        if ($content === '') {
+            foreach ($tokens as $index => $token) {
+                $tokens->clearAt($index);
+            }
+
+            $tokens->clearEmptyTokens();
+
+            return;
+        }
+
+        $tokens->setCode($content);
+    }
+
+    /**
+     * Determine whether the given path should be formatted.
+     */
+    protected function matches(string $path): bool
+    {
+        return $this->extensionOf($path) !== null;
+    }
+
+    /**
+     * The extension of the given path, or null when the fixer does not format it.
+     */
+    protected function extensionOf(string $path): ?string
+    {
+        $fileName = basename(str_replace('\\', '/', $path));
+
+        // Minified assets are machine-generated; reformatting them only bloats diffs.
+        if (str_contains($fileName, '.min.')) {
+            return null;
+        }
+
+        foreach ($this->extensions() as $extension) {
+            if (str_ends_with($fileName, '.'.$extension)) {
+                return $extension;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Fixers/Prettier/CssFixer.php
+++ b/app/Fixers/Prettier/CssFixer.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Fixers\Prettier;
+
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+
+class CssFixer extends BaseFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'Pint/prettier_css';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition('Formats CSS, SCSS and Less files using Prettier.', []);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function extensions(): array
+    {
+        return ['css', 'scss', 'less'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parsers(): array
+    {
+        return [
+            'css' => 'css',
+            'scss' => 'scss',
+            'less' => 'less',
+        ];
+    }
+}

--- a/app/Fixers/Prettier/CssFixer.php
+++ b/app/Fixers/Prettier/CssFixer.php
@@ -26,14 +26,6 @@ class CssFixer extends BaseFixer
     /**
      * {@inheritdoc}
      */
-    protected function extensions(): array
-    {
-        return ['css', 'scss', 'less'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function parsers(): array
     {
         return [

--- a/app/Fixers/Prettier/JsFixer.php
+++ b/app/Fixers/Prettier/JsFixer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Fixers\Prettier;
+
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+
+class JsFixer extends BaseFixer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'Pint/prettier_js';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition('Formats JavaScript files using Prettier.', []);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function extensions(): array
+    {
+        return ['js', 'jsx', 'mjs', 'cjs'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parsers(): array
+    {
+        return [
+            'js' => 'babel',
+            'jsx' => 'babel',
+            'mjs' => 'babel',
+            'cjs' => 'babel',
+        ];
+    }
+}

--- a/app/Fixers/Prettier/JsFixer.php
+++ b/app/Fixers/Prettier/JsFixer.php
@@ -20,15 +20,7 @@ class JsFixer extends BaseFixer
      */
     public function getDefinition(): FixerDefinitionInterface
     {
-        return new FixerDefinition('Formats JavaScript files using Prettier.', []);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function extensions(): array
-    {
-        return ['js', 'jsx', 'mjs', 'cjs'];
+        return new FixerDefinition('Formats JavaScript and TypeScript files using Prettier.', []);
     }
 
     /**
@@ -41,6 +33,8 @@ class JsFixer extends BaseFixer
             'jsx' => 'babel',
             'mjs' => 'babel',
             'cjs' => 'babel',
+            'ts' => 'typescript',
+            'tsx' => 'typescript',
         ];
     }
 }

--- a/app/Support/PhpFragmentFormatter.php
+++ b/app/Support/PhpFragmentFormatter.php
@@ -17,13 +17,18 @@ class PhpFragmentFormatter
      *
      * @var array<int, string>
      */
-    private const DENYLIST = [
-        'no_closing_tag',
-        'no_unused_imports',
-        'Pint/laravel_blade',
-        'Pint/prettier_js',
-        'Pint/prettier_css',
-    ];
+    private const DENYLIST = ['no_closing_tag', 'no_unused_imports'];
+
+    /**
+     * The prefix of every custom fixer Pint registers.
+     *
+     * Custom fixers never run on a fragment: the factory below only knows the
+     * built-in PHP fixers, so their names are dropped before it is handed the
+     * ruleset.
+     *
+     * @var string
+     */
+    private const CUSTOM_FIXER_PREFIX = 'Pint/';
 
     /**
      * Fixers skipped only for stripped fragments, where they corrupt the output.
@@ -96,6 +101,12 @@ class PhpFragmentFormatter
 
         foreach ($deny as $name) {
             unset($rules[$name]);
+        }
+
+        foreach (array_keys($rules) as $name) {
+            if (str_starts_with((string) $name, self::CUSTOM_FIXER_PREFIX)) {
+                unset($rules[$name]);
+            }
         }
 
         $factory = new FixerFactory;

--- a/app/Support/PhpFragmentFormatter.php
+++ b/app/Support/PhpFragmentFormatter.php
@@ -17,7 +17,13 @@ class PhpFragmentFormatter
      *
      * @var array<int, string>
      */
-    private const DENYLIST = ['no_closing_tag', 'no_unused_imports', 'Pint/laravel_blade'];
+    private const DENYLIST = [
+        'no_closing_tag',
+        'no_unused_imports',
+        'Pint/laravel_blade',
+        'Pint/prettier_js',
+        'Pint/prettier_css',
+    ];
 
     /**
      * Fixers skipped only for stripped fragments, where they corrupt the output.

--- a/app/Support/Prettier.php
+++ b/app/Support/Prettier.php
@@ -15,7 +15,7 @@ class Prettier
      *
      * @var int
      */
-    public const VERSION = 1;
+    public const VERSION = 2;
 
     /**
      * The number of seconds the worker may stay silent before it is torn down.
@@ -53,9 +53,10 @@ class Prettier
     /**
      * Formats the given file.
      *
+     * @param  array<string, mixed>  $options
      * @throws PrettierException
      */
-    public function format(string $path, string $content): string
+    public function format(string $path, string $content, array $options = []): string
     {
         $this->ensureStarted();
 
@@ -65,6 +66,7 @@ class Prettier
         $this->inputStream->write(json_encode([
             'path' => $path,
             'content' => $content,
+            'options' => $options,
         ], JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE)."\n");
 
         // Accumulate every chunk; the OS pipe may split the response across reads.

--- a/app/Support/Prettier.php
+++ b/app/Support/Prettier.php
@@ -54,6 +54,7 @@ class Prettier
      * Formats the given file.
      *
      * @param  array<string, mixed>  $options
+     *
      * @throws PrettierException
      */
     public function format(string $path, string $content, array $options = []): string

--- a/resources/js/worker.cjs
+++ b/resources/js/worker.cjs
@@ -59,11 +59,16 @@ process.stdin.on("data", function (chunk) {
 
 async function handleMessage(input) {
     try {
-        const { path: filepath, content } = JSON.parse(input);
+        const { path: filepath, content, options: requestOptions = {} } = JSON.parse(input);
 
         const resolved = filepath.trim();
 
-        const options = resolveOptionPlugins({ ...bundledOptions });
+        // Request options win over the bundled ones, so a fixer can pick the
+        // parser that matches the file it is handing over.
+        const options = resolveOptionPlugins({
+            ...bundledOptions,
+            ...requestOptions,
+        });
 
         const formatted = await prettier.format(content, {
             ...options,

--- a/tests/Feature/Prettier/PrettierTest.php
+++ b/tests/Feature/Prettier/PrettierTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Every prettier fixture file across all groups, as paths relative to the
+ * fixture root.
+ *
+ * @return array<int, string>
+ */
+function prettierFixtureFiles(): array
+{
+    $root = dirname(__DIR__, 2).'/Fixtures/prettier-formatting';
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+    );
+
+    $files = [];
+
+    foreach ($iterator as $file) {
+        if ($file->isFile() && ! str_ends_with($file->getFilename(), '.expected')) {
+            $files[] = ltrim(str_replace($root, '', $file->getPathname()), DIRECTORY_SEPARATOR);
+        }
+    }
+
+    sort($files);
+
+    return $files;
+}
+
+/**
+ * Stage every fixture twice ("input/" and "golden/") into a temporary project
+ * with both prettier rules enabled, then run Pint over it once. The single run
+ * covers the golden-file check (does "input" format to "golden"?) and the
+ * idempotency check (does "golden" survive a re-format?).
+ */
+function formatPrettierFixtureProject(): string
+{
+    static $tmp = null;
+
+    if ($tmp !== null) {
+        return $tmp;
+    }
+
+    $sourceRoot = dirname(__DIR__, 2).'/Fixtures/prettier-formatting';
+
+    $tmp = freshBladeTempDirectory();
+
+    foreach (prettierFixtureFiles() as $relative) {
+        stageBladeFixture($tmp, $sourceRoot, $relative, targetPrefix: 'input/');
+        stageBladeFixture($tmp, $sourceRoot, $relative, fromExpected: true, targetPrefix: 'golden/');
+    }
+
+    file_put_contents($tmp.'/pint.json', json_encode([
+        'preset' => 'laravel',
+        'rules' => [
+            'Pint/prettier_js' => true,
+            'Pint/prettier_css' => true,
+        ],
+    ]).PHP_EOL);
+
+    $process = new Process(['php', 'pint', '--config', $tmp.'/pint.json', $tmp], base_path());
+
+    $process->setTimeout(120);
+
+    $process->run();
+
+    expect($process->getExitCode())->toBe(
+        0,
+        'pint failed while formatting the prettier fixtures: '.$process->getErrorOutput().$process->getOutput(),
+    );
+
+    return $tmp;
+}
+
+it('formats every fixture to its golden file', function (string $file) {
+    $tmp = formatPrettierFixtureProject();
+
+    expect(file_get_contents($tmp.'/input/'.$file))->toBe(
+        file_get_contents(dirname(__DIR__, 2).'/Fixtures/prettier-formatting/'.$file.'.expected'),
+        "Formatted output does not match the golden file for [{$file}].",
+    );
+})->with(fn () => prettierFixtureFiles());
+
+it('re-formats every golden file unchanged (idempotent)', function (string $file) {
+    $tmp = formatPrettierFixtureProject();
+
+    expect(file_get_contents($tmp.'/golden/'.$file))->toBe(
+        file_get_contents(dirname(__DIR__, 2).'/Fixtures/prettier-formatting/'.$file.'.expected'),
+        "Re-formatting the golden file changed it for [{$file}] (not idempotent).",
+    );
+})->with(fn () => prettierFixtureFiles());

--- a/tests/Fixtures/prettier-formatting/css/app.css
+++ b/tests/Fixtures/prettier-formatting/css/app.css
@@ -1,0 +1,2 @@
+body{margin:0;padding:0;color:#333333}
+.card{background:#ffffff;border-radius:4px}

--- a/tests/Fixtures/prettier-formatting/css/app.css.expected
+++ b/tests/Fixtures/prettier-formatting/css/app.css.expected
@@ -1,0 +1,9 @@
+body {
+    margin: 0;
+    padding: 0;
+    color: #333333;
+}
+.card {
+    background: #ffffff;
+    border-radius: 4px;
+}

--- a/tests/Fixtures/prettier-formatting/css/theme.scss
+++ b/tests/Fixtures/prettier-formatting/css/theme.scss
@@ -1,0 +1,1 @@
+$primary:#333;.btn{color:$primary;&:hover{color:lighten($primary,10%)}}

--- a/tests/Fixtures/prettier-formatting/css/theme.scss.expected
+++ b/tests/Fixtures/prettier-formatting/css/theme.scss.expected
@@ -1,0 +1,7 @@
+$primary: #333;
+.btn {
+    color: $primary;
+    &:hover {
+        color: lighten($primary, 10%);
+    }
+}

--- a/tests/Fixtures/prettier-formatting/js/app.js
+++ b/tests/Fixtures/prettier-formatting/js/app.js
@@ -1,0 +1,2 @@
+const   greeting = "hello"
+function greet( name ){return greeting + ', ' + name}

--- a/tests/Fixtures/prettier-formatting/js/app.js.expected
+++ b/tests/Fixtures/prettier-formatting/js/app.js.expected
@@ -1,0 +1,4 @@
+const greeting = 'hello';
+function greet(name) {
+    return greeting + ', ' + name;
+}

--- a/tests/Fixtures/prettier-formatting/js/component.jsx
+++ b/tests/Fixtures/prettier-formatting/js/component.jsx
@@ -1,0 +1,3 @@
+export   default function Card( { title, children } ){
+    return <div className="card"><h2>{title}</h2>{children}</div>
+}

--- a/tests/Fixtures/prettier-formatting/js/component.jsx.expected
+++ b/tests/Fixtures/prettier-formatting/js/component.jsx.expected
@@ -1,0 +1,8 @@
+export default function Card({ title, children }) {
+    return (
+        <div className="card">
+            <h2>{title}</h2>
+            {children}
+        </div>
+    );
+}

--- a/tests/Fixtures/prettier-formatting/js/module.ts
+++ b/tests/Fixtures/prettier-formatting/js/module.ts
@@ -1,0 +1,4 @@
+interface   User { name: string, age: number }
+export function describe( user: User ): string {
+    return `${user.name} (${user.age})`
+}

--- a/tests/Fixtures/prettier-formatting/js/module.ts.expected
+++ b/tests/Fixtures/prettier-formatting/js/module.ts.expected
@@ -1,0 +1,7 @@
+interface User {
+    name: string;
+    age: number;
+}
+export function describe(user: User): string {
+    return `${user.name} (${user.age})`;
+}

--- a/tests/Fixtures/prettier-formatting/js/vendor.min.js
+++ b/tests/Fixtures/prettier-formatting/js/vendor.min.js
@@ -1,0 +1,1 @@
+function   ugly( a,b ){return a+b}

--- a/tests/Fixtures/prettier-formatting/js/vendor.min.js.expected
+++ b/tests/Fixtures/prettier-formatting/js/vendor.min.js.expected
@@ -1,0 +1,1 @@
+function   ugly( a,b ){return a+b}

--- a/tests/Fixtures/rules/prettier-rules.json
+++ b/tests/Fixtures/rules/prettier-rules.json
@@ -1,0 +1,7 @@
+{
+    "rules": {
+        "Pint/laravel_blade": true,
+        "Pint/prettier_js": true,
+        "Pint/prettier_css": true
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -124,7 +124,7 @@ uses()
             $this->markTestSkipped('Node is required to run the blade formatter.');
         }
     })
-    ->in('Feature/Blade');
+    ->in('Feature/Blade', 'Feature/Prettier');
 
 function testOutputFile(): string
 {

--- a/tests/Unit/BladeFormatterTest.php
+++ b/tests/Unit/BladeFormatterTest.php
@@ -16,7 +16,7 @@ function fakePrettier(Closure $handler): Prettier
             parent::__construct($projectRoot);
         }
 
-        public function format(string $path, string $content): string
+        public function format(string $path, string $content, array $options = []): string
         {
             return ($this->handler)($content);
         }

--- a/tests/Unit/Fixers/Prettier/FixersTest.php
+++ b/tests/Unit/Fixers/Prettier/FixersTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use App\Fixers\Prettier\CssFixer;
+use App\Fixers\Prettier\JsFixer;
+use App\Support\Prettier;
+use PhpCsFixer\Tokenizer\Tokens;
+
+/**
+ * A prettier double whose "format" hands the path, content and options to the
+ * given callback, so a fixer can be exercised without booting the node worker.
+ */
+function spyPrettier(Closure $handler): Prettier
+{
+    return new class('', $handler) extends Prettier
+    {
+        public function __construct(string $projectRoot, private Closure $handler)
+        {
+            parent::__construct($projectRoot);
+        }
+
+        public function format(string $path, string $content, array $options = []): string
+        {
+            return ($this->handler)($path, $content, $options);
+        }
+    };
+}
+
+/**
+ * A prettier double that must never be reached.
+ */
+function unreachablePrettier(): Prettier
+{
+    return spyPrettier(fn (): string => throw new Exception('prettier should not be reached.'));
+}
+
+/**
+ * Run the given fixer over the code, returning the fixed result.
+ */
+function fixWithPrettierFixer(object $fixer, string $code, string $filename): string
+{
+    $tokens = Tokens::fromCode($code);
+
+    $fixer->fix(new SplFileInfo($filename), $tokens);
+
+    return $tokens->generateCode();
+}
+
+it('formats javascript through prettier using the babel parser', function () {
+    $fixer = new JsFixer(spyPrettier(
+        function (string $path, string $content, array $options): string {
+            expect($path)->toBe('/app/resources/js/app.js')
+                ->and($options['parser'])->toBe('babel');
+
+            // Stands in for prettier reformatting the file.
+            return str_replace('var', 'let', $content);
+        },
+    ));
+
+    expect(fixWithPrettierFixer($fixer, 'var x = 1', '/app/resources/js/app.js'))->toBe('let x = 1');
+});
+
+it('formats every javascript flavour with the babel parser', function (string $filename) {
+    $fixer = new JsFixer(spyPrettier(
+        function (string $path, string $content, array $options) use ($filename): string {
+            expect(basename($path))->toBe($filename)
+                ->and($options['parser'])->toBe('babel');
+
+            return $content;
+        },
+    ));
+
+    fixWithPrettierFixer($fixer, 'x', '/app/resources/js/'.$filename);
+})->with([
+    ['app.js'],
+    ['component.jsx'],
+    ['module.mjs'],
+    ['config.cjs'],
+]);
+
+it('formats stylesheets with the parser each extension needs', function (string $filename, string $parser) {
+    $fixer = new CssFixer(spyPrettier(
+        function (string $path, string $content, array $options) use ($filename, $parser): string {
+            expect(basename($path))->toBe($filename)
+                ->and($options['parser'])->toBe($parser);
+
+            return $content;
+        },
+    ));
+
+    fixWithPrettierFixer($fixer, 'a{color:red}', '/app/resources/css/'.$filename);
+})->with([
+    ['app.css', 'css'],
+    ['theme.scss', 'scss'],
+    ['theme.less', 'less'],
+]);
+
+it('exposes the javascript rule to the finder and the configuration', function () {
+    $fixer = new JsFixer(unreachablePrettier());
+
+    expect($fixer->getName())->toBe('Pint/prettier_js')
+        ->and($fixer->finderNames())->toBe(['*.js', '*.jsx', '*.mjs', '*.cjs'])
+        ->and($fixer->prettierDependencies())->toBe(['prettier' => '^3.8.4']);
+});
+
+it('exposes the css rule to the finder and the configuration', function () {
+    $fixer = new CssFixer(unreachablePrettier());
+
+    expect($fixer->getName())->toBe('Pint/prettier_css')
+        ->and($fixer->finderNames())->toBe(['*.css', '*.scss', '*.less'])
+        ->and($fixer->prettierDependencies())->toBe(['prettier' => '^3.8.4']);
+});
+
+it('leaves files of other languages alone', function (object $fixer, string $filename) {
+    expect(fixWithPrettierFixer($fixer, 'original', $filename))->toBe('original');
+})->with(fn () => [
+    'javascript on a php file' => [new JsFixer(unreachablePrettier()), '/app/app/Models/User.php'],
+    'javascript on a blade view' => [new JsFixer(unreachablePrettier()), '/app/resources/views/welcome.blade.php'],
+    'javascript on a stylesheet' => [new JsFixer(unreachablePrettier()), '/app/resources/css/app.css'],
+    'css on a script' => [new CssFixer(unreachablePrettier()), '/app/resources/js/app.js'],
+]);
+
+it('leaves minified assets alone', function () {
+    expect(fixWithPrettierFixer(new JsFixer(unreachablePrettier()), 'compressed', '/app/public/build/app.min.js'))->toBe('compressed')
+        ->and(fixWithPrettierFixer(new CssFixer(unreachablePrettier()), 'compressed', '/app/public/build/app.min.css'))->toBe('compressed');
+});
+
+it('clears the tokens when prettier hands back an empty file', function () {
+    $fixer = new JsFixer(spyPrettier(fn (): string => ''));
+
+    expect(fixWithPrettierFixer($fixer, 'var x = 1', '/app/resources/js/app.js'))->toBe('');
+});

--- a/tests/Unit/Fixers/Prettier/FixersTest.php
+++ b/tests/Unit/Fixers/Prettier/FixersTest.php
@@ -59,11 +59,11 @@ it('formats javascript through prettier using the babel parser', function () {
     expect(fixWithPrettierFixer($fixer, 'var x = 1', '/app/resources/js/app.js'))->toBe('let x = 1');
 });
 
-it('formats every javascript flavour with the babel parser', function (string $filename) {
+it('formats every javascript flavour with the parser it needs', function (string $filename, string $parser) {
     $fixer = new JsFixer(spyPrettier(
-        function (string $path, string $content, array $options) use ($filename): string {
+        function (string $path, string $content, array $options) use ($filename, $parser): string {
             expect(basename($path))->toBe($filename)
-                ->and($options['parser'])->toBe('babel');
+                ->and($options['parser'])->toBe($parser);
 
             return $content;
         },
@@ -71,10 +71,12 @@ it('formats every javascript flavour with the babel parser', function (string $f
 
     fixWithPrettierFixer($fixer, 'x', '/app/resources/js/'.$filename);
 })->with([
-    ['app.js'],
-    ['component.jsx'],
-    ['module.mjs'],
-    ['config.cjs'],
+    ['app.js', 'babel'],
+    ['component.jsx', 'babel'],
+    ['module.mjs', 'babel'],
+    ['config.cjs', 'babel'],
+    ['module.ts', 'typescript'],
+    ['component.tsx', 'typescript'],
 ]);
 
 it('formats stylesheets with the parser each extension needs', function (string $filename, string $parser) {
@@ -98,7 +100,7 @@ it('exposes the javascript rule to the finder and the configuration', function (
     $fixer = new JsFixer(unreachablePrettier());
 
     expect($fixer->getName())->toBe('Pint/prettier_js')
-        ->and($fixer->finderNames())->toBe(['*.js', '*.jsx', '*.mjs', '*.cjs'])
+        ->and($fixer->finderNames())->toBe(['*.js', '*.jsx', '*.mjs', '*.cjs', '*.ts', '*.tsx'])
         ->and($fixer->prettierDependencies())->toBe(['prettier' => '^3.8.4']);
 });
 

--- a/tests/Unit/Support/PhpFragmentFormatterTest.php
+++ b/tests/Unit/Support/PhpFragmentFormatterTest.php
@@ -47,7 +47,6 @@ it('keeps the imports of a fragment it formats', function () {
     PHP;
 
     $out = (new PhpFragmentFormatter)->format($in, fragment: true);
-
     expect($out)->toContain('use App\Models\User;')
         ->toContain("\$default = 'all';");
 });
@@ -113,4 +112,26 @@ it('formats an island the same way twice', function () {
     $once = $formatter->format($in);
 
     expect($formatter->format($once))->toBe($once);
+});
+
+it('skips the prettier rules a project enables instead of failing on them', function () {
+    // The rules of "pint.json" flow into the preset's rule set, where only the
+    // PHP fixers can be resolved. The prettier rules must be dropped, not fed
+    // to a factory that does not know them.
+    app()->singleton(
+        ConfigurationJsonRepository::class,
+        fn () => new ConfigurationJsonRepository(dirname(__DIR__, 2).'/Fixtures/rules/prettier-rules.json', 'laravel'),
+    );
+
+    $in = <<<'PHP'
+    <?php
+
+    $default = "all";
+    ?>
+
+    PHP;
+
+    $out = (new PhpFragmentFormatter)->format($in);
+
+    expect($out)->toContain("\$default = 'all';");
 });


### PR DESCRIPTION
Since the Blade rule already requires Prettier, I think it makes sense to also format the JS and CSS files that live in the same project.

This PR adds two opt-in rules:

- `Pint/prettier_js` formats `.js`, `.jsx`, `.mjs`, `.cjs`, `.ts` and `.tsx` files
- `Pint/prettier_css` formats `.css`, `.scss` and `.less` files

Both follow the bundled Prettier style (single quotes, 4 spaces, 120 print width), are skipped for minified files, and are only applied when enabled in `pint.json`.
