### PR TITLE
fix(blade): keep import-mutating fixers away from raw PHP islands

### DIFF
--- a/app/Fixers/LaravelBlade/SkipBladeFilesFixer.php
+++ b/app/Fixers/LaravelBlade/SkipBladeFilesFixer.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Fixers\LaravelBlade;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerConfiguration\FixerConfigurationResolverInterface;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+/**
+ * Decorates a fixer so that it never touches Blade templates.
+ *
+ * Raw "<?php" chunks inside Blade files are tokenized as standalone
+ * root-namespace PHP, so fixers that inject, remove or rewrite import
+ * statements corrupt the template when applied to them.
+ *
+ * @internal
+ */
+class SkipBladeFilesFixer extends AbstractFixer implements ConfigurableFixerInterface
+{
+    public function __construct(protected readonly FixerInterface $fixer)
+    {
+        parent::__construct();
+    }
+
+    public function getName(): string
+    {
+        return $this->fixer->getName();
+    }
+
+    public function supports(SplFileInfo $file): bool
+    {
+        return ! str_ends_with($file->getFilename(), '.blade.php')
+            && $this->fixer->supports($file);
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $this->fixer->isCandidate($tokens);
+    }
+
+    public function isRisky(): bool
+    {
+        return $this->fixer->isRisky();
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return $this->fixer->getDefinition();
+    }
+
+    public function getPriority(): int
+    {
+        return $this->fixer->getPriority();
+    }
+
+    public function configure(array $configuration): void
+    {
+        if (! $this->fixer instanceof ConfigurableFixerInterface) {
+            return;
+        }
+
+        $this->fixer->configure($configuration);
+    }
+
+    public function getConfigurationDefinition(): FixerConfigurationResolverInterface
+    {
+        /** @var ConfigurableFixerInterface&FixerInterface */
+        $fixer = $this->fixer;
+
+        return $fixer->getConfigurationDefinition();
+    }
+
+    protected function applyFix(SplFileInfo $file, Tokens $tokens): void
+    {
+        $this->fixer->fix($file, $tokens);
+    }
+}

--- a/app/PrettierFormatters/PhpBlockFormatting.php
+++ b/app/PrettierFormatters/PhpBlockFormatting.php
@@ -537,7 +537,7 @@ class PhpBlockFormatting implements PrettierPostFormatter
      */
     private function formatIsland(string $region, string $indent): string
     {
-        $formatted = rtrim($this->formatter->format($region));
+        $formatted = rtrim($this->formatter->format($region, fragment: true));
 
         if ($indent === '') {
             return $formatted;

--- a/overrides/FixerFactory.php
+++ b/overrides/FixerFactory.php
@@ -17,11 +17,15 @@ namespace PhpCsFixer;
 use App\BladeFormatter;
 use App\Fixers\LaravelBlade\Fixer as LaravelBladeFixer;
 use App\Fixers\LaravelBlade\NoUnusedImportsFixer as BladeAwareNoUnusedImportsFixer;
+use App\Fixers\LaravelBlade\SkipBladeFilesFixer;
 use App\Fixers\TypeAnnotationsOnlyFixer;
 use PhpCsFixer\ConfigurationException\InvalidFixerConfigurationException;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
+use PhpCsFixer\Fixer\Import\GlobalNamespaceImportFixer;
 use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
+use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use PhpCsFixer\Fixer\WhitespacesAwareFixerInterface;
 use PhpCsFixer\RuleSet\RuleSetInterface;
 use Symfony\Component\Finder\Finder as SymfonyFinder;
@@ -36,6 +40,18 @@ use Symfony\Component\Finder\SplFileInfo;
  */
 final class FixerFactory
 {
+    /**
+     * Fixers that inject, remove or rewrite import statements and
+     * therefore corrupt raw "<?php" chunks inside Blade templates.
+     *
+     * @var list<class-string<FixerInterface>>
+     */
+    private const BLADE_UNSAFE_FIXERS = [
+        FullyQualifiedStrictTypesFixer::class,
+        GlobalNamespaceImportFixer::class,
+        DeclareStrictTypesFixer::class,
+    ];
+
     private FixerNameValidator $nameValidator;
 
     /**
@@ -105,6 +121,10 @@ final class FixerFactory
 
             if ($fixer instanceof NoUnusedImportsFixer) {
                 $fixer = new BladeAwareNoUnusedImportsFixer($fixer);
+            }
+
+            if (in_array($class, self::BLADE_UNSAFE_FIXERS, true)) {
+                $fixer = new SkipBladeFilesFixer($fixer);
             }
 
             $this->registerFixer($fixer, false);

--- a/tests/Fixtures/blade-formatting/php/fqcn-island.blade.php
+++ b/tests/Fixtures/blade-formatting/php/fqcn-island.blade.php
@@ -1,0 +1,9 @@
+<div>
+    <?php
+
+    $rows = \App\Models\Category::childrenOf($record->id);
+
+    ?>
+
+    <div>{{ count($rows) }} rows</div>
+</div>

--- a/tests/Fixtures/blade-formatting/php/fqcn-island.blade.php.expected
+++ b/tests/Fixtures/blade-formatting/php/fqcn-island.blade.php.expected
@@ -1,0 +1,9 @@
+<div>
+    <?php
+
+    $rows = \App\Models\Category::childrenOf($record->id);
+
+    ?>
+
+    <div>{{ count($rows) }} rows</div>
+</div>


### PR DESCRIPTION
Fixes #486

## Problem

With `Pint/laravel_blade` enabled, every preset fixer still runs on `.blade.php`
files, and the prettier post-pass reformats raw `<?php ?>` islands as full PHP
documents. Both paths let `fully_qualified_strict_types` (on by default in the
`laravel` preset via `import_symbols: true`) inject `use` statements into the
middle of a template:

```diff
         <?php
 
-        $rows = \App\Models\Category::childrenOf($record->id);
+        use App\Models\Category;
+
+        $rows = Category::childrenOf($record->id);
         ?>
```

This breaks every view containing a raw `<?php` chunk in one run.
Repro + verified output: https://github.com/muhannad17/pint-blade-repro

## Root cause

Two independent paths reach Blade files:

1. **Main pipeline** — when `Pint/laravel_blade` is on, `.blade.php` files enter
   the normal finder and all preset fixers run on them. Raw `<?php ?>` chunks are
   tokenized as root-namespace PHP, so import-injecting fixers treat each chunk
   as its own mini-file.
2. **Prettier post-pass** — `PhpBlockFormatting::formatIsland()` hands islands to
   `PhpFragmentFormatter` without `fragment: true`, so the fragment denylist
   (which already covers `@php` blocks, echoes, directive args, and attributes)
   never applies to islands.

## Fix

- Wrap `FullyQualifiedStrictTypesFixer`, `GlobalNamespaceImportFixer`, and
  `DeclareStrictTypesFixer` in a new `SkipBladeFilesFixer` decorator whose
  `supports()` returns `false` for `.blade.php` — mirroring the existing
  `NoUnusedImportsFixer` blade guard.
- Pass `fragment: true` in `formatIsland()` so islands get the same denylist as
  other fragment types.

Regular `.php` files are unaffected: auto-imported symbols still work exactly
as before.

## Testing

- New golden fixture: `tests/Fixtures/blade-formatting/php/fqcn-island.blade.php`
  (fails with injection before this patch).
- Full suite: 763 passed, 0 failed, 1 skipped.