### PR TITLE
[1.x] feat: Support Bun as a JS runtime for Prettier

### DIFF
--- a/app/Actions/EnsurePrettierIsConfigured.php
+++ b/app/Actions/EnsurePrettierIsConfigured.php
@@ -40,7 +40,7 @@ class EnsurePrettierIsConfigured
 
         $this->ensureSupportedDistribution();
 
-        $this->ensureNodeIsInstalled()
+        $this->ensureRuntimeIsInstalled()
             ->ensureNodeDependenciesAreInstalled();
     }
 
@@ -99,12 +99,17 @@ class EnsurePrettierIsConfigured
     }
 
     /**
-     * Ensure node is installed.
+     * Ensure the JavaScript runtime required to run the bundled prettier scripts is installed.
      */
-    protected function ensureNodeIsInstalled(): static
+    protected function ensureRuntimeIsInstalled(): static
     {
-        if (Process::run('node -v')->failed()) {
-            abort(1, 'The rules enabled in your pint configuration require Node.js to be installed.');
+        $binary = $this->prettier->runtimeBinary();
+
+        if (Process::run([$binary, '-v'])->failed()) {
+            abort(1, sprintf(
+                'The rules enabled in your pint configuration require [%s] to be installed.',
+                $binary,
+            ));
         }
 
         return $this;
@@ -241,7 +246,7 @@ class EnsurePrettierIsConfigured
     protected function probe(string $package): array
     {
         $result = Process::path($this->prettier->projectRoot())
-            ->run(['node', $this->prettier->versionProbePath(), $package]);
+            ->run([$this->prettier->runtimeBinary(), $this->prettier->versionProbePath(), $package]);
 
         if ($result->failed()) {
             return ['resolved' => false, 'version' => null];

--- a/app/Actions/EnsurePrettierIsConfigured.php
+++ b/app/Actions/EnsurePrettierIsConfigured.php
@@ -99,7 +99,7 @@ class EnsurePrettierIsConfigured
     }
 
     /**
-     * Ensure the JavaScript runtime required to run the bundled prettier scripts is installed.
+     * Ensure the JavaScript runtime is installed.
      */
     protected function ensureRuntimeIsInstalled(): static
     {

--- a/app/Actions/EnsurePrettierIsConfigured.php
+++ b/app/Actions/EnsurePrettierIsConfigured.php
@@ -103,13 +103,8 @@ class EnsurePrettierIsConfigured
      */
     protected function ensureRuntimeIsInstalled(): static
     {
-        $binary = $this->prettier->runtimeBinary();
-
-        if (Process::run([$binary, '-v'])->failed()) {
-            abort(1, sprintf(
-                'The rules enabled in your pint configuration require [%s] to be installed.',
-                $binary,
-            ));
+        if (Process::run([$this->prettier->runtimeBinary(), '-v'])->failed()) {
+            abort(1, 'The rules enabled in your pint configuration require a Node.js runtime to be installed.');
         }
 
         return $this;

--- a/app/Actions/EnsurePrettierIsConfigured.php
+++ b/app/Actions/EnsurePrettierIsConfigured.php
@@ -104,7 +104,7 @@ class EnsurePrettierIsConfigured
     protected function ensureRuntimeIsInstalled(): static
     {
         if (Process::run([$this->prettier->runtimeBinary(), '-v'])->failed()) {
-            abort(1, 'The rules enabled in your pint configuration require a Node.js runtime to be installed.');
+            abort(1, 'The rules enabled in your pint configuration require a JavaScript runtime (Node.js or Bun) to be installed.');
         }
 
         return $this;

--- a/app/Enums/NodePackageManager.php
+++ b/app/Enums/NodePackageManager.php
@@ -48,4 +48,15 @@ enum NodePackageManager: string
     {
         return $this->value;
     }
+
+    /**
+     * The JavaScript runtime binary used to execute the bundled prettier scripts.
+     */
+    public function runtimeBinary(): string
+    {
+        return match ($this) {
+            self::Bun => 'bun',
+            default => 'node',
+        };
+    }
 }

--- a/app/Enums/NodePackageManager.php
+++ b/app/Enums/NodePackageManager.php
@@ -50,7 +50,7 @@ enum NodePackageManager: string
     }
 
     /**
-     * The JavaScript runtime binary used to execute the bundled prettier scripts.
+     * The JavaScript runtime binary used to execute scripts.
      */
     public function runtimeBinary(): string
     {

--- a/app/Support/Prettier.php
+++ b/app/Support/Prettier.php
@@ -44,7 +44,7 @@ class Prettier
     }
 
     /**
-     * The root directory of the node project.
+     * The root directory of the JavaScript project.
      */
     public function projectRoot(): string
     {
@@ -182,7 +182,7 @@ class Prettier
     }
 
     /**
-     * The path to the bundled node script that probes installed package versions.
+     * The path to the bundled script that probes installed package versions.
      */
     public function versionProbePath(): string
     {

--- a/app/Support/Prettier.php
+++ b/app/Support/Prettier.php
@@ -198,8 +198,7 @@ class Prettier
     }
 
     /**
-     * The JavaScript runtime binary used to execute the bundled prettier scripts,
-     * matching the package manager detected for the project.
+     * The JavaScript runtime binary used to execute the bundled prettier scripts.
      */
     public function runtimeBinary(): string
     {

--- a/app/Support/Prettier.php
+++ b/app/Support/Prettier.php
@@ -2,6 +2,7 @@
 
 namespace App\Support;
 
+use App\Enums\NodePackageManager;
 use App\Exceptions\PrettierException;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
@@ -146,7 +147,7 @@ class Prettier
         }
 
         $this->process = new Process(
-            ['node', $this->workerPath(), $this->projectRoot, $this->configPath()],
+            [$this->runtimeBinary(), $this->workerPath(), $this->projectRoot, $this->configPath()],
             $this->projectRoot,
         );
 
@@ -194,6 +195,15 @@ class Prettier
     public function configPath(): string
     {
         return $this->resourcePath('prettier/prettierrc.json');
+    }
+
+    /**
+     * The JavaScript runtime binary used to execute the bundled prettier scripts,
+     * matching the package manager detected for the project.
+     */
+    public function runtimeBinary(): string
+    {
+        return NodePackageManager::detect($this->projectRoot)->runtimeBinary();
     }
 
     /**


### PR DESCRIPTION
This PR adds the ability to use Bun without Node

Today, if you use Bun, you just get:

<img width="753" height="140" alt="Screenshot 2026-08-28 at 13 39 22" src="https://github.com/user-attachments/assets/eb3f6036-57d3-4032-b854-3e2fa8be551f" />

But, Bun can be used as run time, so we shouldn't need Node.  

With this change you just get told you need the prettier plugin (I did `./pint app:build pint --build-version=dev`): 

<img width="898" height="337" alt="image" src="https://github.com/user-attachments/assets/c7736e77-1e54-4e8e-980c-45fb7a76d95d" />

And once you install, it runs as expected:.
<img width="1178" height="131" alt="Screenshot 2026-08-28 at 13 44 51" src="https://github.com/user-attachments/assets/1a850412-3eff-4e4b-b555-1e7a65d7c5a9" />

 
 I've tweaked some wording and comments too while I was here, as its not always node. 
 
 I've not added any tests, cos I can't see any in the same vein? & this is fairly simple, but let me know if anything needs adjusting 
 
 Thanks! 🫡🫡🫡🫡🫡🫡🫡🫡🫡🫡 
