### PR TITLE
fix: drop the trailing comma added to a multiline directive argument

### DIFF
--- a/app/PrettierFormatters/PhpBlockFormatting.php
+++ b/app/PrettierFormatters/PhpBlockFormatting.php
@@ -149,8 +149,10 @@ class PhpBlockFormatting implements PrettierPostFormatter
 
         if ($keyword = self::CONTROL_DIRECTIVES[strtolower($name)] ?? null) {
             $host = $keyword.' ('.$core.') {}';
+            $call = false;
         } else {
             $host = '__pint__('.$core.');';
+            $call = true;
         }
 
         $formatted = $this->stripPhpWrapper($this->formatter->format("<?php\n".$host."\n", fragment: true));
@@ -163,7 +165,24 @@ class PhpBlockFormatting implements PrettierPostFormatter
 
         $inner = substr($formatted, $open + 1, $close - $open - 1);
 
+        if ($call) {
+            $inner = $this->stripHostTrailingComma($inner);
+        }
+
         return $this->reindentArg($inner, $indent);
+    }
+
+    /**
+     * Drop the trailing comma the synthetic call host invited.
+     *
+     * Wrapping an argument in "__pint__(...)" makes it a multi-line argument
+     * list, which "trailing_comma_in_multiline" is entitled to punctuate. Blade
+     * compiles the directive's argument straight into PHP, where that comma is a
+     * syntax error, so it never belongs to the argument itself.
+     */
+    private function stripHostTrailingComma(string $inner): string
+    {
+        return (string) preg_replace('/,(\s*)$/', '$1', $inner);
     }
 
     /**

--- a/tests/Unit/PrettierFormatters/PhpBlockFormattingTest.php
+++ b/tests/Unit/PrettierFormatters/PhpBlockFormattingTest.php
@@ -2,10 +2,36 @@
 
 use App\PrettierFormatters\PhpBlockFormatting;
 use App\Support\PhpFragmentFormatter;
+use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
+use PhpCsFixer\Tokenizer\Tokens;
 
 function phpBlockFormatting(): PhpBlockFormatting
 {
     return new PhpBlockFormatting(new PhpFragmentFormatter);
+}
+
+/**
+ * A formatter whose only rule punctuates multi-line arrays *and* arguments.
+ *
+ * The "laravel" preset only punctuates arrays, but a project may opt
+ * "arguments" into "trailing_comma_in_multiline", which then sees the synthetic
+ * "__pint__(...)" host as a multi-line call.
+ */
+function phpBlockFormattingWithTrailingCommas(): PhpBlockFormatting
+{
+    return new PhpBlockFormatting(new class extends PhpFragmentFormatter
+    {
+        public function format(string $code, bool $fragment = false): string
+        {
+            $fixer = new TrailingCommaInMultilineFixer;
+            $fixer->configure(['elements' => ['arrays', 'arguments']]);
+
+            $tokens = Tokens::fromCode($code);
+            $fixer->fix(new SplFileInfo('fragment.php'), $tokens);
+
+            return $tokens->generateCode();
+        }
+    });
 }
 
 it('leaves a brace control structure split across raw-php islands untouched', function () {
@@ -107,4 +133,29 @@ it('leaves a nested multiline directive argument untouched when no fixer re-inde
     BLADE;
 
     expect($formatter->postFormat($in))->toBe($in);
+});
+
+it('does not leave a trailing comma on a multiline directive argument', function () {
+    // Blade compiles the argument straight into "if (...):", where a trailing
+    // comma is a syntax error, so it never belongs to the argument itself.
+    $in = <<<'BLADE'
+    @if (
+        ($user->isAdmin() || $user->isOwner())
+            && $user->isActive()
+    )
+        <span>Admin</span>
+    @endif
+    BLADE;
+
+    expect(phpBlockFormattingWithTrailingCommas()->postFormat($in))->toBe($in);
+});
+
+it('keeps the trailing comma of an array inside a multiline directive argument', function () {
+    $in = <<<'BLADE'
+    @include('partials.card', [
+        'title' => $title,
+    ])
+    BLADE;
+
+    expect(phpBlockFormattingWithTrailingCommas()->postFormat($in))->toBe($in);
 });


### PR DESCRIPTION
Hello!

A Blade directive's argument is formatted by wrapping it in a synthetic `__pint__(...)` call and extracting what comes back out of the `parens`. When the argument spans multiple lines with `)` on its own line, `trailing_comma_in_multiline` sees a multi-line **argument list** and punctuates it, so the comma is extracted back into the directive:

```blade
    @if (
        $user->isAdmin()
        && $user->isActive(), <--- note this added comment
    )
```

This fixes that parse error with some post processing

Thanks!